### PR TITLE
Create config-fermat.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         grep 'warning:' build.log | sed 's/\x1B\[\([0-9]\+\(;[0-9]\+\)*\)\?m//g' | awk '{ print $NF }' | sort | uniq -c | sort -nr >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         for s in tt t s m l; do time ./Mlucas -s $s -cpu "0:$(( $(nproc --all) - 1 ))" |& tee -a test.log; done
+        bash -- ../config-fermat.sh -cpu "0:$(( $(nproc --all) - 1 ))"
     - uses: actions/upload-artifact@v4
       if: always()
       with:
@@ -81,6 +82,7 @@ jobs:
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( $(nproc --all) - 1 ))"
+        bash -- ../config-fermat.sh -cpu "0:$(( $(nproc --all) - 1 ))"
       continue-on-error: true
 
   TSan-Linux:
@@ -217,6 +219,10 @@ jobs:
         grep 'warning:' build.log | sed 's/\x1B\[\([0-9]\+\(;[0-9]\+\)*\)\?m//g' | awk '{ print $NF }' | sort | uniq -c | sort -nr >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
         for s in tt t s m l; do time ./Mlucas -s $s -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))" 2>&1 | tee -a test.log; done
+        if (( $(sysctl -n hw.optional.AdvSIMD) )); then
+            cd ../obj_NOSIMD
+        fi
+        bash -- ../config-fermat.sh -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
     - uses: actions/upload-artifact@v4
       if: always()
       with:
@@ -243,6 +249,9 @@ jobs:
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
+        if ! (( $(sysctl -n hw.optional.AdvSIMD) )); then
+            bash -- ../config-fermat.sh -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
+        fi
 
   TSan-macOS:
     name: ThreadSanitizer macOS
@@ -315,6 +324,7 @@ jobs:
         done
         cd obj
         for s in tt t s m l; do time ./Mlucas -s $s -cpu "0:$(( NUMBER_OF_PROCESSORS - 1 ))" |& tee -a test.log; done
+        bash -- ../config-fermat.sh -cpu "0:$(( NUMBER_OF_PROCESSORS - 1 ))"
     - uses: actions/upload-artifact@v4
       if: always()
       with:
@@ -353,3 +363,4 @@ jobs:
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( NUMBER_OF_PROCESSORS - 1 ))" |& tee -a test.log
+        bash -- ../config-fermat.sh -cpu "0:$(( NUMBER_OF_PROCESSORS - 1 ))"

--- a/config-fermat.sh
+++ b/config-fermat.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Shell script for generating fermat.cfg; mlucas output saved to config-fermat.log
+# Shell script for generating fermat.cfg; Mlucas output saved to config-fermat.log
 ITERS=10000     # Number of iterations; use 100, 1000, or 10000 to match pre-computed values
 MIN=14          # Minimum Fermat number (14 or greater)
 MAX=29          # Maximum Fermat number (33 or less)
@@ -7,12 +7,15 @@ ARGS=(
     "$@"
     # Add desired -cpu or -core settings here, or as following arguments, e.g. ./config-fermat.sh -cpu 0:3
 )
-FFTS=([1]=14 [2]=15 [4]=16 [7]=17 [8]=17)   # First, tiny FFT lengths for F14 to F17
-for ((n = 0; n < 16; ++n)); do              # Then, from small to egregious FFTs for F18 to F33
+FFTS=([1]=14 [2]=15 [4]=16 [7]=17 [8]=17)   # First, tiny FFT lengths for F14 to F17;
+for ((n = 0; n < 16; ++n)); do              # Then, from small up to egregious FFTs for F18 to F33.
     m=$((1 << n))                           # The largest FFT reached is 512M, if MAX is set to 33.
-    f=$((18 + n))                           # Note that large FFTs begin to require considerable runtime.
-    for k in 14 15 16; do                   # Also the multiples of 7K, 14K, ... become unworkable around F30.
-        FFTS[k * m]=$f
+    f=$((18 + n))                           # Note that large FFTs require considerable runtime at 10000 iterations.
+    for k in 15 16; do
+        if [[ $k -eq 15 && $n -lt 10 ]]; then
+            FFTS[14 * m]=$f                 # k = 7 multiples (7K, 14K, ...) become unworkable after F27 (14M).
+        fi
+        FFTS[k * m]=$f                      # k = 15, 16 should both be supported up to at least F32.
         if [[ $k -eq 15 && $n -gt 5 ]]; then
             FFTS[63 * m >> 2]=$f            # k = 63 is supported for F24 and above (1008K).
         fi
@@ -27,7 +30,7 @@ for fft in "${!FFTS[@]}"; do
     fi
     printf '\n\tTesting F%s (%s),\tFFT length: %sK\n\n' "$f" $((1 << f)) "$fft"
     args=("${ARGS[@]}")
-    if [[ $f -ge 32 ]]; then
+    if [[ $f -le 17 || $f -ge 32 ]]; then
         args+=(-shift 0)
     fi
     time ./Mlucas -f "$f" -fft "$fft" -iters $ITERS "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing'

--- a/config-fermat.sh
+++ b/config-fermat.sh
@@ -40,7 +40,7 @@ MAX=29
 # Mlucas arguments
 ARGS=(
 	"$@"
-	# Add desired -cpu or -core settings here, or as following arguments, e.g. ./config-fermat.sh -cpu 0:3
+	# Add desired -cpu or -core settings here, or as following arguments, e.g. ../config-fermat.sh -cpu 0:3
 
 )
 

--- a/config-fermat.sh
+++ b/config-fermat.sh
@@ -12,8 +12,8 @@ for ((n = 0; n < 16; ++n)); do              # Then, from small up to egregious F
     m=$((1 << n))                           # The largest FFT reached is 512M, if MAX is set to 33.
     f=$((18 + n))                           # Note that large FFTs require considerable runtime at 10000 iterations.
     for k in 15 16; do
-        if [[ $k -eq 15 && $n -lt 10 ]]; then
-            FFTS[14 * m]=$f                 # k = 7 multiples (7K, 14K, ...) become unworkable after F27 (14M).
+        if [[ $k -eq 15 && $n -lt 11 ]]; then
+            FFTS[14 * m]=$f                 # k = 7 multiples (7K, 14K, ...) become unworkable after F28 (14M).
         fi
         FFTS[k * m]=$f                      # k = 15, 16 should both be supported up to at least F32.
         if [[ $k -eq 15 && $n -gt 5 ]]; then

--- a/config-fermat.sh
+++ b/config-fermat.sh
@@ -1,37 +1,82 @@
 #!/bin/bash
+
 # Shell script for generating fermat.cfg; Mlucas output saved to config-fermat.log
-ITERS=10000     # Number of iterations; use 100, 1000, or 10000 to match pre-computed values
-MIN=14          # Minimum Fermat number (14 or greater)
-MAX=29          # Maximum Fermat number (33 or less)
+
+################################################################################
+#                                                                              #
+#   (C) 2024 by Catherine Cowie and Teal Dulcet.                               #
+#                                                                              #
+#  This program is free software; you can redistribute it and/or modify it     #
+#  under the terms of the GNU General Public License as published by the       #
+#  Free Software Foundation; either version 2 of the License, or (at your      #
+#  option) any later version.                                                  #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful, but WITHOUT #
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       #
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for   #
+#  more details.                                                               #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License along     #
+#  with this program; see the file GPL.txt.  If not, you may view one at       #
+#  http://www.fsf.org/licenses/licenses.html, or obtain one by writing to the  #
+#  Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA     #
+#  02111-1307, USA.                                                            #
+#                                                                              #
+################################################################################
+
+# Mlucas
+MLUCAS=./Mlucas
+
+# Number of iterations
+# use 100, 1000, or 10000 to match pre-computed values
+ITERS=100
+
+# Minimum Fermat number (14 or greater)
+MIN=14
+
+# Maximum Fermat number (33 or less)
+MAX=29
+
+# Mlucas arguments
 ARGS=(
-    "$@"
-    # Add desired -cpu or -core settings here, or as following arguments, e.g. ./config-fermat.sh -cpu 0:3
+	"$@"
+	# Add desired -cpu or -core settings here, or as following arguments, e.g. ./config-fermat.sh -cpu 0:3
+
 )
-FFTS=([1]=14 [2]=15 [4]=16 [7]=17 [8]=17)   # First, tiny FFT lengths for F14 to F17;
-for ((n = 0; n < 16; ++n)); do              # Then, from small up to egregious FFTs for F18 to F33.
-    m=$((1 << n))                           # The largest FFT reached is 512M, if MAX is set to 33.
-    f=$((18 + n))                           # Note that large FFTs require considerable runtime at 10000 iterations.
-    for k in 15 16; do
-        if [[ $k -eq 15 && $n -lt 11 ]]; then
-            FFTS[14 * m]=$f                 # k = 7 multiples (7K, 14K, ...) become unworkable after F28 (14M).
-        fi
-        FFTS[k * m]=$f                      # k = 15, 16 should both be supported up to at least F32.
-        if [[ $k -eq 15 && $n -gt 5 ]]; then
-            FFTS[63 * m >> 2]=$f            # k = 63 is supported for F24 and above (1008K).
-        fi
-    done
+
+# First, tiny FFT lengths for F14 to F17;
+FFTS=([1]=14 [2]=15 [4]=16 [7]=17 [8]=17)
+# Then, from small up to egregious FFTs for F18 to F33.
+# The largest FFT reached is 512M, if MAX is set to 33.
+# Note that large FFTs require considerable runtime at 10000 iterations.
+for ((n = 0; n < 16; ++n)); do
+	m=$((1 << n))
+	f=$((18 + n))
+	for k in 15 16; do
+		if [[ $k -eq 15 && $n -lt 11 ]]; then
+			# k = 7 multiples (7K, 14K, ...) become unworkable after F28 (14M).
+			FFTS[14 * m]=$f
+		fi
+		# k = 15, 16 should both be supported up to at least F32.
+		FFTS[k * m]=$f
+		if [[ $k -eq 15 && $n -gt 5 ]]; then
+			# k = 63 is supported for F24 and above (1008K).
+			FFTS[63 * m >> 2]=$f
+		fi
+	done
 done
+
 for fft in "${!FFTS[@]}"; do
-    f=${FFTS[fft]}
-    if [[ -n $MIN && $f -lt $MIN ]]; then
-        continue
-    elif [[ -n $MAX && $f -gt $MAX ]]; then
-        break
-    fi
-    printf '\n\tTesting F%s (%s),\tFFT length: %sK\n\n' "$f" $((1 << f)) "$fft"
-    args=("${ARGS[@]}")
-    if [[ $f -le 17 || $f -ge 32 ]]; then
-        args+=(-shift 0)
-    fi
-    time ./Mlucas -f "$f" -fft "$fft" -iters $ITERS "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing'
+	f=${FFTS[fft]}
+	if [[ -n $MIN && $f -lt $MIN ]]; then
+		continue
+	elif [[ -n $MAX && $f -gt $MAX ]]; then
+		break
+	fi
+	printf '\n\tTesting F%s (%s),\tFFT length: %sK\n\n' "$f" $((1 << f)) "$fft"
+	args=("${ARGS[@]}")
+	if [[ $f -le 17 || $f -ge 32 ]]; then
+		args+=(-shift 0)
+	fi
+	time $MLUCAS -f "$f" -fft "$fft" -iters $ITERS "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing'
 done

--- a/config-fermat.sh
+++ b/config-fermat.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Shell script for generating fermat.cfg; mlucas output saved to config-fermat.log
+ITERS=10000     # Number of iterations; use 100, 1000, or 10000 to match pre-computed values
+MIN=14          # Minimum Fermat number (14 or greater)
+MAX=29          # Maximum Fermat number (33 or less)
+ARGS=(
+    "$@"
+    # Add desired -cpu or -core settings here, or as following arguments, e.g. ./config-fermat.sh -cpu 0:3
+)
+FFTS=([1]=14 [2]=15 [4]=16 [7]=17 [8]=17)   # First, tiny FFT lengths for F14 to F17
+for ((n = 0; n < 16; ++n)); do              # Then, from small to egregious FFTs for F18 to F33
+    m=$((1 << n))                           # The largest FFT reached is 512M, if MAX is set to 33.
+    f=$((18 + n))                           # Note that large FFTs begin to require considerable runtime.
+    for k in 14 15 16; do                   # Also the multiples of 7K, 14K, ... become unworkable around F30.
+        FFTS[k * m]=$f
+        if [[ $k -eq 15 && $n -gt 5 ]]; then
+            FFTS[63 * m >> 2]=$f            # k = 63 is supported for F24 and above (1008K).
+        fi
+    done
+done
+for fft in "${!FFTS[@]}"; do
+    f=${FFTS[fft]}
+    if [[ -n $MIN && $f -lt $MIN ]]; then
+        continue
+    elif [[ -n $MAX && $f -gt $MAX ]]; then
+        break
+    fi
+    printf '\n\tTesting F%s (%s),\tFFT length: %sK\n\n' "$f" $((1 << f)) "$fft"
+    args=("${ARGS[@]}")
+    if [[ $f -ge 32 ]]; then
+        args+=(-shift 0)
+    fi
+    time ./Mlucas -f "$f" -fft "$fft" -iters $ITERS "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing'
+done


### PR DESCRIPTION
Shell-script cowritten by Teal Dulcet and Catherine Cowie to configure Mlucas for production work on Fermat numbers, by testing the Fermat modular squaring code at various FFT lengths over 10000 iterations, on the appropriate Fermat number for that size, which then writes timing and radix set data to fermat.cfg in the Mlucas executable directory Mlucas/obj. A log file config-fermat.log records the Mlucas output. During installation a copy of this script should be copied to the Mlucas executable directory.