### PR TITLE
Fast CPUs have gotten faster: reduce self-test times by factor 5

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -123,7 +123,7 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 **************** THIS IS THE ONLY SELF-TEST ORDINARY USERS ARE RECOMMENDED TO DO: *************
 *                                                                                             *
 * -s medium Runs 100 or 1000-iteration self-tests on a set of 16 Mersenne exponents, covering *
-* -s m      FFT lengths from 2M to 7.5M. This will take around an hour on a fast CPU.         *
+* -s m      FFT lengths from 2M to 7.5M. This will take around 10 minutes on a fast CPU.         *
 *                                                                                             *
 ***********************************************************************************************
 

--- a/help.txt
+++ b/help.txt
@@ -115,10 +115,10 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 	iteration number and (optionally) FFT length to use.
 
  -s tiny	Runs 100 (<= 4 threads) or 1000-iteration self-tests on a set of 32 Mersenne exponents,
- -s t		covering FFT lengths 8K-120K. This will take around 1 minute on a fast CPU.
+ -s t		covering FFT lengths 8K-120K. This will take around 10 seconds on a fast CPU.
 
  -s small	Runs 100 or 1000-iteration self-tests on a set of 32 Mersenne exponents, covering
- -s s		FFT lengths 120K-1920K. This will take around 10 minutes on a fast CPU..
+ -s s		FFT lengths 120K-1920K. This will take around 2 minutes on a fast CPU..
 
 **************** THIS IS THE ONLY SELF-TEST ORDINARY USERS ARE RECOMMENDED TO DO: *************
 *                                                                                             *
@@ -128,13 +128,13 @@ The (very rough) time estimates are for 1000 iterations done using 4 or more cor
 ***********************************************************************************************
 
  -s large	Runs 100 or 1000-iteration self-tests on a set of 24 Mersenne exponents, covering
- -s l		FFT lengths 8M to 60M. This will take around 10 hours on a fast CPU.
+ -s l		FFT lengths 8M to 60M. This will take around 2 hours on a fast CPU.
 
  -s all		Runs 100 or 1000--iteration self-tests of all the above FFT lengths.
- -s a		This will take around 12 hours on a fast CPU.
+ -s a		This will take around 3 hours on a fast CPU.
 
  -s xl		[The 'h' form is short for 'huge'.] Runs 100 or 1000-iteration self-tests on a set
- -s h		of 16 M(p), covering FFT lengths 64M-240M. This will take several days on a fast CPU.
+ -s h		of 16 M(p), covering FFT lengths 64M-240M. This will take around a day on a fast CPU.
 
  -s xxl		[The 'e' form is short for 'egregious'.] Runs 100 or 1000-iteration self-tests on a set
  -s e		of 9 M(p), covering FFT lengths 256M-512M. This will take several days on a fast CPU, and


### PR DESCRIPTION
I just downloaded Mlucas on my M1 MBP (32GB RAM) and ran the tiny and small self tests. They were at least a factor of 5 faster than what was stated.

This PR divides all self-test run-times by around a factor of 5.

Self-test runtimes:
tiny: 8s (instead of 1 minute)
small: 1m23s (instead of 10 minutes)