### PR TITLE
Parallel lto codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
     - name: Script
       run: |
         set -x 
+        export XCFLAGS=-fsanitize=address,undefined
         bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
@@ -182,6 +183,7 @@ jobs:
     - name: Script
       run: |
         set -x
+        export XCFLAGS=-fsanitize=thread
         bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
@@ -380,6 +382,7 @@ jobs:
     - name: Script
       run: |
         set -x
+        export XCFLAGS=-fsanitize=address,undefined
         bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
@@ -405,6 +408,7 @@ jobs:
     - name: Script
       run: |
         set -x
+        export XCFLAGS=-fsanitize=thread
         bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
@@ -519,6 +523,7 @@ jobs:
       shell: bash
       run: |
         set -x
+        export XCFLAGS=-fsanitize=address,undefined
         bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,9 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y libhwloc-dev
     - name: Before script
+      # With [^\s]* we also remove possible -flto= stuff
       run: |
-        sed -i 's/-O3 -flto/-Og -fsanitize=address,undefined/' makemake.sh
+        sed -i 's/-O3 -flto[^\s]*/-Og -fsanitize=address,undefined/' makemake.sh
         $CC --version
     - name: Script
       run: |
@@ -179,7 +180,7 @@ jobs:
         sudo apt-get install -y libhwloc-dev
     - name: Before script
       run: |
-        sed -i 's/-O3 -flto/-Og -fsanitize=thread/' makemake.sh
+        sed -i 's/-O3 -flto[^\s]*/-Og -fsanitize=thread/' makemake.sh
         $CC --version
     - name: Script
       run: |
@@ -378,7 +379,7 @@ jobs:
         brew install hwloc
     - name: Before script
       run: |
-        sed -i '' 's/-O3 -flto/-Og -fsanitize=address,undefined/' makemake.sh
+        sed -i '' 's/-O3 -flto[^\s]*/-Og -fsanitize=address,undefined/' makemake.sh
         clang --version
     - name: Script
       run: |
@@ -404,7 +405,7 @@ jobs:
         brew install hwloc
     - name: Before script
       run: |
-        sed -i '' 's/-O3 -flto/-Og -fsanitize=thread/' makemake.sh
+        sed -i '' 's/-O3 -flto[^\s]*/-Og -fsanitize=thread/' makemake.sh
         clang --version
     - name: Script
       run: |
@@ -518,7 +519,7 @@ jobs:
     - name: Before script
       shell: bash
       run: |
-        sed -i 's/-O3 -flto/-Og -fsanitize=address,undefined/' makemake.sh
+        sed -i 's/-O3 -flto[^\s]*/-Og -fsanitize=address,undefined/' makemake.sh
         $CC --version
     - name: Script
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,12 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y libhwloc-dev
     - name: Before script
-      # With [^\s]* we also remove possible -flto= stuff
       run: |
-        sed -i 's/-O3 -flto[^[:space:]]*/-Og -fsanitize=address,undefined/' makemake.sh
         $CC --version
     - name: Script
       run: |
-        set -x
-        bash -e -o pipefail -- makemake.sh use_hwloc
+        set -x 
+        bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( $(nproc --all) - 1 ))"
@@ -180,12 +178,11 @@ jobs:
         sudo apt-get install -y libhwloc-dev
     - name: Before script
       run: |
-        sed -i 's/-O3 -flto[^\s]*/-Og -fsanitize=thread/' makemake.sh
         $CC --version
     - name: Script
       run: |
         set -x
-        bash -e -o pipefail -- makemake.sh use_hwloc
+        bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( $(nproc --all) - 1 ))"
@@ -379,12 +376,11 @@ jobs:
         brew install hwloc
     - name: Before script
       run: |
-        sed -i '' 's/-O3 -flto[^\s]*/-Og -fsanitize=address,undefined/' makemake.sh
         clang --version
     - name: Script
       run: |
         set -x
-        bash -e -o pipefail -- makemake.sh use_hwloc
+        bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
@@ -405,12 +401,11 @@ jobs:
         brew install hwloc
     - name: Before script
       run: |
-        sed -i '' 's/-O3 -flto[^\s]*/-Og -fsanitize=thread/' makemake.sh
         clang --version
     - name: Script
       run: |
         set -x
-        bash -e -o pipefail -- makemake.sh use_hwloc
+        bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( $(sysctl -n hw.ncpu) - 1 ))"
@@ -519,13 +514,12 @@ jobs:
     - name: Before script
       shell: bash
       run: |
-        sed -i 's/-O3 -flto[^\s]*/-Og -fsanitize=address,undefined/' makemake.sh
         $CC --version
     - name: Script
       shell: bash
       run: |
         set -x
-        bash -e -o pipefail -- makemake.sh use_hwloc
+        bash -e -o pipefail -- makemake.sh use_hwloc debug
         cd obj
         make clean
         time ./Mlucas -s m -cpu "0:$(( NUMBER_OF_PROCESSORS - 1 ))" |& tee -a test.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
     - name: Before script
       # With [^\s]* we also remove possible -flto= stuff
       run: |
-        sed -i 's/-O3 -flto[^\s]*/-Og -fsanitize=address,undefined/' makemake.sh
+        sed -i 's/-O3 -flto[^[:space:]]*/-Og -fsanitize=address,undefined/' makemake.sh
         $CC --version
     - name: Script
       run: |

--- a/makemake.sh
+++ b/makemake.sh
@@ -34,16 +34,24 @@ shopt -s nocasematch
 # for mode in AVX512 AVX2 AVX SSE2; do
 	# if grep -iq "$mode" /proc/cpuinfo; then
 		# echo -e "The CPU supports the ${mode} SIMD build mode.\n"
-		# ARGS+=( "-DUSE_${mode}" )
+		# CPP_ARGS+=( "-DUSE_${mode}" )
 		# break
 	# fi
 # done
+
 
 DIR=obj
 Mlucas=Mlucas
 Mfactor=Mfactor
 TARGET=$Mlucas
-ARGS=(-DUSE_THREADS) # Optional compile args
+
+# Optional compile [optimize] args
+C_ARGS=(-fdiagnostics-color -Wall -g)
+C_ARGS_OPT=(-g -O3)
+C_ARGS_DEBUG=(-g -Og -fsanitize=address,undefined)
+C_ARGS_LTO=()
+# Optional preprocessor args
+CPP_ARGS=(-DUSE_THREADS)
 WORDS=''
 # Optional link args
 LD_ARGS=()
@@ -53,17 +61,19 @@ MAKE_ARGS=()
 MODES=()
 GMP=1
 HWLOC=0
+DEBUG=0  # 0: off, 1: on, keep lto, 2: on, no lto (lto is compatible with debug info in recent gcc/clang)
+CC=${CC:-gcc}
 
 case $OSTYPE in
-	darwin*)
+	(darwin*)
 		echo -e "MacOS detected for build host.\n"
 		CPU_THREADS=$(sysctl -n hw.ncpu)
 		;;
-	msys | cygwin)
+	(msys | cygwin)
 		echo -e "Windows detected for build host.\n"
 		CPU_THREADS=$NUMBER_OF_PROCESSORS
 		;;
-	linux* | *)
+	(linux* | *)
 		echo -e "Assuming OS = Linux for build host.\n"
 		CPU_THREADS=$(nproc --all)
 		;;
@@ -78,15 +88,24 @@ if ! command -v $MAKE >/dev/null; then
 	echo "On Ubuntu and Debian run: 'sudo apt-get update' and 'sudo apt-get install -y build-essential'" >&2
 	exit 1
 fi
-if [[ -n $CC ]]; then
-	if ! command -v "$CC" >/dev/null; then
-		echo "Error: $CC is not installed." >&2
-		exit 1
-	fi
-elif ! command -v gcc >/dev/null; then
-	echo "Error: This script requires the GNU C compiler" >&2
-	echo "On Ubuntu and Debian run: 'sudo apt-get update' and 'sudo apt-get install -y build-essential'" >&2
+if ! command -v "$CC" >/dev/null; then
+	echo "Error: $CC is not installed." >&2
+	echo "For GCC, on Ubuntu and Debian run: 'sudo apt-get update' and 'sudo apt-get install -y build-essential'" >&2
 	exit 1
+fi
+
+MAKE_ARGS+=(-j "$CPU_THREADS")
+
+CCVER=$($CC --version | head -n1)
+if [[ $CCVER == *"clang"* ]]; then
+	echo "Clang detected as C compiler. Enabling ThinLTO for multithreaded codegen."
+	C_ARGS_LTO+=(-flto=thin)
+elif [[ $CCVER == *"gcc"* ]]; then
+	echo "GCC detected as C compiler. Enabling multithreaded LTO."
+	C_ARGS_LTO+=(-flto="$CPU_THREADS")
+else 
+	echo "Unknown C compiler detected: $CCVER, doing just -flto and hoping for the best."
+	C_ARGS_LTO+=(-flto)
 fi
 
 if [[ ! $OSTYPE == darwin* ]]; then
@@ -95,8 +114,11 @@ if [[ ! $OSTYPE == darwin* ]]; then
 	if [[ $OSTYPE != msys && $OSTYPE != cygwin ]]; then
 		LD_ARGS+=(-lrt)
 	fi
+	# Only supported on ELF platforms, but is harmless on not-mac since the compiler is not ancient:
+	CC_ARGS+=(-gz)
+	# Could make output smaller
+	LD_ARGS+=(-Wl,-O1)
 fi
-MAKE_ARGS+=(-j "$CPU_THREADS")
 
 # $0 contains script-name, but $@ starts with first ensuing cmd-line arg, if it exists:
 echo "Total number of input parameters = $#"
@@ -106,30 +128,33 @@ echo "Total number of input parameters = $#"
 # order fashion, [details snipped]
 arglist=("$@") # Local array into which we copy cmd-line args in order to be able to manipulate them
 for i in "${!arglist[@]}"; do
-	echo "Arg[$i] = ${arglist[i]}"
+	printf "Arg[$i] = %q\n" "${arglist[i]}"
 done
 # Now loop over the optional args and execute the above-described preprocessing step:
 for arg in "$@"; do
 
 	case ${arg} in
-		'no_gmp')
+		('no_gmp')
 			GMP=0
 			;;
-		'use_hwloc')
+		('use_hwloc')
 			HWLOC=1
 			;;
-		'avx512_skylake' | 'avx512_knl' | 'avx512' | 'k1om' | 'avx2' | 'avx' | 'sse2' | 'asimd' | 'nosimd')
+		('avx512_skylake' | 'avx512_knl' | 'avx512' | 'k1om' | 'avx2' | 'avx' | 'sse2' | 'asimd' | 'nosimd')
 			MODES+=("$arg")
 			;;
-		'mfac')
+		('mfac')
 			TARGET=$Mfactor
 			;;
-		'1word' | '2word' | '3word' | '4word' | 'nword')
+		('1word' | '2word' | '3word' | '4word' | 'nword')
 			WORDS=$arg
 			;;
-		*)
+		('debug')
+			((DEBUG++))
+			;;
+		(*)
 			echo "Usage: $0 [SIMD build mode]" >&2
-			echo "Optional arguments must be 'no_gmp', 'use_hwloc' or one and only one of the supported SIMD-arithmetic types:" >&2
+			echo "Optional arguments must be 'no_gmp', 'use_hwloc', 'debug' or one and only one of the supported SIMD-arithmetic types:" >&2
 			echo -e "\t[x86_64: avx512 k1om avx2 avx sse2]; [Armv8: asimd]; or 'nosimd' for scalar-double build.\n" >&2
 			exit 1
 			;;
@@ -141,13 +166,24 @@ if ((GMP)); then
 	LD_ARGS+=(-lgmp)
 else
 	echo "Building sans Gnu-MP ... this means no GCDs will be taken in p-1 work."
-	ARGS+=(-DINCLUDE_GMP=0)
+	CPP_ARGS+=(-DINCLUDE_GMP=0)
 fi
 
 if ((HWLOC)); then
 	echo "Building with HWLOC hardware-topology support."
-	ARGS+=(-DINCLUDE_HWLOC=1)
+	CPP_ARGS+=(-DINCLUDE_HWLOC=1)
 	LD_ARGS+=(-lhwloc)
+fi
+
+if ((DEBUG)); then
+	echo "Building with debug flags."
+	C_ARGS+=("${C_ARGS_DEBUG[@]}")
+else
+	C_ARGS+=("${C_ARGS_OPT[@]}")
+fi
+
+if ((DEBUG < 2)); then
+	C_ARGS+=("${C_ARGS_LTO[@]}")
 fi
 
 if [[ $TARGET == "$Mfactor" ]]; then
@@ -182,6 +218,7 @@ fi
 # o "Use GMP" = TRUE is default in link step, 'no_gmp' overrides;
 # o "Use HWLOC" = FALSE is default, 'use_hwloc' overrides.
 # Thx to tdulcet for offering a streamlined case-based syntax here, but ugh - non-matching ')', really?:
+# It can match in both POSIX sh and bash! --Artoria2e5
 if [[ ${#MODES[*]} -gt 1 ]]; then
 	echo -e "Only one arch-specifying optional argument is allowed ... aborting." >&2
 	exit 1
@@ -192,45 +229,45 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 	arg=${MODES[0]}
 
 	case ${arg} in
-		'avx512_skylake')
+		('avx512_skylake')
 			echo "Building for avx512_skylake SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			echo "Warning: The 'avx512_skylake' option is deprecated, use 'avx512' instead."
-			ARGS+=(-DUSE_AVX512 -march=skylake-avx512)
+			C_ARGS+=(-DUSE_AVX512 -march=skylake-avx512)
 			;;
-		'avx512_knl')
+		('avx512_knl')
 			echo "Building for avx512_knl SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			echo "Warning: The 'avx512_knl' option is deprecated, use 'avx512' instead."
-			ARGS+=(-DUSE_AVX512 -march=knl)
+			C_ARGS+=(-DUSE_AVX512 -march=knl)
 			;;
-		'avx512')
+		('avx512')
 			echo "Building for AVX512 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_AVX512 -mavx512f)
+			C_ARGS+=(-DUSE_AVX512 -mavx512f)
 			;;
-		'k1om')
+		('k1om')
 			echo "Building for 1st-gen Xeon Phi 512-bit SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_IMCI512)
+			C_ARGS+=(-DUSE_IMCI512)
 			;;
-		'avx2')
+		('avx2')
 			echo "Building for AVX2 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_AVX2 -mavx2)
+			C_ARGS+=(-DUSE_AVX2 -mavx2)
 			;;
-		'avx')
+		('avx')
 			echo "Building for AVX SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_AVX -mavx)
+			C_ARGS+=(-DUSE_AVX -mavx)
 			;;
-		'sse2')
+		('sse2')
 			echo "Building for SSE2 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_SSE2 -msse2)
+			C_ARGS+=(-DUSE_SSE2 -msse2)
 			;;
-		'asimd')
+		('asimd')
 			echo "Building for ASIMD SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_ARM_V8_SIMD)
+			C_ARGS+=(-DUSE_ARM_V8_SIMD)
 			;;
-		'nosimd')
+		('nosimd')
 			echo "Building in scalar-double (no-SIMD) mode in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			# This one's a no-op
 			;;
-		*)
+		(*)
 			echo "Unrecognized SIMD-build flag ... aborting." >&2
 			exit 1
 			;;
@@ -243,24 +280,24 @@ elif [[ $OSTYPE == darwin* ]]; then
 	# MacOS:
 	if (($(sysctl -n hw.optional.avx512f))); then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX512 -march=native)
+		C_ARGS+=(-DUSE_AVX512 -march=native)
 	elif (($(sysctl -n hw.optional.avx2_0))); then
 		echo -e "The CPU supports the AVX2 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX2 -march=native -mavx2)
+		C_ARGS+=(-DUSE_AVX2 -march=native -mavx2)
 	elif (($(sysctl -n hw.optional.avx1_0))); then
 		echo -e "The CPU supports the AVX SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX -march=native -mavx)
+		C_ARGS+=(-DUSE_AVX -march=native -mavx)
 	elif (($(sysctl -n hw.optional.sse2))); then
 		echo -e "The CPU supports the SSE2 SIMD build mode.\n"
 		# On my Core2Duo Mac, 'native' gives "error: bad value for -march= switch":
-		ARGS+=(-DUSE_SSE2 -march=core2)
+		C_ARGS+=(-DUSE_SSE2 -march=core2)
 	elif (($(sysctl -n hw.optional.neon))); then
 		echo -e "The CPU supports the ASIMD build mode.\n"
-		ARGS+=(-DUSE_ARM_V8_SIMD -mcpu=native) # -march=native
+		C_ARGS+=(-DUSE_ARM_V8_SIMD -mcpu=native) # -march=native
 	else
 		echo -e "The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n"
 		echo "Warning: If this is a 64-bit x86 or ARM system, this likely means there is a bug in this script. Please report!"
-		ARGS+=(-march=native)
+		C_ARGS+=(-march=native)
 	fi
 
 elif [[ $OSTYPE == linux* ]]; then
@@ -268,23 +305,23 @@ elif [[ $OSTYPE == linux* ]]; then
 	# Linux:
 	if grep -iq 'avx512' /proc/cpuinfo; then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX512 -march=native)
+		CPP_ARGS+=(-DUSE_AVX512 -march=native)
 	elif grep -iq 'avx2' /proc/cpuinfo; then
 		echo -e "The CPU supports the AVX2 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX2 -march=native -mavx2)
+		CPP_ARGS+=(-DUSE_AVX2 -march=native -mavx2)
 	elif grep -iq 'avx' /proc/cpuinfo; then
 		echo -e "The CPU supports the AVX SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX -march=native -mavx)
+		CPP_ARGS+=(-DUSE_AVX -march=native -mavx)
 	elif grep -iq 'sse2' /proc/cpuinfo; then
 		echo -e "The CPU supports the SSE2 SIMD build mode.\n"
-		ARGS+=(-DUSE_SSE2 -march=native)
+		CPP_ARGS+=(-DUSE_SSE2 -march=native)
 	elif grep -iq 'asimd' /proc/cpuinfo && [[ $HOSTTYPE == aarch64 ]]; then
 		echo -e "The CPU supports the ASIMD build mode.\n"
-		ARGS+=(-DUSE_ARM_V8_SIMD -mcpu=native) # -march=native
+		CPP_ARGS+=(-DUSE_ARM_V8_SIMD -mcpu=native) # -march=native
 	else
 		echo -e "The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n"
 		echo "Warning: If this is a 64-bit x86 or ARM system, this likely means there is a bug in this script. Please report!"
-		ARGS+=(-march=native)
+		CPP_ARGS+=(-march=native)
 	fi
 
 else
@@ -333,10 +370,10 @@ EOF
 	trap 'rm /tmp/simd{.c,}' EXIT
 	args=()
 	case $HOSTTYPE in
-		aarch64 | arm*)
+		(aarch64 | arm*)
 			args+=(-mcpu=native)
 			;;
-		x86_64 | *)
+		(x86_64 | *)
 			args+=(-march=native)
 			;;
 	esac
@@ -346,7 +383,7 @@ EOF
 		echo "Error: Unable to detect the SIMD build mode" >&2
 		exit 1
 	fi
-	ARGS+=($output)
+	C_ARGS+=($output)
 fi
 
 if [[ -d $DIR ]]; then
@@ -370,8 +407,8 @@ fi
 # stack trace of the issue. If one wishes, one can run 'strip -g Mlucas' to remove the debugging symbols:
 cat <<EOF >Makefile
 CC ?= gcc
-CFLAGS = -fdiagnostics-color -Wall -g -O3 -flto=auto
-CPPFLAGS ?= -I/usr/local/include -I/opt/homebrew/include
+CFLAGS ?= ${C_ARGS[@]}
+CPPFLAGS ?= -I/usr/local/include -I/opt/homebrew/include ${CPP_ARGS[@]}
 LDFLAGS ?= -L/opt/homebrew/lib
 LDLIBS = ${LD_ARGS[@]} # -static
 
@@ -383,9 +420,9 @@ $Mlucas: \$(OBJS)
 $Mfactor: \$(OBJS_MFAC)
 	\$(CC) \$(LDFLAGS) \$(CFLAGS) -o \$@ \$^ \$(LDLIBS)
 factor.o: ../src/factor.c
-	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS -DTRYQ=4 \$<
+	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c -DFACTOR_STANDALONE $WORDS -DTRYQ=4 \$<
 %.o: ../src/%.c
-	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} \$<
+	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c \$<
 clean:
 	rm -f \$(OBJS) \$(OBJS_MFAC)
 

--- a/makemake.sh
+++ b/makemake.sh
@@ -48,7 +48,7 @@ TARGET=$Mlucas
 # Optional compile [optimize] args
 C_ARGS=(-fdiagnostics-color -Wall -g)
 C_ARGS_OPT=(-g -O3)
-C_ARGS_DEBUG=(-g -Og -fsanitize=address,undefined)
+C_ARGS_DEBUG=(-g -Og '-fsanitize=address,undefined')
 C_ARGS_LTO=()
 # Optional preprocessor args
 CPP_ARGS=(-DUSE_THREADS)
@@ -79,6 +79,7 @@ case $OSTYPE in
 		;;
 esac
 
+# shellcheck disable=SC2209
 MAKE=make
 if ! command -v $MAKE >/dev/null && command -v mingw32-make >/dev/null; then
 	MAKE=mingw32-make
@@ -117,7 +118,7 @@ if [[ ! $OSTYPE == darwin* ]]; then
 	# Only supported on ELF platforms, but is harmless on not-mac since the compiler is not ancient:
 	CC_ARGS+=(-gz)
 	# Could make output smaller
-	LD_ARGS+=(-Wl,-O1)
+	LD_ARGS+=("-Wl,-O1")
 fi
 
 # $0 contains script-name, but $@ starts with first ensuing cmd-line arg, if it exists:
@@ -383,7 +384,8 @@ EOF
 		echo "Error: Unable to detect the SIMD build mode" >&2
 		exit 1
 	fi
-	C_ARGS+=($output)
+	mapfile -t output_array <<<"$output"
+	C_ARGS+=("${output_array[@]}")
 fi
 
 if [[ -d $DIR ]]; then

--- a/makemake.sh
+++ b/makemake.sh
@@ -46,9 +46,11 @@ Mfactor=Mfactor
 TARGET=$Mlucas
 
 # Optional compile [optimize] args
-C_ARGS=(-fdiagnostics-color -Wall -g)
+C_ARGS=(-fdiagnostics-color -Wall)
 C_ARGS_OPT=(-g -O3)
-C_ARGS_DEBUG=(-g -Og '-fsanitize=address,undefined')
+C_ARGS_DEBUG=(-g -Og)
+mapfile -t C_ARGS_ADD <<< "$XCFLAGS"
+C_ARGS+=("${C_ARGS_ADD[@]}")
 C_ARGS_LTO=()
 # Optional preprocessor args
 CPP_ARGS=(-DUSE_THREADS)

--- a/makemake.sh
+++ b/makemake.sh
@@ -131,7 +131,7 @@ echo "Total number of input parameters = $#"
 # order fashion, [details snipped]
 arglist=("$@") # Local array into which we copy cmd-line args in order to be able to manipulate them
 for i in "${!arglist[@]}"; do
-	printf "Arg[$i] = %q\n" "${arglist[i]}"
+	printf 'Arg[%s] = %q\n' "$i" "${arglist[i]}"
 done
 # Now loop over the optional args and execute the above-described preprocessing step:
 for arg in "$@"; do

--- a/makemake.sh
+++ b/makemake.sh
@@ -370,7 +370,7 @@ fi
 # stack trace of the issue. If one wishes, one can run 'strip -g Mlucas' to remove the debugging symbols:
 cat <<EOF >Makefile
 CC ?= gcc
-CFLAGS = -fdiagnostics-color -Wall -g -O3 -flto # =auto
+CFLAGS = -fdiagnostics-color -Wall -g -O3 -flto=auto
 CPPFLAGS ?= -I/usr/local/include -I/opt/homebrew/include
 LDFLAGS ?= -L/opt/homebrew/lib
 LDLIBS = ${LD_ARGS[@]} # -static


### PR DESCRIPTION
Lto was turned on ten months ago but with single-thread codegen, which made builds much slower than before. At a little cost to code quality (due to partitioning) we can get back much of the speed by enabling parallel codegen.

Yes, my copy of Apple Clang understands what this is, though it does not partition in this case. Clang wants a specific -flto-partitions=N flag, since it interprets -flto=auto as -flto=full, but then GCC wouldn't know what flag that is.