### PR TITLE
Fixed GCC 15 support and added support for musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     name: Mlucas Linux
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'ubuntu-26.04' && matrix.cc == 'gcc' }}
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-22.04-arm, ubuntu-24.04-arm, ubuntu-26.04-arm]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     name: Mlucas Linux
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ (matrix.os == 'ubuntu-24.04' && matrix.cc == 'clang') || matrix.os == 'ubuntu-26.04' }}
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-22.04-arm, ubuntu-24.04-arm, ubuntu-26.04-arm]
@@ -79,6 +80,7 @@ jobs:
     name: Mlucas Singlethreaded Linux
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ !endsWith(matrix.os, '-arm') }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
@@ -134,11 +136,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04' || matrix.container == 'alpine:3.8') && matrix.cc == 'clang') }}
+    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        container: ["ubuntu:16.04", "ubuntu:18.04", "ubuntu:20.04"] # "alpine:3.8", "alpine:3.12", "alpine:3.16", "alpine:3.20", "alpine:3.24"
+        container: ["ubuntu:16.04", "ubuntu:18.04", "ubuntu:20.04", "alpine:3.8", "alpine:3.12", "alpine:3.16", "alpine:3.20", "alpine:3.24"]
         cc: [gcc, clang]
       fail-fast: false
     env:
@@ -175,6 +177,10 @@ jobs:
       run: |
         $CC --version
         ldd --version || true
+    - name: Fix
+      if: ${{ (matrix.container == 'ubuntu:16.04' || matrix.container == 'alpine:3.8' || matrix.container == 'alpine:3.12' || matrix.container == 'alpine:3.16') && matrix.cc == 'clang' }}
+      run: |
+        sed -i 's/ -flto//' makemake.sh
     - name: Script
       shell: bash
       run: |

--- a/makemake.sh
+++ b/makemake.sh
@@ -75,7 +75,7 @@ if ! command -v $MAKE >/dev/null && command -v mingw32-make >/dev/null; then
 fi
 if ! command -v $MAKE >/dev/null; then
 	echo "Error: This script requires Make" >&2
-	echo "On Ubuntu and Debian run: 'sudo apt-get update' and 'sudo apt-get install -y build-essential'" >&2
+	echo "On Ubuntu and Debian run: 'sudo apt update' and 'sudo apt install -y build-essential'" >&2
 	exit 1
 fi
 if [[ -n $CC ]]; then
@@ -85,7 +85,7 @@ if [[ -n $CC ]]; then
 	fi
 elif ! command -v gcc >/dev/null; then
 	echo "Error: This script requires the GNU C compiler" >&2
-	echo "On Ubuntu and Debian run: 'sudo apt-get update' and 'sudo apt-get install -y build-essential'" >&2
+	echo "On Ubuntu and Debian run: 'sudo apt update' and 'sudo apt install -y build-essential'" >&2
 	exit 1
 fi
 
@@ -112,19 +112,19 @@ done
 for arg in "$@"; do
 
 	case ${arg} in
-		'no_gmp')
+		no_gmp)
 			GMP=0
 			;;
-		'use_hwloc')
+		use_hwloc)
 			HWLOC=1
 			;;
-		'avx512_skylake' | 'avx512_knl' | 'avx512' | 'k1om' | 'avx2' | 'avx' | 'sse2' | 'asimd' | 'nosimd')
+		avx512_skylake | avx512_knl | avx512 | k1om | avx2 | avx | sse2 | asimd | nosimd)
 			MODES+=("$arg")
 			;;
-		'mfac')
+		mfac)
 			TARGET=$Mfactor
 			;;
-		'1word' | '2word' | '3word' | '4word' | 'nword')
+		[1-4n]word)
 			WORDS=$arg
 			;;
 		*)
@@ -192,41 +192,41 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 	arg=${MODES[0]}
 
 	case ${arg} in
-		'avx512_skylake')
+		avx512_skylake)
 			echo "Building for avx512_skylake SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			echo "Warning: The 'avx512_skylake' option is deprecated, use 'avx512' instead."
-			ARGS+=(-DUSE_AVX512 -march=skylake-avx512)
+			ARGS+=(-DUSE_AVX512 -march=skylake-avx512 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
 			;;
-		'avx512_knl')
+		avx512_knl)
 			echo "Building for avx512_knl SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			echo "Warning: The 'avx512_knl' option is deprecated, use 'avx512' instead."
-			ARGS+=(-DUSE_AVX512 -march=knl)
+			ARGS+=(-DUSE_AVX512 -march=knl -mavx512f -mavx512cd -mavx512er -mfma)
 			;;
-		'avx512')
+		avx512)
 			echo "Building for AVX512 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_AVX512 -mavx512f)
+			ARGS+=(-DUSE_AVX512 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
 			;;
-		'k1om')
+		k1om)
 			echo "Building for 1st-gen Xeon Phi 512-bit SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			ARGS+=(-DUSE_IMCI512)
 			;;
-		'avx2')
+		avx2)
 			echo "Building for AVX2 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
-			ARGS+=(-DUSE_AVX2 -mavx2)
+			ARGS+=(-DUSE_AVX2 -mavx2 -mfma)
 			;;
-		'avx')
+		avx)
 			echo "Building for AVX SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			ARGS+=(-DUSE_AVX -mavx)
 			;;
-		'sse2')
+		sse2)
 			echo "Building for SSE2 SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			ARGS+=(-DUSE_SSE2 -msse2)
 			;;
-		'asimd')
+		asimd)
 			echo "Building for ASIMD SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			ARGS+=(-DUSE_ARM_V8_SIMD)
 			;;
-		'nosimd')
+		nosimd)
 			echo "Building in scalar-double (no-SIMD) mode in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			# This one's a no-op
 			;;
@@ -243,17 +243,17 @@ elif [[ $OSTYPE == darwin* ]]; then
 	# MacOS:
 	if (($(sysctl -n hw.optional.avx512f))); then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX512 -march=native)
+		ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
 	elif (($(sysctl -n hw.optional.avx2_0))); then
 		echo -e "The CPU supports the AVX2 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX2 -march=native -mavx2)
+		ARGS+=(-DUSE_AVX2 -march=native -mavx2 -mfma)
 	elif (($(sysctl -n hw.optional.avx1_0))); then
 		echo -e "The CPU supports the AVX SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX -march=native -mavx)
 	elif (($(sysctl -n hw.optional.sse2))); then
 		echo -e "The CPU supports the SSE2 SIMD build mode.\n"
 		# On my Core2Duo Mac, 'native' gives "error: bad value for -march= switch":
-		ARGS+=(-DUSE_SSE2 -march=core2)
+		ARGS+=(-DUSE_SSE2 -march=core2 -msse2)
 	elif (($(sysctl -n hw.optional.neon))); then
 		echo -e "The CPU supports the ASIMD build mode.\n"
 		ARGS+=(-DUSE_ARM_V8_SIMD -mcpu=native) # -march=native
@@ -268,16 +268,16 @@ elif [[ $OSTYPE == linux* ]]; then
 	# Linux:
 	if grep -iq 'avx512' /proc/cpuinfo; then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX512 -march=native)
+		ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
 	elif grep -iq 'avx2' /proc/cpuinfo; then
 		echo -e "The CPU supports the AVX2 SIMD build mode.\n"
-		ARGS+=(-DUSE_AVX2 -march=native -mavx2)
+		ARGS+=(-DUSE_AVX2 -march=native -mavx2 -mfma)
 	elif grep -iq 'avx' /proc/cpuinfo; then
 		echo -e "The CPU supports the AVX SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX -march=native -mavx)
 	elif grep -iq 'sse2' /proc/cpuinfo; then
 		echo -e "The CPU supports the SSE2 SIMD build mode.\n"
-		ARGS+=(-DUSE_SSE2 -march=native)
+		ARGS+=(-DUSE_SSE2 -march=native -msse2)
 	elif grep -iq 'asimd' /proc/cpuinfo && [[ $HOSTTYPE == aarch64 ]]; then
 		echo -e "The CPU supports the ASIMD build mode.\n"
 		ARGS+=(-DUSE_ARM_V8_SIMD -mcpu=native) # -march=native
@@ -298,16 +298,16 @@ int main()
 #ifdef __x86_64__
 	#ifdef __AVX512F__
 		fputs("The CPU supports the AVX512 SIMD build mode.\n\n", stderr);
-		puts("-DUSE_AVX512 -march=native");
+		puts("-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma");
 	#elif defined __AVX2__
 		fputs("The CPU supports the AVX2 SIMD build mode.\n\n", stderr);
-		puts("-DUSE_AVX2 -march=native -mavx2");
+		puts("-DUSE_AVX2 -march=native -mavx2 -mfma");
 	#elif defined __AVX__
 		fputs("The CPU supports the AVX SIMD build mode.\n\n", stderr);
 		puts("-DUSE_AVX -march=native -mavx");
 	#elif defined __SSE2__
 		fputs("The CPU supports the SSE2 SIMD build mode.\n\n", stderr);
-		puts("-DUSE_SSE2 -march=native");
+		puts("-DUSE_SSE2 -march=native -msse2");
 	#else
 		fputs("The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n\n", stderr);
 		fputs("Warning: This likely means there is a bug in this script. Please report!\n", stderr);
@@ -370,10 +370,10 @@ fi
 # stack trace of the issue. If one wishes, one can run 'strip -g Mlucas' to remove the debugging symbols:
 cat <<EOF >Makefile
 CC ?= gcc
-CFLAGS = -fdiagnostics-color -Wall -g -O3 -flto # =auto
+CFLAGS ?= -fdiagnostics-color -Wall -g -O3 -flto # =auto
 CPPFLAGS ?= -I/usr/local/include -I/opt/homebrew/include
 LDFLAGS ?= -L/opt/homebrew/lib
-LDLIBS = ${LD_ARGS[@]} # -static
+LDLIBS ?= ${LD_ARGS[@]} # -static
 
 OBJS=br.o dft_macro.o fermat_mod_square.o fgt_m61.o get_cpuid.o get_fft_radices.o get_fp_rnd_const.o get_preferred_fft_radix.o getRealTime.o imul_macro.o mers_mod_square.o mi64.o Mlucas.o pairFFT_mul.o pair_square.o pm1.o qfloat.o radix1008_ditN_cy_dif1.o radix1024_ditN_cy_dif1.o radix104_ditN_cy_dif1.o radix10_ditN_cy_dif1.o radix112_ditN_cy_dif1.o radix11_ditN_cy_dif1.o radix120_ditN_cy_dif1.o radix128_ditN_cy_dif1.o radix12_ditN_cy_dif1.o radix13_ditN_cy_dif1.o radix144_ditN_cy_dif1.o radix14_ditN_cy_dif1.o radix15_ditN_cy_dif1.o radix160_ditN_cy_dif1.o radix16_dif_dit_pass.o radix16_ditN_cy_dif1.o radix16_dyadic_square.o radix16_pairFFT_mul.o radix16_wrapper_ini.o radix16_wrapper_square.o radix176_ditN_cy_dif1.o radix17_ditN_cy_dif1.o radix18_ditN_cy_dif1.o radix192_ditN_cy_dif1.o radix208_ditN_cy_dif1.o radix20_ditN_cy_dif1.o radix224_ditN_cy_dif1.o radix22_ditN_cy_dif1.o radix240_ditN_cy_dif1.o radix24_ditN_cy_dif1.o radix256_ditN_cy_dif1.o radix26_ditN_cy_dif1.o radix288_ditN_cy_dif1.o radix28_ditN_cy_dif1.o radix30_ditN_cy_dif1.o radix31_ditN_cy_dif1.o radix320_ditN_cy_dif1.o radix32_dif_dit_pass.o radix32_ditN_cy_dif1.o radix32_dyadic_square.o radix32_wrapper_ini.o radix32_wrapper_square.o radix352_ditN_cy_dif1.o radix36_ditN_cy_dif1.o radix384_ditN_cy_dif1.o radix4032_ditN_cy_dif1.o radix40_ditN_cy_dif1.o radix44_ditN_cy_dif1.o radix48_ditN_cy_dif1.o radix512_ditN_cy_dif1.o radix52_ditN_cy_dif1.o radix56_ditN_cy_dif1.o radix5_ditN_cy_dif1.o radix60_ditN_cy_dif1.o radix63_ditN_cy_dif1.o radix64_ditN_cy_dif1.o radix6_ditN_cy_dif1.o radix72_ditN_cy_dif1.o radix768_ditN_cy_dif1.o radix7_ditN_cy_dif1.o radix80_ditN_cy_dif1.o radix88_ditN_cy_dif1.o radix8_dif_dit_pass.o radix8_ditN_cy_dif1.o radix960_ditN_cy_dif1.o radix96_ditN_cy_dif1.o radix992_ditN_cy_dif1.o radix9_ditN_cy_dif1.o rng_isaac.o threadpool.o twopmodq100.o twopmodq128_96.o twopmodq128.o twopmodq160.o twopmodq192.o twopmodq256.o twopmodq64_test.o twopmodq80.o twopmodq96.o twopmodq.o types.o util.o
 OBJS_MFAC=getRealTime.o get_cpuid.o get_fft_radices.o get_fp_rnd_const.o imul_macro.o mi64.o qfloat.o rng_isaac.o twopmodq100.o twopmodq128_96.o twopmodq128.o twopmodq160.o twopmodq192.o twopmodq256.o twopmodq64_test.o twopmodq80.o twopmodq96.o twopmodq.o types.o util.o threadpool.o factor.o

--- a/src/platform.h
+++ b/src/platform.h
@@ -1303,7 +1303,7 @@ extern int NTHREADS;
 // Nov 2020: Under MacOS, use of sysctlbyname call in util.c::print_host_info needs this moved outside #ifdef USE_THREADS.
 // Feb 2021: Under Linux, per this [url=https://github.com/open5gs/open5gs/issues/600]Github discussion[/url],
 // "sysctl() is deprecated and may break build with glibc >= 2.30", so add an appropriate GLIBC-version clause:
-#if defined(OS_TYPE_MACOSX) || !defined(OS_TYPE_GNU_HURD) && !defined(__MINGW32__) && ((__GLIBC__ < 2) || (__GLIBC_MINOR__ < 30))
+#if defined(OS_TYPE_MACOSX) || !defined(OS_TYPE_GNU_HURD) && !defined(__MINGW32__) && defined(__GLIBC__) && ((__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 30))
   #ifdef OS_TYPE_LINUX
 	#warning GLIBC either not defined or version < 2.30 ... including <sys/sysctl.h> header.
   #endif
@@ -1355,15 +1355,16 @@ extern int NTHREADS;
 		...and the "implicit" warnings disppear. Anyway, add that one to the build-related mental "WTF?" bin
 		and just #define __USE_GNU instead.
 		*/
-		#define __USE_GNU
+		#define _GNU_SOURCE
 		#include <sched.h>
 
 		#include <unistd.h>	// Needed for Posix sleep() command, among other things
 		#if defined(OS_TYPE_LINUX) && !defined(__MINGW32__)
 
 			// These additional Linux-only includes make sure __NR_gettid, used in our syscall-based get-thread-ID, is defined:
-			#include <linux/unistd.h>
-			#include <asm/unistd.h>
+			// #include <linux/unistd.h>
+			// #include <asm/unistd.h>
+			#include <sys/syscall.h>
 
 		#elif defined(OS_TYPE_MACOSX)
 

--- a/src/radix144_main_carry_loop.h
+++ b/src/radix144_main_carry_loop.h
@@ -141,8 +141,8 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			k8 = *(iptr+0x8);	rad9_optr[8] = tm1 + (k8<<5);
 
 			// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-			tm1 = rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
-			tm2 = rad9_optr;
+			tm1 = (vec_dbl *)rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+			tm2 = (vec_dbl *)rad9_optr;
 			SSE2_RADIX_09_DIT_X2(va0,va1,va2,va3,va4,va5,va6,va7,va8, cc1,two, vb0,vb1,vb2,vb3,vb4,vb5,vb6,vb7,vb8,
 				tm1,tm2
 			);	tmp += 4;
@@ -631,8 +631,8 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			rad9_optr[7] = tmp + 0xe2;
 			rad9_optr[8] = tmp + 0x102;
 			// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-			tm0 = rad9_iptr;	// Can't use tm1 here since use that for s1p00 offsets in loop body
-			tm2 = rad9_optr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+			tm0 = (vec_dbl *)rad9_iptr;	// Can't use tm1 here since use that for s1p00 offsets in loop body
+			tm2 = (vec_dbl *)rad9_optr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
 			SSE2_RADIX_09_DIF_X2(vb0,vb1,vb2,vb3,vb4,vb5,vb6,vb7,vb8, cc1,two, va0,va1,va2,va3,va4,va5,va6,va7,va8,
 				tm0,tm2
 			);	tmp += 4;

--- a/src/radix288_main_carry_loop.h
+++ b/src/radix288_main_carry_loop.h
@@ -79,8 +79,8 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			rad9_iptr[8] = tmp + 0x202;		rad9_optr[8] = tm1 + k8;
 
 			// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-			tm1 = rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
-			tm2 = rad9_optr;
+			tm1 = (vec_dbl *)rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+			tm2 = (vec_dbl *)rad9_optr;
 			SSE2_RADIX_09_DIT_X2(va0,va1,va2,va3,va4,va5,va6,va7,va8, ycc1,two, vb0,vb1,vb2,vb3,vb4,vb5,vb6,vb7,vb8,
 				tm1,tm2
 			);	tmp += 4;
@@ -522,8 +522,8 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			rad9_optr[8] = tmp + 0x202;		rad9_iptr[8] = tm1 + k8;
 
 			// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-			tm0 = rad9_iptr;	// Can't use tm1 here since use that for s1p00 offsets in loop body
-			tm2 = rad9_optr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+			tm0 = (vec_dbl *)rad9_iptr;	// Can't use tm1 here since use that for s1p00 offsets in loop body
+			tm2 = (vec_dbl *)rad9_optr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
 			SSE2_RADIX_09_DIF_X2(vb0,vb1,vb2,vb3,vb4,vb5,vb6,vb7,vb8, ycc1,two, va0,va1,va2,va3,va4,va5,va6,va7,va8,
 				tm0,tm2
 			);	tmp += 4;

--- a/src/radix36_main_carry_loop.h
+++ b/src/radix36_main_carry_loop.h
@@ -75,8 +75,8 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		*vb0,*vb1,*vb2,*vb3,*vb4,*vb5,*vb6,*vb7,*vb8;	// O-ptrs
 	   #ifdef USE_AVX2
 		// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-		tm1 = rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
-		tm2 = rad9_optr;
+		tm1 = (vec_dbl *)rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+		tm2 = (vec_dbl *)rad9_optr;
 		for(l = 0, tmp = r00, ntmp = 0; l < 2; l++, ntmp += 18) {
 	   #else
 		for(l = 0, tmp = r00, ntmp = 0; l < 4; l++, ntmp += 9) {
@@ -134,8 +134,8 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		/* Radix-9 DFT uses adjacent temps, i.e. stride = 2*16 bytes: */
 	   #ifdef USE_AVX2
 		// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-		tm1 = rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
-		tm2 = rad9_optr;
+		tm1 = (vec_dbl *)rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+		tm2 = (vec_dbl *)rad9_optr;
 		// Pointer patterns here same as for DIF, just need to swap I/O by reversing order of tm1,tm2 --> tm2,tm1 in macro arglists:
 		rad9_iptr[0] = s1p27; rad9_iptr[1] = s1p23; rad9_iptr[2] = s1p19; rad9_iptr[3] = s1p15; rad9_iptr[4] = s1p11; rad9_iptr[5] = s1p07; rad9_iptr[6] = s1p03; rad9_iptr[7] = s1p35; rad9_iptr[8] = s1p31;
 		rad9_optr[0] = r10; rad9_optr[1] = r12; rad9_optr[2] = r14; rad9_optr[3] = r16; rad9_optr[4] = r18; rad9_optr[5] = r1a; rad9_optr[6] = r1c; rad9_optr[7] = r1e; rad9_optr[8] = r1g;
@@ -325,7 +325,7 @@ $zmm1.v8_double = {0, 0, 0, 0, 1284, 257, 912, -274}, d4-7 nowhere near the corr
 Output:
 */
 		add0 += p04;				// prefetch of a + [prefetch offset] + p4,5,6,7
-		tmp  = (double *)tmp +  4;	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
+		tmp  = (vec_dbl *)((double *)tmp +  4);	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,0x800, sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);	// Call 2 wts-data pointers += 0x400
 	   #endif
 /*
@@ -609,8 +609,8 @@ vinsertf64x4 1,ymm1,zmm0,zmm0	 3-6/1 for y,z,z, 7/1 for m256,z,z			3/1 for y,z,z
 		// Radix-9 DFT inputs can use same optr_off[] perm-index array as DIT:
 	   #ifdef USE_AVX2
 		// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-		tm1 = rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
-		tm2 = rad9_optr;
+		tm1 = (vec_dbl *)rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+		tm2 = (vec_dbl *)rad9_optr;
 		for(l = 0, tmp = r00, ntmp = 0; l < 2; l++, ntmp += 18) {
 	   #else
 		for(l = 0, tmp = r00, ntmp = 0; l < 4; l++, ntmp += 9) {
@@ -668,8 +668,8 @@ vinsertf64x4 1,ymm1,zmm0,zmm0	 3-6/1 for y,z,z, 7/1 for m256,z,z			3/1 for y,z,z
 		/* Radix-9 DFT uses adjacent temps, i.e. stride = 2*16 bytes: */
 	   #ifdef USE_AVX2
 		// Due to GCC macro argc limit of 30, to enable 16-register data-doubled version of the radix-9 macros need 2 length-9 ptr arrays:
-		tm1 = rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
-		tm2 = rad9_optr;
+		tm1 = (vec_dbl *)rad9_iptr;	// Stash head-of-array-ptrs in tmps to workaround GCC's "not directly addressable" macro arglist stupidity
+		tm2 = (vec_dbl *)rad9_optr;
 		rad9_iptr[0] = s1p27; rad9_iptr[1] = s1p23; rad9_iptr[2] = s1p19; rad9_iptr[3] = s1p15; rad9_iptr[4] = s1p11; rad9_iptr[5] = s1p07; rad9_iptr[6] = s1p03; rad9_iptr[7] = s1p35; rad9_iptr[8] = s1p31;
 		rad9_optr[0] = r10; rad9_optr[1] = r12; rad9_optr[2] = r14; rad9_optr[3] = r16; rad9_optr[4] = r18; rad9_optr[5] = r1a; rad9_optr[6] = r1c; rad9_optr[7] = r1e; rad9_optr[8] = r1g;
 		SSE2_RADIX_09_DIF_X2(s1p00,s1p32,s1p28,s1p24,s1p20,s1p16,s1p12,s1p08,s1p04, cc1,two, r00,r02,r04,r06,r08,r0a,r0c,r0e,r0g,

--- a/src/radix44_main_carry_loop.h
+++ b/src/radix44_main_carry_loop.h
@@ -222,7 +222,7 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		// AVX-512 mode calls this macro twice, with Call 2ptr-offsets fiddled as described in comments to that version of the macro:
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,0x000, sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);
 		add0 += p04;				// prefetch of a + [prefetch offset] + p4,5,6,7
-		tmp  = (double *)tmp +  4;	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
+		tmp  = (vec_dbl *)((double *)tmp +  4);	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,0x800, sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);	// Call 2 wts-data pointers += 0x400
 	   #else
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,i,     sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);

--- a/src/radix52_main_carry_loop.h
+++ b/src/radix52_main_carry_loop.h
@@ -238,7 +238,7 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		// AVX-512 mode calls this macro twice, with Call 2ptr-offsets fiddled as described in comments to that version of the macro:
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,0x000, sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);
 		add0 += p04;				// prefetch of a + [prefetch offset] + p4,5,6,7
-		tmp  = (double *)tmp +  4;	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
+		tmp  = (vec_dbl *)((double *)tmp +  4);	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,0x800, sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);	// Call 2 wts-data pointers += 0x400
 	   #else
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,i,     sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);

--- a/src/radix60_main_carry_loop.h
+++ b/src/radix60_main_carry_loop.h
@@ -310,7 +310,7 @@ for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		// AVX-512 mode calls this macro twice, with Call 2ptr-offsets fiddled as described in comments to that version of the macro:
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,0x000, sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);
 		add0 += p04;				// prefetch of a + [prefetch offset] + p4,5,6,7
-		tmp  = (double *)tmp +  4;	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
+		tmp  = (vec_dbl *)((double *)tmp +  4);	// Call 2 will handle the .d4-7 doubles of our 4 input zmm register-sized vector data
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,0x800, sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);	// Call 2 wts-data pointers += 0x400
 	   #else
 		AVX_cmplx_carry_fast_errcheck_X4(tmp, tm1, itmp, half_arr,i,     sign_mask,sse_bw,sse_n,sse_sw, add0,p01,p02,p03, addr);

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -329,7 +329,7 @@ me at: heber.tomer@gmail.com
 
 		cpu_set_t cpu_set;
 		int i,errcode;
-		pid_t thread_id = syscall (__NR_gettid);
+		pid_t thread_id = syscall (SYS_gettid);
 	  #if THREAD_POOL_DEBUG
 		printf("executing worker thread id %u, syscall_id = %u\n", my_id, thread_id);
 	  #endif
@@ -674,7 +674,7 @@ me at: heber.tomer@gmail.com
 		for (i = 0; i < num_threads; i++)
 		{
 			CPU_SET(i, &cpu_set);
-			thread_id = (pid_t) syscall (__NR_gettid);
+			thread_id = (pid_t) syscall (SYS_gettid);
 			errcode = sched_setaffinity (thread_id, sizeof(cpu_set), &cpu_set);
 		  #if THREAD_POOL_DEBUG
 			printf("syscall_id = %u, setaffinity[%d] = %d, ISSET[%d] = %d\n", thread_id,i,errcode,i,CPU_ISSET(i, &cpu_set));

--- a/src/twopmodq100.c
+++ b/src/twopmodq100.c
@@ -158,7 +158,7 @@
 		/***************************************************/
 
 			sc_arr = ALLOC_DOUBLE(sc_arr, 0x140*max_threads);	if(!sc_arr){ sprintf(cbuf, "ERROR: unable to allocate sc_arr!.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
-			sc_ptr = (uint64 *)ALIGN_VEC_DBL(sc_arr);	// Force vec_u64-alignment
+			sc_ptr = (double *)ALIGN_VEC_DBL(sc_arr);	// Force vec_u64-alignment
 			ASSERT(((uintptr_t)sc_ptr & 0x3f) == 0, "sc_ptr not 64-byte aligned!");
 		  #ifdef MULTITHREAD
 			__r0  = sc_ptr;

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -5523,7 +5523,7 @@ if(~pshift != p+78) {
 			/***************************************************/
 
 				sc_arr = ALLOC_DOUBLE(sc_arr, 0x1c0*max_threads);	if(!sc_arr){ sprintf(cbuf, "ERROR: unable to allocate sc_arr!.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
-				sc_ptr = (uint64 *)ALIGN_VEC_DBL(sc_arr);	// Force vec_u64-alignment
+				sc_ptr = (double *)ALIGN_VEC_DBL(sc_arr);	// Force vec_u64-alignment
 				ASSERT(((uintptr_t)sc_ptr & 0x3f) == 0, "sc_ptr not 64-byte aligned!");
 			  #ifdef MULTITHREAD
 				__r0  = sc_ptr;
@@ -6270,7 +6270,7 @@ if(~pshift != p+78) {
 			/***************************************************/
 
 				sc_arr = ALLOC_DOUBLE(sc_arr, 0x380*max_threads);	if(!sc_arr){ sprintf(cbuf, "ERROR: unable to allocate sc_arr!.\n"); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
-				sc_ptr = (uint64 *)ALIGN_VEC_DBL(sc_arr);	// Force vec_u64-alignment
+				sc_ptr = (double *)ALIGN_VEC_DBL(sc_arr);	// Force vec_u64-alignment
 				ASSERT(((uintptr_t)sc_ptr & 0x3f) == 0, "sc_ptr not 64-byte aligned!");
 			  #ifdef MULTITHREAD
 				__r0  = sc_ptr;


### PR DESCRIPTION
* Added support for GCC 15 on x86 by fixing incompatible pointer type errors.
  * This was contributed by @ldesnogu and cherry picked from #34.
* Added support for the musl C standard library implementation.
  * Enabled the CI to test building on Alpine Linux, which uses musl.