### PR TITLE
Free threadpools on re-init instead of leaking them (fixes #44)

### DIFF
--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1147,6 +1147,11 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 
 		main_work_units = 0;
 		pool_work_units = radix0;
+		// Free any threadpool left over from a prior runlength/radix-set before creating the new one,
+		// so a radix/runlength switch does not leak NTHREADS worker threads each time. Safe here because
+		// this re-init only happens at the top of a mod_square call, at which point the previous config's
+		// pool is quiescent - the preceding call drained it via the dispatch-completion wait below:
+		if(tpool) { threadpool_free(tpool); tpool = 0x0; }
 		ASSERT(0x0 != (tpool = threadpool_init(NTHREADS, MAX_THREADS, pool_work_units, &thread_control)), "threadpool_init failed!");
 		printf("%s: Init threadpool of %d threads\n",func,NTHREADS);
 

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -1352,6 +1352,11 @@ for(i=0; i < NRT; i++) {
 
 		main_work_units = 0;
 		pool_work_units = nchunks;
+		// Free any threadpool left over from a prior runlength/radix-set before creating the new one,
+		// so a radix/runlength switch does not leak NTHREADS worker threads each time. Safe here because
+		// this re-init only happens at the top of a mod_square call, at which point the previous config's
+		// pool is quiescent - the preceding call drained it via the dispatch-completion wait below:
+		if(tpool) { threadpool_free(tpool); tpool = 0x0; }
 		ASSERT(0x0 != (tpool = threadpool_init(NTHREADS, MAX_THREADS, pool_work_units, &thread_control)), "threadpool_init failed!");
 		printf("%s: Init threadpool of %d threads\n",func,NTHREADS);
 

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -989,7 +989,6 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
   #ifdef MULTITHREAD
 	static int *thr_ret = 0x0;
 	static pthread_t *thread = 0x0;
-	static pthread_attr_t attr;
 	static struct pm1_thread_data_t *tdat = 0x0;
 	// Threadpool-based dispatch:
 	static struct threadpool *tpool = 0x0;
@@ -1161,12 +1160,16 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	containing as close to npad/NTHREADS doubles as possible, but satisfying the aforementioned starting-
 	address alignment criterion:
 	*/
+	// Free any thread-arrays/pool left over from a prior Stage-2 call before re-allocating, so repeated
+	// Stage-2 invocations - including any that returned early on a modmul error, bypassing the ERR_RETURN
+	// cleanup below - do not leak the NTHREADS worker threads or the per-thread arrays:
+	if(tpool)   { threadpool_free(tpool); tpool   = 0x0; }
+	if(thr_ret) { free((void *)thr_ret); thr_ret = 0x0; }
+	if(thread)  { free((void *)thread ); thread  = 0x0; }
+	if(tdat)    { free((void *)tdat   ); tdat    = 0x0; }
 	thr_ret  = (int *)calloc(NTHREADS, sizeof(int));
 	thread   = (pthread_t *)calloc(NTHREADS, sizeof(pthread_t));
 	tdat     = (struct pm1_thread_data_t *)calloc(NTHREADS, sizeof(struct pm1_thread_data_t));
-	// Initialize and set thread detached attribute:
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	const int nbytes_simd_align = (RE_IM_STRIDE*8) - 1;	// And per-thread data chunk addresses with this to check SIMD alignment
 	ASSERT(((intptr_t)mult[0] & nbytes_simd_align) == 0x0,"mult[0] not aligned on 64-byte boundary!");
 	ASSERT(((intptr_t)buf [0] & nbytes_simd_align) == 0x0,"buf [0] not aligned on 64-byte boundary!");	// Since npad a multiple of RE_IM_STRIDE, only need to check buf[0] alignment
@@ -2534,6 +2537,7 @@ ERR_RETURN:
 	free((void *)b); b = 0x0;
 	free((void *)map); map = 0x0;
   #ifdef MULTITHREAD
+	if(tpool) { threadpool_free(tpool); tpool = 0x0; }	// Join+free the Stage-2 worker pool so it does not linger after this call
 	free((void *)thr_ret ); thr_ret  = 0x0;
 	free((void *)thread  ); thread   = 0x0;
 	free((void *)tdat    ); tdat     = 0x0;


### PR DESCRIPTION
## Summary

`threadpool_free()` is complete and correct but **was never called anywhere** in the codebase, so worker threads accumulate:

- **`mers_mod_square` / `fermat_mod_square`**: every `first_entry` re-init overwrites the static `tpool` pointer with a fresh `threadpool_init(...)`, leaking `NTHREADS` worker threads per runlength/radix-set switch (this matches the reporter's "18 threads with NTHREADS=1 after ~16 re-inits").
- **`pm1` Stage 2**: `threadpool_init` runs on every invocation and the pool is never freed; the per-thread arrays are freed at `ERR_RETURN` but the several early `return ierr` modmul-error paths bypass that cleanup.

## Fix

- **mers/fermat**: free the previous pool before re-creating it at the top of a `mod_square` call. Safe because the prior config's pool is **quiescent** there — the preceding call already drained it via the dispatch-completion wait (`free_tasks_queue.num_tasks == pool_work_units`).
- **pm1 Stage 2**: free the pool at `ERR_RETURN` (prompt cleanup on the normal + `goto`-error exits) **and** free-before-realloc the pool + per-thread arrays at the top of the alloc block, so the early-`return` error paths that bypass `ERR_RETURN` can't leak across repeated Stage-2 calls. Also removed the dead `pthread_attr_t` (init'd every call, never used — `threadpool_init` creates its threads with a `NULL` attr — so it was itself a small per-call pthread-attr leak).

## Verification

AVX2 build, 4 carry threads (`-cpu 0:3`), multi-length self-test `-s s` (127 radix-set re-inits), process thread count sampled from `/proc/<pid>/task`:

| | peak threads | behavior |
|---|---|---|
| baseline (`main`) | **621** | climbs monotonically with re-init count |
| this PR | **117** | **plateaus** — bounded, no per-config growth |

24/24 radix-sets still pass with **zero crashes**, confirming the pre-init free is race-free. Instrumentation confirmed `threadpool_free` is now called once per re-init (25 frees / 26 mers pools in `-s tt`), each `pthread_join` returning 0.

## Note on the residual (separate, bounded)

The remaining ~117 threads are **not** a per-config leak: each `radix*_ditN_cy_dif1.c` holds its own static carry-step `tpool`, created **once per leading radix** (guarded by `if(tdat==0x0)`, and `tdat` is never reset) and reused for the life of the process. That's a bounded one-pool-per-radix allocation (≈ distinct-radix count × `NTHREADS`), which is why the fixed curve *plateaus* instead of growing. Freeing those cleanly needs a different mechanism (they have no re-init point to hook, and no teardown hook exists), so I've left it out of this PR — happy to do it as a follow-up if you'd like.

`pm1` Stage 2 is compile-verified and follows the same (verified) pattern as mers; it isn't exercised by the Mersenne self-test, so its runtime path wasn't driven here.

Fixes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
