### PR TITLE
Recover the p-1 stage-1 B1 from the .s1_prod savefile on restart (fixes #31)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1785,8 +1785,18 @@ READ_RESTART_FILE:
 	int update_shift = (RES_SHIFT != 0ull);	// If shift = 0 at outset, don't update (only need for Fermat-mod, due to the random-bit aspect there)
 
 	if(TEST_TYPE == TEST_TYPE_PM1 && ilo >= maxiter) {
-		ASSERT(ilo == maxiter && ilo == PM1_S1_PROD_BITS,"For completed S1 expect ilo == maxiter == PM1_S1_PROD_BITS!");
-		snprintf(cbuf,sizeof(cbuf), "%s: p-1 stage 1 to b1 = %u already done -- proceeding to stage 2.\n",PSTRING,B1);
+		// Task 20/#31: For a genuinely-completed Stage 1 we expect ilo == maxiter == PM1_S1_PROD_BITS. If instead
+		// ilo *exceeds* the current-B1 product length, the savefile was produced with a larger B1 (e.g. a low-memory
+		// run bumps B1 up ~25%) and its '.s1_prod' product-savefile is missing, so compute_pm1_s1_product() could not
+		// recover/adopt the original B1. Do NOT proceed to Stage 2 - a partial powering to the larger B1 is not a
+		// completed Stage 1 at this B1, and treating it as such silently loses factors. Fail with actionable guidance.
+		if(ilo != maxiter || ilo != PM1_S1_PROD_BITS) {
+			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s p-1 restart-file Stage 1 iteration count [%u] exceeds the Stage 1 prime-powers-product length [%u] for the current b1 = %u.\n"
+				"The savefile was written with a larger B1 and its '.s1_prod' product-savefile is missing, so the original B1 cannot be recovered automatically.\n"
+				"Re-run with the original (larger) '-b1 <N>', or delete this exponent's p-1 savefiles to start a fresh run.\n", PSTRING, ilo, PM1_S1_PROD_BITS, B1);
+			mlucas_fprint(cbuf,1);	ASSERT(0, "p-1 Stage 1 restart B1-mismatch: see preceding message.");
+		}
+		snprintf(cbuf,STR_MAX_LEN*2, "%s: p-1 stage 1 to b1 = %u already done -- proceeding to stage 2.\n",PSTRING,B1);
 		fprintf(stderr,"%s",cbuf);
 		ilo = ihi;		// Need this to differentiate between just-completed S1 and S1 residue read from restart file,
 		goto PM1_STAGE2;// in terms of whether we need to do a GCD before proceeding to S2
@@ -5233,7 +5243,18 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 			if(nsquares > 0xFFFFFFFFull)
 				ASSERT(B2_start <= nsquares, "P-1 stage 2 restart requires (B2_start in worktodo assignment) <= (savefile nsquares field)!");
 		} else {	// It's a stage 1 restart:
-			ASSERT(nsquares <= 0xFFFFFFFFull && nsquares < 1.5*(double)B1, "P-1 stage 1 restart: savefile nsquares value out of bounds!");
+			ASSERT(nsquares <= 0xFFFFFFFFull, "P-1 stage 1 restart: savefile nsquares value out of bounds!");
+			// Task 20/#31: nsquares >= ~1.5*B1 means the savefile's in-progress Stage 1 was run to a larger B1 than
+			// the current run's. compute_pm1_s1_product() normally recovers that B1 from the '.s1_prod' product-savefile
+			// and adopts it before we get here; if we still land here, that file is missing/unreadable, so the original
+			// B1 cannot be recovered. Fail with actionable guidance rather than the bare bounds-assert (a partial powering
+			// to the larger B1 is not a completed - nor a valid partial - Stage 1 at the smaller B1: proceeding loses factors).
+			if(nsquares >= 1.5*(double)B1) {
+				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s: p-1 Stage 1 restart-file iteration count [%" PRIu64 "] is too large for the current b1 = %u.\n"
+					"The in-progress Stage 1 was run to a larger B1; its '.s1_prod' product-savefile (which records that B1) is missing or unreadable, so it cannot be recovered automatically.\n"
+					"Re-run with the original (larger) '-b1 <N>', or delete this exponent's p-1 savefiles to start a fresh run.\n", func, nsquares, B1);
+				mlucas_fprint(cbuf,1);	ASSERT(0, "p-1 Stage 1 restart B1-mismatch: see preceding message.");
+			}
 		}
 		// If S2 restart and (nsquares > B2_start), read the ensuing S2 interim residue; if (nsquares == B2_start)
 		// it means S2 started but was aborted for some reason before writing an interim S2 residue. That will set

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1791,12 +1791,12 @@ READ_RESTART_FILE:
 		// recover/adopt the original B1. Do NOT proceed to Stage 2 - a partial powering to the larger B1 is not a
 		// completed Stage 1 at this B1, and treating it as such silently loses factors. Fail with actionable guidance.
 		if(ilo != maxiter || ilo != PM1_S1_PROD_BITS) {
-			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s P-1 restart-file Stage 1 iteration count [%u] exceeds the Stage 1 prime-powers-product length [%u] for the current B1 = %u.\n"
+			snprintf(cbuf,sizeof(cbuf), "ERROR: %s P-1 restart-file Stage 1 iteration count [%u] exceeds the Stage 1 prime-powers-product length [%u] for the current B1 = %u.\n"
 				"The savefile was written with a larger B1 and its '.s1_prod' product-savefile is missing, so the original B1 cannot be recovered automatically.\n"
 				"Re-run with the original (larger) '-b1 <N>', or delete this exponent's P-1 savefiles to start a fresh run.\n", PSTRING, ilo, PM1_S1_PROD_BITS, B1);
 			mlucas_fprint(cbuf,1);	ASSERT(0, "P-1 Stage 1 restart B1-mismatch: see preceding message.");
 		}
-		snprintf(cbuf,STR_MAX_LEN*2, "%s: P-1 Stage 1 to B1 = %u already done -- proceeding to Stage 2.\n",PSTRING,B1);
+		snprintf(cbuf,sizeof(cbuf), "%s: P-1 Stage 1 to B1 = %u already done -- proceeding to Stage 2.\n",PSTRING,B1);
 		fprintf(stderr,"%s",cbuf);
 		ilo = ihi;		// Need this to differentiate between just-completed S1 and S1 residue read from restart file,
 		goto PM1_STAGE2;// in terms of whether we need to do a GCD before proceeding to S2
@@ -5250,7 +5250,7 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 			// B1 cannot be recovered. Fail with actionable guidance rather than the bare bounds-assert (a partial powering
 			// to the larger B1 is not a completed - nor a valid partial - Stage 1 at the smaller B1: proceeding loses factors).
 			if(nsquares >= 1.5*(double)B1) {
-				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s: P-1 Stage 1 restart-file iteration count [%" PRIu64 "] is too large for the current B1 = %u.\n"
+				snprintf(cbuf,sizeof(cbuf), "ERROR: %s: P-1 Stage 1 restart-file iteration count [%" PRIu64 "] is too large for the current B1 = %u.\n"
 					"The in-progress Stage 1 was run to a larger B1; its '.s1_prod' product-savefile (which records that B1) is missing or unreadable, so it cannot be recovered automatically.\n"
 					"Re-run with the original (larger) '-b1 <N>', or delete this exponent's P-1 savefiles to start a fresh run.\n", func, nsquares, B1);
 				mlucas_fprint(cbuf,1);	ASSERT(0, "P-1 Stage 1 restart B1-mismatch: see preceding message.");

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1785,18 +1785,18 @@ READ_RESTART_FILE:
 	int update_shift = (RES_SHIFT != 0ull);	// If shift = 0 at outset, don't update (only need for Fermat-mod, due to the random-bit aspect there)
 
 	if(TEST_TYPE == TEST_TYPE_PM1 && ilo >= maxiter) {
-		// Task 20/#31: For a genuinely-completed Stage 1 we expect ilo == maxiter == PM1_S1_PROD_BITS. If instead
+		// For a genuinely-completed Stage 1 we expect ilo == maxiter == PM1_S1_PROD_BITS. If instead
 		// ilo *exceeds* the current-B1 product length, the savefile was produced with a larger B1 (e.g. a low-memory
 		// run bumps B1 up ~25%) and its '.s1_prod' product-savefile is missing, so compute_pm1_s1_product() could not
 		// recover/adopt the original B1. Do NOT proceed to Stage 2 - a partial powering to the larger B1 is not a
 		// completed Stage 1 at this B1, and treating it as such silently loses factors. Fail with actionable guidance.
 		if(ilo != maxiter || ilo != PM1_S1_PROD_BITS) {
-			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s p-1 restart-file Stage 1 iteration count [%u] exceeds the Stage 1 prime-powers-product length [%u] for the current b1 = %u.\n"
+			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s P-1 restart-file Stage 1 iteration count [%u] exceeds the Stage 1 prime-powers-product length [%u] for the current B1 = %u.\n"
 				"The savefile was written with a larger B1 and its '.s1_prod' product-savefile is missing, so the original B1 cannot be recovered automatically.\n"
-				"Re-run with the original (larger) '-b1 <N>', or delete this exponent's p-1 savefiles to start a fresh run.\n", PSTRING, ilo, PM1_S1_PROD_BITS, B1);
-			mlucas_fprint(cbuf,1);	ASSERT(0, "p-1 Stage 1 restart B1-mismatch: see preceding message.");
+				"Re-run with the original (larger) '-b1 <N>', or delete this exponent's P-1 savefiles to start a fresh run.\n", PSTRING, ilo, PM1_S1_PROD_BITS, B1);
+			mlucas_fprint(cbuf,1);	ASSERT(0, "P-1 Stage 1 restart B1-mismatch: see preceding message.");
 		}
-		snprintf(cbuf,STR_MAX_LEN*2, "%s: p-1 stage 1 to b1 = %u already done -- proceeding to stage 2.\n",PSTRING,B1);
+		snprintf(cbuf,STR_MAX_LEN*2, "%s: P-1 Stage 1 to B1 = %u already done -- proceeding to Stage 2.\n",PSTRING,B1);
 		fprintf(stderr,"%s",cbuf);
 		ilo = ihi;		// Need this to differentiate between just-completed S1 and S1 residue read from restart file,
 		goto PM1_STAGE2;// in terms of whether we need to do a GCD before proceeding to S2
@@ -5244,16 +5244,16 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 				ASSERT(B2_start <= nsquares, "P-1 stage 2 restart requires (B2_start in worktodo assignment) <= (savefile nsquares field)!");
 		} else {	// It's a stage 1 restart:
 			ASSERT(nsquares <= 0xFFFFFFFFull, "P-1 stage 1 restart: savefile nsquares value out of bounds!");
-			// Task 20/#31: nsquares >= ~1.5*B1 means the savefile's in-progress Stage 1 was run to a larger B1 than
+			// nsquares >= ~1.5*B1 means the savefile's in-progress Stage 1 was run to a larger B1 than
 			// the current run's. compute_pm1_s1_product() normally recovers that B1 from the '.s1_prod' product-savefile
 			// and adopts it before we get here; if we still land here, that file is missing/unreadable, so the original
 			// B1 cannot be recovered. Fail with actionable guidance rather than the bare bounds-assert (a partial powering
 			// to the larger B1 is not a completed - nor a valid partial - Stage 1 at the smaller B1: proceeding loses factors).
 			if(nsquares >= 1.5*(double)B1) {
-				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s: p-1 Stage 1 restart-file iteration count [%" PRIu64 "] is too large for the current b1 = %u.\n"
+				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s: P-1 Stage 1 restart-file iteration count [%" PRIu64 "] is too large for the current B1 = %u.\n"
 					"The in-progress Stage 1 was run to a larger B1; its '.s1_prod' product-savefile (which records that B1) is missing or unreadable, so it cannot be recovered automatically.\n"
-					"Re-run with the original (larger) '-b1 <N>', or delete this exponent's p-1 savefiles to start a fresh run.\n", func, nsquares, B1);
-				mlucas_fprint(cbuf,1);	ASSERT(0, "p-1 Stage 1 restart B1-mismatch: see preceding message.");
+					"Re-run with the original (larger) '-b1 <N>', or delete this exponent's P-1 savefiles to start a fresh run.\n", func, nsquares, B1);
+				mlucas_fprint(cbuf,1);	ASSERT(0, "P-1 Stage 1 restart B1-mismatch: see preceding message.");
 			}
 		}
 		// If S2 restart and (nsquares > B2_start), read the ensuing S2 interim residue; if (nsquares == B2_start)

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -117,9 +117,9 @@ uint32	pm1_set_bounds(const uint64 p, const uint32 n, const uint32 tf_bits, cons
 uint32	pm1_check_bounds();
 uint32	compute_pm1_s1_product(const uint64 p);
 uint32	pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uint32 *nmul, uint64 *maxmult);
-int		 read_pm1_s1_prod(const char *fname, uint64 p, uint32 *nbits, uint64 arr[], uint64 *sum64);
-int		write_pm1_s1_prod(const char *fname, uint64 p, uint32 nbits, uint64 arr[], uint64 sum64);
-void	pm1_bigstep_size(uint32 *nbuf, uint32 *bigstep, uint32 *m, const uint32 psmall);
+int		 read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 **arr, uint64*sum64);
+int		write_pm1_s1_prod(const char*fname, uint64 p, uint32 nbits, uint64 arr[], uint64 sum64);
+void	pm1_bigstep_size(uint32 *nbuf, uint32*bigstep, uint32*m, const uint32 psmall);
 int		modpow(double a[], double b[], uint32 input_is_int, uint64 pow,
 			int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 			uint64 p, int n, int scrnFlag, double *tdiff);

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -333,11 +333,43 @@ global would be needed to store that - and remultiply by the appropriate one for
 */
 uint32 compute_pm1_s1_product(const uint64 p) {
 	const double A = 1.1;
+	const char func[] = "compute_pm1_s1_product";
 	ASSERT(B1 > 0, "Call to compute_pm1_s1_product needs Stage 1 bound global B1 to be set!");
-	double ln = log(B1), lg = ln*ILG2;
-	uint32 i,len = 0,nmul,nbits,ebits = (uint32)((lg-A)*B1/(ln-A));
+	uint32 i,len = 0,nmul,nbits,ebits;
 	uint64 iseed,maxmult;
 	char savefile[STR_MAX_LEN];
+
+  #ifndef PM1_STANDALONE
+	// Build the ".s1_prod" precomputed-product savefile name:
+	strcpy(savefile, RESTARTFILE);
+	savefile[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
+	strcat(savefile, ".s1_prod");
+	/* Task 20/#31: pm1_set_bounds() auto-sizes B1 from available RAM - a low-memory run bumps B1 up ~25% to run a
+	deeper Stage 1 - so a restart under a different memory budget can pick a different B1 than the Stage 1 already in
+	progress. The in-progress powering (and the residue restart-file's iteration count) belong to the B1 recorded in
+	the ".s1_prod" savefile, and a partial powering to one B1 is not interchangeable with any other B1. So if that
+	savefile exists, adopt its B1 *before* sizing PM1_S1_PRODUCT below - both so the buffer matches the stored product
+	and so we resume that exact Stage 1 rather than silently recomputing at a different B1 (the crash reported in #31).
+	Peek just the header here (TEST_TYPE, MODULUS_TYPE, B1); read_pm1_s1_prod() re-reads and fully validates it. To
+	instead start a fresh p-1 run at a different B1, delete this exponent's p-1 savefiles first. */
+	{
+		FILE*fp_s1p = mlucas_fopen(savefile,"rb");
+		if(fp_s1p) {
+			int c0 = fgetc(fp_s1p), c1 = fgetc(fp_s1p), eof = 0;	uint32 j,fb1 = 0;
+			for(j = 0; j < 32; j += 8) { int cc = fgetc(fp_s1p); if(cc == EOF) { eof = 1; break; } fb1 += (uint32)cc << j; }
+			fclose(fp_s1p);
+			// Only adopt a sane, different B1 from a header whose type-tags match this run (guards against a truncated/foreign file):
+			if(!eof && test_types_compatible(c0,TEST_TYPE) && c1 == MODULUS_TYPE && fb1 >= 10000 && fb1 <= 2863311530u && fb1 != B1) {
+				sprintf(cbuf,"INFO: %s: current-run B1 [%u] differs from the in-progress Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,fb1);
+				mlucas_fprint(cbuf,pm1_standlone+1);
+				if(B2_start) B2_start = fb1;	// keep the Stage 2 start-bound tracking the adopted Stage 1 bound (Stage 2 begins where Stage 1 ends)
+				B1 = fb1;
+			}
+		}
+	}
+  #endif
+	double ln = log(B1), lg = ln*ILG2;
+	ebits = (uint32)((lg-A)*B1/(ln-A));
 
 	// Compute Stage 1 prime-powers product, starting with alloc of needed memory:
 	uint32 s1p_alloc = ((ebits + 63)>>6) + 1;	// Add 1 to account for seeding-by-binary-exponent described below
@@ -349,10 +381,8 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 
 	// (E.g. on restart) First see if a savefile holding the precomputed/bit-reversed product for this p and B1 exists:
   #ifndef PM1_STANDALONE
-	strcpy(savefile, RESTARTFILE);
-	savefile[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
-	strcat(savefile, ".s1_prod");
 	if((len = read_pm1_s1_prod(savefile, p, &PM1_S1_PROD_BITS, PM1_S1_PRODUCT, &PM1_S1_PROD_RES64)) != 0) {
+		PM1_S1_PROD_B1 = B1;	// The stored product corresponds to (the possibly-just-adopted) B1
 		sprintf(cbuf, "INFO: Successfully read precomputed/bit-reversed Stage 1 prime-powers product savefile for this modulus and B1 = %u.\n",B1);
 		mlucas_fprint(cbuf,pm1_standlone+1);
 	} else {	// Compute product from scratch:
@@ -495,6 +525,8 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 arr[], uin
 		i = fgetc(fptr);	b1 += (uint64)i << j;
 	}
 	if(B1 != b1) {
+		// Task 20/#31: caller (compute_pm1_s1_product) peeks and adopts the savefile's B1 before this read, so a
+		// mismatch here should not happen for a valid file; treat it as a corrupt/foreign savefile and recompute.
 		sprintf(cbuf, "INFO: %s: B1 of current run[%u] mismatches one[%u] of savefile data.\n",func,B1,b1);
 		goto PM1_S1P_READ_RETURN;
 	}

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -30,6 +30,12 @@ Then to run, e.g.
 #include "Mlucas.h"
 #define STR_MAX_LEN 1024
 
+// P-1 Stage 1 B1 bounds. The Stage 1 prime-powers product has ~1.5*B1 bits and its bitlength is stored
+// as a uint32, so B1 must satisfy 1.5*B1 <= 2^32, i.e. B1 <= 2^33/3 = 2863311530. Lower bound of 10^4
+// avoids a large-buffer-count underflow of qlo in Stage 2 (see pm1_set_bounds()):
+#define PM1_B1_MIN         10000u
+#define PM1_B1_MAX    2863311530u	// = 2^33/3
+
 #ifdef PM1_STANDALONE
 	#warning Building pm1.c in PM1_STANDALONE mode.
 	char STATFILE[] = "pm1_debug.txt";
@@ -199,11 +205,11 @@ uint32 pm1_set_bounds(const uint64 p, const uint32 n, const uint32 tf_bits, cons
 			PM1_S2_NBUF = (uint32)dtmp - 5;
 		}
 	}
-	// Force B1 >= 10^4 to avoid possible large-buffer-count underflow of qlo in stage 2.
-	// Conservatively use (#bits in Stage 1 prime-powers product ~= 1.5*B1), must fit into a uint32, thus B1_max = 2^33/3 = 2863311530:
+	// PM1_B1_MIN/PM1_B1_MAX (defined at top of file) bound B1: lower to avoid a Stage 2 qlo underflow,
+	// upper (2^33/3) so the ~1.5*B1-bit Stage 1 prime-powers product's bitlength fits a uint32:
 	i64 = p>>7;
-	ASSERT(i64 <= 2863311530ull, "Stage 1 prime-powers product must fit into a uint32; default B1 for your exponent is too large!");
-	B1 = MAX((uint32)i64,10000);	// #bits in Stage 1 prime-powers product ~= 1.4*B1, so e.g. B1 = p/128 gives a ~= 1.1*p/100 bits
+	ASSERT(i64 <= PM1_B1_MAX, "Stage 1 prime-powers product must fit into a uint32; default B1 for your exponent is too large!");
+	B1 = MAX((uint32)i64,PM1_B1_MIN);	// #bits in Stage 1 prime-powers product ~= 1.4*B1, so e.g. B1 = p/128 gives a ~= 1.1*p/100 bits
 	B1 = (B1 + 99999)*inv100k;	B1 *= 100000;	ASSERT(B1 >= 100000, "B1 unacceptably small!");	// Round up to nearest 100k:
 	if(PM1_S2_NBUF < 24) {
 		sprintf(cbuf,"pm1_set_bounds: Insufficient free memory for Stage 2 ... will run only Stage 1.\n");
@@ -333,7 +339,6 @@ global would be needed to store that - and remultiply by the appropriate one for
 */
 uint32 compute_pm1_s1_product(const uint64 p) {
 	const double A = 1.1;
-	const char func[] = "compute_pm1_s1_product";
 	ASSERT(B1 > 0, "Call to compute_pm1_s1_product needs Stage 1 bound global B1 to be set!");
 	uint32 i,len = 0,nmul,nbits,ebits,s1p_alloc;
 	uint64 iseed,maxmult;
@@ -513,7 +518,7 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 **arr, uin
 		B1 is not interchangeable with any other, so adopt the savefile's B1 and resume that exact Stage 1 rather than
 		recomputing at a different B1. Only adopt a sane value; an out-of-range b1 (or the type-tag mismatches above)
 		means a truncated/foreign file, so bail and recompute at the current B1. */
-		if(b1 >= 10000 && b1 <= 2863311530u) {
+		if(b1 >= PM1_B1_MIN && b1 <= PM1_B1_MAX) {
 			snprintf(cbuf, STR_MAX_LEN*2, "INFO: %s: current-run B1 [%u] differs from the Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,b1);
 			mlucas_fprint(cbuf,pm1_standlone+1);
 			if(B2_start) B2_start = b1;	// keep the Stage 2 start-bound tracking the adopted Stage 1 bound (Stage 2 begins where Stage 1 ends)

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -372,7 +372,7 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 		s1p_alloc = ((ebits + 63)>>6) + 1;	// Add 1 to account for seeding-by-binary-exponent described below
 		PM1_S1_PRODUCT = ALLOC_UINT64(PM1_S1_PRODUCT, s1p_alloc);
 		if(!PM1_S1_PRODUCT ){
-			snprintf(cbuf, STR_MAX_LEN*2, "ERROR: unable to allocate array PM1_S1_PRODUCT with %u linbs in main.\n",s1p_alloc);
+			snprintf(cbuf, sizeof(cbuf), "ERROR: unable to allocate array PM1_S1_PRODUCT with %u linbs in main.\n",s1p_alloc);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 		}
 		// For M(p) want to seed the S1 prime-powers product with 2*p; for F(m) we want seed = 2^(m+2). Since in the latter
@@ -416,7 +416,7 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 		}
 	} 	// endif(read_pm1_s1_prod)
   #endif
-	snprintf(cbuf,STR_MAX_LEN*2,"Product of Stage 1 prime powers with B1 = %u is %u bits (%u limbs), vs estimated %u. Setting PRP_BASE = 3.\n",B1,PM1_S1_PROD_BITS+1,len,ebits);
+	snprintf(cbuf,sizeof(cbuf),"Product of Stage 1 prime powers with B1 = %u is %u bits (%u limbs), vs estimated %u. Setting PRP_BASE = 3.\n",B1,PM1_S1_PROD_BITS+1,len,ebits);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 	PRP_BASE = 3;
 	sprintf(cbuf,"BRed (PM1_S1_PRODUCT sans leading bit) has %u limbs, Res64 = %" PRIu64 "\n",len,PM1_S1_PROD_RES64);
@@ -519,12 +519,12 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 **arr, uin
 		recomputing at a different B1. Only adopt a sane value; an out-of-range b1 (or the type-tag mismatches above)
 		means a truncated/foreign file, so bail and recompute at the current B1. */
 		if(b1 >= PM1_B1_MIN && b1 <= PM1_B1_MAX) {
-			snprintf(cbuf, STR_MAX_LEN*2, "INFO: %s: current-run B1 [%u] differs from the Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,b1);
+			snprintf(cbuf, sizeof(cbuf), "INFO: %s: current-run B1 [%u] differs from the Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,b1);
 			mlucas_fprint(cbuf,pm1_standlone+1);
 			if(B2_start) B2_start = b1;	// keep the Stage 2 start-bound tracking the adopted Stage 1 bound (Stage 2 begins where Stage 1 ends)
 			B1 = b1;
 		} else {
-			snprintf(cbuf, STR_MAX_LEN*2, "INFO: %s: savefile B1 [%u] is out of range; treating as corrupt/foreign and recomputing.\n",func,b1);
+			snprintf(cbuf, sizeof(cbuf), "INFO: %s: savefile B1 [%u] is out of range; treating as corrupt/foreign and recomputing.\n",func,b1);
 			goto PM1_S1P_READ_RETURN;
 		}
 	}
@@ -539,7 +539,7 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 **arr, uin
 	nbytes = (*nbits + 7)/8; nlimbs = (nbytes + 7)/8;
 	*arr = ALLOC_UINT64(*arr, nlimbs);
 	if(!*arr) {
-		snprintf(cbuf, STR_MAX_LEN*2, "ERROR: %s: unable to allocate array PM1_S1_PRODUCT with %u limbs.\n",func,nlimbs);
+		snprintf(cbuf, sizeof(cbuf), "ERROR: %s: unable to allocate array PM1_S1_PRODUCT with %u limbs.\n",func,nlimbs);
 		mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 	}
 	for(i = 0; i < nlimbs; i++) { (*arr)[i] = 0ull; }

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -335,8 +335,9 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 	const double A = 1.1;
 	const char func[] = "compute_pm1_s1_product";
 	ASSERT(B1 > 0, "Call to compute_pm1_s1_product needs Stage 1 bound global B1 to be set!");
-	uint32 i,len = 0,nmul,nbits,ebits;
+	uint32 i,len = 0,nmul,nbits,ebits,s1p_alloc;
 	uint64 iseed,maxmult;
+	double ln,lg;
 	char savefile[STR_MAX_LEN];
 
   #ifndef PM1_STANDALONE
@@ -344,49 +345,31 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 	strcpy(savefile, RESTARTFILE);
 	savefile[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
 	strcat(savefile, ".s1_prod");
-	/* Task 20/#31: pm1_set_bounds() auto-sizes B1 from available RAM - a low-memory run bumps B1 up ~25% to run a
-	deeper Stage 1 - so a restart under a different memory budget can pick a different B1 than the Stage 1 already in
-	progress. The in-progress powering (and the residue restart-file's iteration count) belong to the B1 recorded in
-	the ".s1_prod" savefile, and a partial powering to one B1 is not interchangeable with any other B1. So if that
-	savefile exists, adopt its B1 *before* sizing PM1_S1_PRODUCT below - both so the buffer matches the stored product
-	and so we resume that exact Stage 1 rather than silently recomputing at a different B1 (the crash reported in #31).
-	Peek just the header here (TEST_TYPE, MODULUS_TYPE, B1); read_pm1_s1_prod() re-reads and fully validates it. To
-	instead start a fresh p-1 run at a different B1, delete this exponent's p-1 savefiles first. */
-	{
-		FILE*fp_s1p = mlucas_fopen(savefile,"rb");
-		if(fp_s1p) {
-			int c0 = fgetc(fp_s1p), c1 = fgetc(fp_s1p), eof = 0;	uint32 j,fb1 = 0;
-			for(j = 0; j < 32; j += 8) { int cc = fgetc(fp_s1p); if(cc == EOF) { eof = 1; break; } fb1 += (uint32)cc << j; }
-			fclose(fp_s1p);
-			// Only adopt a sane, different B1 from a header whose type-tags match this run (guards against a truncated/foreign file):
-			if(!eof && test_types_compatible(c0,TEST_TYPE) && c1 == MODULUS_TYPE && fb1 >= 10000 && fb1 <= 2863311530u && fb1 != B1) {
-				sprintf(cbuf,"INFO: %s: current-run B1 [%u] differs from the in-progress Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,fb1);
-				mlucas_fprint(cbuf,pm1_standlone+1);
-				if(B2_start) B2_start = fb1;	// keep the Stage 2 start-bound tracking the adopted Stage 1 bound (Stage 2 begins where Stage 1 ends)
-				B1 = fb1;
-			}
-		}
-	}
+	/* (E.g. on restart) First see if a savefile holding the precomputed/bit-reversed product exists. read_pm1_s1_prod()
+	adopts the savefile's B1 if it differs from the current run's, and allocates PM1_S1_PRODUCT to fit, so it must be
+	called *before* we size the buffer from B1 below. Rationale: pm1_set_bounds() auto-sizes B1 from available RAM (a
+	low-memory run bumps B1 up ~25% to run a deeper Stage 1), so a restart under a different memory budget can pick a
+	different B1 than the Stage 1 already in progress. The in-progress powering (and the residue restart-file's iteration
+	count) belong to the B1 recorded in this savefile, and a partial powering to one B1 is not interchangeable with any
+	other, so we resume that exact Stage 1 rather than silently recomputing at a different B1. To instead start a fresh
+	run at a different B1, delete this exponent's p-1 savefiles first. */
+	len = read_pm1_s1_prod(savefile, p, &PM1_S1_PROD_BITS, &PM1_S1_PRODUCT, &PM1_S1_PROD_RES64);
   #endif
-	double ln = log(B1), lg = ln*ILG2;
-	ebits = (uint32)((lg-A)*B1/(ln-A));
-
-	// Compute Stage 1 prime-powers product, starting with alloc of needed memory:
-	uint32 s1p_alloc = ((ebits + 63)>>6) + 1;	// Add 1 to account for seeding-by-binary-exponent described below
-	PM1_S1_PRODUCT = ALLOC_UINT64(PM1_S1_PRODUCT, s1p_alloc);
-	if(!PM1_S1_PRODUCT ){
-		sprintf(cbuf, "ERROR: unable to allocate array PM1_S1_PRODUCT with %u linbs in main.\n",s1p_alloc);
-		mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
-	}
-
-	// (E.g. on restart) First see if a savefile holding the precomputed/bit-reversed product for this p and B1 exists:
+	// Estimated #bits in the product, from the (possibly-just-adopted) B1; also the from-scratch alloc size below:
+	ln = log(B1); lg = ln*ILG2;	ebits = (uint32)((lg-A)*B1/(ln-A));
   #ifndef PM1_STANDALONE
-	if((len = read_pm1_s1_prod(savefile, p, &PM1_S1_PROD_BITS, PM1_S1_PRODUCT, &PM1_S1_PROD_RES64)) != 0) {
+	if(len != 0) {
 		PM1_S1_PROD_B1 = B1;	// The stored product corresponds to (the possibly-just-adopted) B1
 		sprintf(cbuf, "INFO: Successfully read precomputed/bit-reversed Stage 1 prime-powers product savefile for this modulus and B1 = %u.\n",B1);
 		mlucas_fprint(cbuf,pm1_standlone+1);
-	} else {	// Compute product from scratch:
+	} else {	// Compute product from scratch, starting with alloc of needed memory:
   #endif
+		s1p_alloc = ((ebits + 63)>>6) + 1;	// Add 1 to account for seeding-by-binary-exponent described below
+		PM1_S1_PRODUCT = ALLOC_UINT64(PM1_S1_PRODUCT, s1p_alloc);
+		if(!PM1_S1_PRODUCT ){
+			sprintf(cbuf, "ERROR: unable to allocate array PM1_S1_PRODUCT with %u linbs in main.\n",s1p_alloc);
+			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
+		}
 		// For M(p) want to seed the S1 prime-powers product with 2*p; for F(m) we want seed = 2^(m+2). Since in the latter
 		// case our input p contains 2^m, can handle both cases via iseed = 4*p, giving an extra *2 in the Mersenne case:
 		iseed = p<<2;	ASSERT((iseed>>2) == p,"Binary exponent overflows (uint64)4*p in compute_pm1_s1_product!");
@@ -428,7 +411,7 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 		}
 	} 	// endif(read_pm1_s1_prod)
   #endif
-	sprintf(cbuf,"Product of Stage 1 prime powers with b1 = %u is %u bits (%u limbs), vs estimated %u. Setting PRP_BASE = 3.\n",B1,PM1_S1_PROD_BITS+1,len,ebits);
+	sprintf(cbuf,"Product of Stage 1 prime powers with B1 = %u is %u bits (%u limbs), vs estimated %u. Setting PRP_BASE = 3.\n",B1,PM1_S1_PROD_BITS+1,len,ebits);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 	PRP_BASE = 3;
 	sprintf(cbuf,"BRed (PM1_S1_PRODUCT sans leading bit) has %u limbs, Res64 = %" PRIu64 "\n",len,PM1_S1_PROD_RES64);
@@ -492,7 +475,7 @@ uint32 pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uin
 }
 
 // Returns 1 on successful read, 0 otherwise:
-int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 arr[], uint64*sum64)
+int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 **arr, uint64*sum64)
 {
 	const char func[] = "read_pm1_s1_prod";
 	int retval = 0;
@@ -525,10 +508,20 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 arr[], uin
 		i = fgetc(fptr);	b1 += (uint64)i << j;
 	}
 	if(B1 != b1) {
-		// Task 20/#31: caller (compute_pm1_s1_product) peeks and adopts the savefile's B1 before this read, so a
-		// mismatch here should not happen for a valid file; treat it as a corrupt/foreign savefile and recompute.
-		sprintf(cbuf, "INFO: %s: B1 of current run[%u] mismatches one[%u] of savefile data.\n",func,B1,b1);
-		goto PM1_S1P_READ_RETURN;
+		/* The savefile's Stage 1 was run to a different B1 than the current run's (pm1_set_bounds() auto-sizes B1 from
+		available RAM, so a restart under a different memory budget can pick a different B1). A partial powering to one
+		B1 is not interchangeable with any other, so adopt the savefile's B1 and resume that exact Stage 1 rather than
+		recomputing at a different B1. Only adopt a sane value; an out-of-range b1 (or the type-tag mismatches above)
+		means a truncated/foreign file, so bail and recompute at the current B1. */
+		if(b1 >= 10000 && b1 <= 2863311530u) {
+			sprintf(cbuf, "INFO: %s: current-run B1 [%u] differs from the Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,b1);
+			mlucas_fprint(cbuf,pm1_standlone+1);
+			if(B2_start) B2_start = b1;	// keep the Stage 2 start-bound tracking the adopted Stage 1 bound (Stage 2 begins where Stage 1 ends)
+			B1 = b1;
+		} else {
+			sprintf(cbuf, "INFO: %s: savefile B1 [%u] is out of range; treating as corrupt/foreign and recomputing.\n",func,b1);
+			goto PM1_S1P_READ_RETURN;
+		}
 	}
 	// Read bitlength of precomputed/bit-reversed product:
 	*nbits = 0;
@@ -536,20 +529,26 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 arr[], uin
 		i = fgetc(fptr);	*nbits += i << j;
 	}
 
-	// Set the number of product bytes and zero the corr. target-array limbs:
+	// Set the number of product bytes, (re)allocate the target array to fit (its size follows the just-read - and
+	// possibly-just-adopted-B1 - product, which the caller cannot size in advance), and zero its limbs:
 	nbytes = (*nbits + 7)/8; nlimbs = (nbytes + 7)/8;
-	for(i = 0; i < nlimbs; i++) { arr[i] = 0ull; }
+	*arr = ALLOC_UINT64(*arr, nlimbs);
+	if(!*arr) {
+		sprintf(cbuf, "ERROR: %s: unable to allocate array PM1_S1_PRODUCT with %u limbs.\n",func,nlimbs);
+		mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
+	}
+	for(i = 0; i < nlimbs; i++) { (*arr)[i] = 0ull; }
 
 	// Read the bytewise product into our array of 64-bit limbs:
 	// j holds index of current byte of limb, (j>>3) = index of current limb of target
 	for(j = 0; j < nbytes; j++) {				//vvvvvvvvv = 8*j (mod 64)
-		c = fgetc(fptr);	arr[j>>3] += ((uint64)c << ((j<<3)&63));
+		c = fgetc(fptr);	(*arr)[j>>3] += ((uint64)c << ((j<<3)&63));
 	}
 	// Read 8 bytes of simple (sum of limbs, mod 2^64) checksum, compare to one computed from read data:
 	for(j = 0; j < 64; j += 8) {
 		i = fgetc(fptr);	isum64 += (uint64)i << j;
 	}
-	for(i = 0; i < nlimbs; i++) { itmp64 += arr[i]; }
+	for(i = 0; i < nlimbs; i++) { itmp64 += (*arr)[i]; }
 	if(itmp64 != isum64) {
 		sprintf(cbuf, "INFO: %s: Computed checksum[%" PRIX64 "] mismatches one[%" PRIX64 "] appended to savefile data.\n",func,itmp64,isum64);
 		*sum64 = 0ull;

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -367,7 +367,7 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 		s1p_alloc = ((ebits + 63)>>6) + 1;	// Add 1 to account for seeding-by-binary-exponent described below
 		PM1_S1_PRODUCT = ALLOC_UINT64(PM1_S1_PRODUCT, s1p_alloc);
 		if(!PM1_S1_PRODUCT ){
-			sprintf(cbuf, "ERROR: unable to allocate array PM1_S1_PRODUCT with %u linbs in main.\n",s1p_alloc);
+			snprintf(cbuf, STR_MAX_LEN*2, "ERROR: unable to allocate array PM1_S1_PRODUCT with %u linbs in main.\n",s1p_alloc);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 		}
 		// For M(p) want to seed the S1 prime-powers product with 2*p; for F(m) we want seed = 2^(m+2). Since in the latter
@@ -411,7 +411,7 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 		}
 	} 	// endif(read_pm1_s1_prod)
   #endif
-	sprintf(cbuf,"Product of Stage 1 prime powers with B1 = %u is %u bits (%u limbs), vs estimated %u. Setting PRP_BASE = 3.\n",B1,PM1_S1_PROD_BITS+1,len,ebits);
+	snprintf(cbuf,STR_MAX_LEN*2,"Product of Stage 1 prime powers with B1 = %u is %u bits (%u limbs), vs estimated %u. Setting PRP_BASE = 3.\n",B1,PM1_S1_PROD_BITS+1,len,ebits);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 	PRP_BASE = 3;
 	sprintf(cbuf,"BRed (PM1_S1_PRODUCT sans leading bit) has %u limbs, Res64 = %" PRIu64 "\n",len,PM1_S1_PROD_RES64);
@@ -514,12 +514,12 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 **arr, uin
 		recomputing at a different B1. Only adopt a sane value; an out-of-range b1 (or the type-tag mismatches above)
 		means a truncated/foreign file, so bail and recompute at the current B1. */
 		if(b1 >= 10000 && b1 <= 2863311530u) {
-			sprintf(cbuf, "INFO: %s: current-run B1 [%u] differs from the Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,b1);
+			snprintf(cbuf, STR_MAX_LEN*2, "INFO: %s: current-run B1 [%u] differs from the Stage 1 savefile's B1 [%u]; adopting the savefile's B1 to safely resume that Stage 1 to completion.\n",func,B1,b1);
 			mlucas_fprint(cbuf,pm1_standlone+1);
 			if(B2_start) B2_start = b1;	// keep the Stage 2 start-bound tracking the adopted Stage 1 bound (Stage 2 begins where Stage 1 ends)
 			B1 = b1;
 		} else {
-			sprintf(cbuf, "INFO: %s: savefile B1 [%u] is out of range; treating as corrupt/foreign and recomputing.\n",func,b1);
+			snprintf(cbuf, STR_MAX_LEN*2, "INFO: %s: savefile B1 [%u] is out of range; treating as corrupt/foreign and recomputing.\n",func,b1);
 			goto PM1_S1P_READ_RETURN;
 		}
 	}
@@ -534,7 +534,7 @@ int read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 **arr, uin
 	nbytes = (*nbits + 7)/8; nlimbs = (nbytes + 7)/8;
 	*arr = ALLOC_UINT64(*arr, nlimbs);
 	if(!*arr) {
-		sprintf(cbuf, "ERROR: %s: unable to allocate array PM1_S1_PRODUCT with %u limbs.\n",func,nlimbs);
+		snprintf(cbuf, STR_MAX_LEN*2, "ERROR: %s: unable to allocate array PM1_S1_PRODUCT with %u limbs.\n",func,nlimbs);
 		mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 	}
 	for(i = 0; i < nlimbs; i++) { (*arr)[i] = 0ull; }


### PR DESCRIPTION
## Summary

Fixes #31. A p-1 run whose Stage 1 is interrupted and later resumed under a **different memory budget** (or a changed `-b1`) crashes on restart, because the auto-sized Stage 1 bound B1 is not recovered from the savefile that records it.

### Root cause
`pm1_set_bounds()` auto-sizes B1 from available RAM: when there is too little memory for Stage 2 it bumps B1 up ~25% to run a deeper Stage 1. On a restart with a different amount of free RAM it therefore picks a *different* B1 than the Stage 1 already in progress. The in-progress LR-binary powering of the Stage 1 prime-powers product — and the residue restart-file's iteration count — belong to the original B1, and a partial powering to one B1 is **not** interchangeable with any other B1 (the two use different prime sets). The old code silently recomputed the product at the current B1, after which the restart-file iteration count no longer matched the product length, tripping an assertion:
- `read_ppm1_savefiles`: `nsquares <= 0xFFFFFFFF && nsquares < 1.5*B1` (this is the one that actually fires first), or
- the `ilo == maxiter == PM1_S1_PROD_BITS` check in the main setup path.

The fix suggested in the issue thread — relax the assert and proceed to Stage 2 — is **unsafe**: a partial powering to the larger B1 is not a completed Stage 1 at the smaller B1, so jumping to Stage 2 silently loses factors.

### Fix
The `.s1_prod` product-savefile already records the B1 its product was built for, so nothing new needs to be written — the change is recovery-only: make that recorded B1 authoritative on restart.

`compute_pm1_s1_product()` now calls `read_pm1_s1_prod()` *before* it sizes anything from B1. `read_pm1_s1_prod()` compares the stored B1 against the current run's and, if they differ and the stored value is in range, adopts it (`B1 = b1`) and moves `B2_start` with it, so Stage 2's start-bound tracks the adopted Stage 1 bound and the run resumes *that* Stage 1 to completion. An out-of-range stored B1 is treated as a corrupt/foreign file and the product is recomputed at the current B1 as before. To instead start a fresh run at a different B1, delete the exponent's p-1 savefiles first (the code says so).

If the `.s1_prod` file is missing so the original B1 cannot be recovered, both the stage-1 restart-file bounds check (in `read_ppm1_savefiles()`) and the completed-S1 check (in `ernstMain()`) now fail with actionable guidance ("re-run with the original `-b1 <N>`, or delete this exponent's p-1 savefiles") instead of a bare assertion — never proceeding to Stage 2 on an incomplete powering.

### Verification
Built a baseline (pre-fix) and fixed binary from the same tree (via `git stash`), M65537 p-1 Stage 1:
- Interrupt mid-Stage-1 at **B1 = 30000** (restart file left at iteration ~42000), then restart at **B1 = 10000**:
  - **baseline** aborts (`read_ppm1_savefiles` nsquares bounds assert) — reproduces #31;
  - **fixed** logs the B1 adoption, resumes from the checkpoint, and completes Stage 1, reporting the result at the correct **B1 = 30000** (`{"status":"NF", ..., "B1":30000}`), matching a from-scratch full Stage 1 at B1 = 30000.
- **Same-B1 restart** (B1 = 30000) resumes normally, with no spurious adoption message — no regression.
- **`.s1_prod` deleted** restart prints the actionable error instead of a cryptic bounds assert.

### Scope of the diff
Three files: `src/pm1.c`, `src/Mlucas.c` and `src/Mlucas.h`.

- `pm1.c`: `read_pm1_s1_prod()`'s out-param changes from `uint64 arr[]` to `uint64 **arr` and the function now *owns* the `PM1_S1_PRODUCT` allocation (`*arr = ALLOC_UINT64(*arr, nlimbs);`), since only it knows the stored product's length; the B1-adoption logic lives there. `compute_pm1_s1_product()` is reordered so the read happens before the from-scratch sizing, and allocates only on the from-scratch path. Two new file-scope constants `PM1_B1_MIN`/`PM1_B1_MAX` replace the literals previously inline in `pm1_set_bounds()`, and bound the adopted value.
- `Mlucas.h`: the `read_pm1_s1_prod()` prototype.
- `Mlucas.c`: the two graceful-error conversions described above.

No behaviour change on a fresh run. On a matching-B1 restart the only difference is that `PM1_S1_PRODUCT` is now sized to the exact `nlimbs` read from the savefile rather than to the `((ebits+63)>>6)+1` estimate; the array is used only up to the stored product's length either way.
