### PR TITLE
CI: skip the AVX-512 build mode on compilers whose assembler can't do it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'alpine:3.8') && matrix.cc == 'gcc') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04' || matrix.container == 'alpine:3.8') && matrix.cc == 'clang') }}
+    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,16 +187,16 @@ jobs:
         else
             MODES+=( SSE2 AVX AVX2 )
             # Only test the AVX-512 build mode if the compiler's assembler can handle the AVX-512 constructs
-            # Mlucas's kernels use: the extended registers (zmm16-31/xmm16-31/k0-7) and the AVX-512ER reciprocal
-            # instruction vrcp28pd (mi64.c, compiled under plain USE_AVX512). Ancient clang can't - clang 3.8
-            # (ubuntu:16.04) rejects the extended register names ("unknown register name 'xmm30'"), and clang 5.0
-            # (alpine:3.8) rejects vrcp28pd ("instruction requires: AVX-512 ER ISA"). Modern gcc/clang assemble
-            # both under -mavx512f (adding -mavx512er is not an option - modern toolchains have removed that flag).
-            # Probe for both and skip AVX-512 rather than fail the build on a mode that provably can't work here.
-            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax\n\tvrcp28pd %%zmm8,%%zmm0":::"zmm31","xmm16","xmm17","k1","eax","zmm0","zmm8");return 0;}' | "${CC:-gcc}" -mavx512f -x c -o /dev/null - >/dev/null 2>&1; then
+            # Mlucas's kernels use: the extended registers (zmm16-31/xmm16-31/k0-7). Ancient clang can't -
+            # clang 3.8 (ubuntu:16.04) rejects the extended register names ("unknown register name 'xmm30'").
+            # (The one AVX-512ER instruction, vrcp28pd, lived in an unused mi64.c routine and is now gated to
+            # KNL-only via __AVX512ER__, so plain AVX-512 builds no longer need an ER-capable assembler -
+            # which is why clang 5.0 on alpine:3.8 can now build AVX-512.) Probe and skip AVX-512 rather than
+            # fail the build on a mode that provably can't work here.
+            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax":::"zmm31","xmm16","xmm17","k1","eax");return 0;}' | "${CC:-gcc}" -mavx512f -x c -o /dev/null - >/dev/null 2>&1; then
                 MODES+=( AVX512 )
             else
-                echo "::warning title=AVX-512 build skipped::$("${CC:-gcc}" --version | head -n1): its assembler can't handle the AVX-512 constructs Mlucas's kernels need (extended registers zmm16-31 and/or the vrcp28pd ER instruction); skipping the AVX-512 build mode."
+                echo "::warning title=AVX-512 build skipped::$("${CC:-gcc}" --version | head -n1): its assembler can't handle the AVX-512 extended registers (zmm16-31/xmm16-31/k0-7) Mlucas's kernels need; skipping the AVX-512 build mode."
             fi
         fi
         for mode in "${MODES[@]}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,16 @@ jobs:
         if [[ $HOSTTYPE == aarch64 ]]; then
             MODES+=( ASIMD )
         else
-            MODES+=( SSE2 AVX AVX2 AVX512 )
+            MODES+=( SSE2 AVX AVX2 )
+            # Only test the AVX-512 build mode if the compiler's assembler supports the extended register
+            # names (zmm16-31/xmm16-31/k0-7) its kernels require. Ancient clang (e.g. 3.8 in the ubuntu:16.04
+            # container) does not, so an AVX-512 build there fails with "unknown register name 'xmm30'";
+            # probe and skip it rather than fail this (allowed-to-fail) job. Mirrors makemake.sh try_avx512_asm().
+            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax":::"zmm31","xmm16","xmm17","k1","eax");return 0;}' | "${CC:-gcc}" -mavx512f -x c -o /dev/null - >/dev/null 2>&1; then
+                MODES+=( AVX512 )
+            else
+                echo "Skipping AVX-512 build mode: ${CC:-gcc}'s assembler lacks AVX-512 extended-register support."
+            fi
         fi
         for mode in "${MODES[@]}"; do
             echo -e "\n$mode\n"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && matrix.container == 'ubuntu:16.04') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04') && matrix.cc == 'clang') || (matrix.container == 'alpine:3.8' && (!endsWith(matrix.os, '-arm') || matrix.cc == 'clang')) }}
+    continue-on-error: ${{ (!endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'alpine:3.8') && matrix.cc == 'gcc') || (endsWith(matrix.os, '-arm') && (matrix.container == 'ubuntu:16.04' || matrix.container == 'ubuntu:18.04' || matrix.container == 'alpine:3.8') && matrix.cc == 'clang') }}
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
@@ -186,14 +186,17 @@ jobs:
             MODES+=( ASIMD )
         else
             MODES+=( SSE2 AVX AVX2 )
-            # Only test the AVX-512 build mode if the compiler's assembler supports the extended register
-            # names (zmm16-31/xmm16-31/k0-7) its kernels require. Ancient clang (e.g. 3.8 in the ubuntu:16.04
-            # container) does not, so an AVX-512 build there fails with "unknown register name 'xmm30'";
-            # probe and skip it rather than fail this (allowed-to-fail) job. Mirrors makemake.sh try_avx512_asm().
-            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax":::"zmm31","xmm16","xmm17","k1","eax");return 0;}' | "${CC:-gcc}" -mavx512f -x c -o /dev/null - >/dev/null 2>&1; then
+            # Only test the AVX-512 build mode if the compiler's assembler can handle the AVX-512 constructs
+            # Mlucas's kernels use: the extended registers (zmm16-31/xmm16-31/k0-7) and the AVX-512ER reciprocal
+            # instruction vrcp28pd (mi64.c, compiled under plain USE_AVX512). Ancient clang can't - clang 3.8
+            # (ubuntu:16.04) rejects the extended register names ("unknown register name 'xmm30'"), and clang 5.0
+            # (alpine:3.8) rejects vrcp28pd ("instruction requires: AVX-512 ER ISA"). Modern gcc/clang assemble
+            # both under -mavx512f (adding -mavx512er is not an option - modern toolchains have removed that flag).
+            # Probe for both and skip AVX-512 rather than fail the build on a mode that provably can't work here.
+            if echo 'int main(void){__asm__ __volatile__("vpxord %%zmm31,%%zmm31,%%zmm31\n\tvmovdqa64 %%xmm16,%%xmm17\n\tkmovw %%k1,%%eax\n\tvrcp28pd %%zmm8,%%zmm0":::"zmm31","xmm16","xmm17","k1","eax","zmm0","zmm8");return 0;}' | "${CC:-gcc}" -mavx512f -x c -o /dev/null - >/dev/null 2>&1; then
                 MODES+=( AVX512 )
             else
-                echo "Skipping AVX-512 build mode: ${CC:-gcc}'s assembler lacks AVX-512 extended-register support."
+                echo "::warning title=AVX-512 build skipped::$("${CC:-gcc}" --version | head -n1): its assembler can't handle the AVX-512 constructs Mlucas's kernels need (extended registers zmm16-31 and/or the vrcp28pd ER instruction); skipping the AVX-512 build mode."
             fi
         fi
         for mode in "${MODES[@]}"; do

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -4311,7 +4311,13 @@ void mi64_modmul53_batch(const double a[], const double b[], const double m[], d
 	static double err[72], *eptr = err;	while((uint64)eptr & 0x3f) { ++eptr; }
 // ewm: wrap in AVX (not AVX2) prepro flag because my older gcc on the Haswell barfs on the MULXs in this file when built using USE_AVX2, but is OK with the FMA3 portion of AVX2
 #if defined(USE_AVX) && !defined(USE_IMCI512)
-  #ifdef USE_AVX512
+  // This AVX-512 path uses VRCP28PD, an AVX-512ER instruction that exists only on Knights Landing
+  // (KNL, built via 'avx512_knl' => -mavx512er). mi64_modmul53_batch() is currently unused (only a
+  // commented-out test harness references it), so rather than require an ER-capable assembler for every
+  // AVX-512 build - which breaks e.g. clang whose integrated assembler rejects VRCP28PD unless the target
+  // has ER - gate the ER code on __AVX512ER__. Plain AVX-512 builds (Skylake-X, Zen4, ...) fall through
+  // to the AVX path below, which is fine as the routine is not called. See #73.
+  #if defined(USE_AVX512) && defined(__AVX512ER__)
 	const double two = 2.0;
 	const double *ptwo = &two;
 	const uint32 ndata = 64;	uint32 i;


### PR DESCRIPTION
## Summary

The **"Linux old"** CI job builds every SIMD mode in each old-toolchain container. clang 3.8 (`ubuntu:16.04`) doesn't know the AVX-512 extended register names (`zmm16-31`, `xmm16-31`, `k0-7`) that Mlucas's AVX-512 kernels use, so the AVX-512 build there fails with `error: unknown register name 'xmm30' in asm`. Those jobs are already `continue-on-error`, so this doesn't block CI — but it leaves a confusing red X and build-log noise on a mode that provably cannot work with that compiler.

## Change

### `.github/workflows/ci.yml`

Gate the `AVX512` entry of the mode list (in the Linux-old job only) on a small capability probe — the same extended-register asm that `makemake.sh`'s `try_avx512_asm()` uses — so `AVX512` is added to `MODES` only when the compiler's assembler accepts those registers:

```sh
MODES+=( SSE2 AVX AVX2 )
if echo '…zmm31/xmm16-17/k1 asm…' | "${CC:-gcc}" -mavx512f -x c -o /dev/null - >/dev/null 2>&1; then
    MODES+=( AVX512 )
else
    echo "::warning title=AVX-512 build skipped::$("${CC:-gcc}" --version | head -n1): its assembler can't handle the AVX-512 extended registers …"
fi
```

The skip emits a GitHub Actions `::warning` annotation naming the compiler, so it's visible which jobs dropped the mode rather than silently building one fewer.

Compilers that support AVX-512 — all the modern ones, and GCC as far back as 5.4 — still build and test it; old clang simply skips it, so the job goes green on its own rather than relying on `continue-on-error` to mask an expected failure.

Scoped to the Linux-old job only (the regular Linux/macOS/Windows jobs run on modern toolchains).

### `src/mi64.c`

An intermediate revision of this PR also probed for `vrcp28pd`, because clang 5.0 (`alpine:3.8`) knows the extended registers but rejected that instruction — `instruction requires: AVX-512 ER ISA` — and so failed the AVX-512 build for a second, unrelated reason. Probing for it would have cost `alpine:3.8` a mode it can otherwise handle, so the final revision fixes the cause instead:

`vrcp28pd` is AVX-512**ER**, an extension that exists only on Knights Landing. It appears in exactly one place, the AVX-512 arm of `mi64_modmul53_batch()`, which was compiled under plain `USE_AVX512` — so every AVX-512 build needed an ER-capable assembler. That arm is now gated on `__AVX512ER__`:

```c
-  #ifdef USE_AVX512
+  #if defined(USE_AVX512) && defined(__AVX512ER__)
```

Non-KNL AVX-512 builds now compile the AVX arm of that routine instead. **This is a real source change, not a CI-only one**, but the behaviour change is latent: `mi64_modmul53_batch()` has no live caller — its sole call site is inside a commented-out test harness in the same file — so no live code path changes. Verified that a gcc `avx512` build (no ER) compiles with `vrcp28pd` absent from `mi64.o`. Adding `-mavx512er` was not an option: modern gcc has removed the flag.

Per review on #73, the ER code "was likely meant for KNL".

## Verification

- `ci.yml` still parses as valid YAML; the mode-selection snippet runs correctly under `bash`.
- Ran the probe on a capable compiler (system GCC): exits 0 → `MODES` includes `AVX512`.
- Ran the probe on **clang 3.8** in an `ubuntu:16.04` container: exits non-zero → `AVX512` is skipped.
- With the `__AVX512ER__` gate in place, clang 5.0 on `alpine:3.8` passes the probe and builds the AVX-512 mode.

Related to the older-compiler-support work in #60.
