### PR TITLE
Relax the Gerbicz-check carry-out assert for p == 63 (mod 64) (fixes #33)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2156,7 +2156,10 @@ READ_RESTART_FILE:
 			// Use mi64 routines to compute d[]*PRP_BASE and do ensuing equality check:
 			itmp64 = ((MODULUS_TYPE == MODULUS_TYPE_FERMAT) ? 3ull : (uint64)PRP_BASE);	// Fermat-mod uses PRP_BASE to store 2 for random-shift-offset scheme
 			c_uint64_ptr[j] = mi64_mul_scalar(c_uint64_ptr, itmp64, c_uint64_ptr, j);
-			ASSERT(c_uint64_ptr[j] == 0ull, "d[]*PRP_BASE result has unexpected carryout!");
+			// Carryout from d[]*PRP_BASE must be < PRP_BASE ; the mod-reduction loop just below folds any such
+			// carry back in. (For p == 63 (mod 64) the top limb has only 1 spare bit, so a carry of up to
+			// PRP_BASE-1 is a normal, legal outcome here, not an error.)
+			ASSERT(c_uint64_ptr[j] < itmp64, "d[]*PRP_BASE result has unexpected carryout!");
 			// Need to (mod N) ... store modulus N in d[] doubles-array, which is freed up by above convert_res_FP_bytewise(d,...) call:
 			if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
 				// Loop rather than call to mi64_set_eq_scalar here, since need to set all elts = -1:


### PR DESCRIPTION
## Problem (#33)

The periodic Gerbicz check computes `d[]*PRP_BASE` via `mi64_mul_scalar` and asserted the carry-out was exactly 0. For exponents `p == 63 (mod 64)` the top residue limb has only 1 spare bit, so a carry-out of up to `PRP_BASE-1` is a **normal, legal** outcome — the mod-reduction loop just below folds it back in. The strict assert crashed otherwise-healthy runs (~1/3 of Gerbicz checks for such exponents). All three reported exponents are `== 63 (mod 64)`.

## Fix

One line: `ASSERT(c_uint64_ptr[j] == 0ull, …)` → `ASSERT(c_uint64_ptr[j] < itmp64, …)` (carry must be < base).

## Verification (AVX2)

PRP test of p=1000639 (prime, `== 63 (mod 64)`), Gerbicz interval temporarily lowered to force many checks: **7 of 24 checks showed a real carry-out of 1** (each of which the old assert would have crashed); all passed with the relaxed assert. A full-cadence run reached 100% with no assert firing.

_Note: verifying this fix surfaced a separate, pre-existing bug — a corrupted carryout in `mi64_mul_scalar_add_vec2`'s asm that crashes the final PRP-determination (`Mlucas.c` `rmodb == 0` assert after short-div). Root-caused and fixed in #80; unrelated to this change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #33.