### PR TITLE
Fix executed shift-exponent and null-pointer-offset UB (fixes #28, #9)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3100,7 +3100,7 @@ uint64 	shift_word(double a[], int n, const uint64 p, const uint64 shift, const 
 		// not including the current word, hence (64-mod64) rather than (63-mod64) as the BIGWORD_BITMAP[w64] shift count.
 		// NOTE: That (64 - ...) shiftcount also necessitates an added AND-mask to zero the result in the mod64 == 0 case:
 		itmp64 = BIGWORD_BITMAP[w64];	i = (int)bits_per_word;
-		ii = BIGWORD_NBITS[w64] + i*mod64 + popcount64( (itmp64<<(64-mod64)) & -(mod64 != 0) );
+		ii = BIGWORD_NBITS[w64] + i*mod64 + (mod64 ? popcount64( itmp64<<(64-mod64) ) : 0);
 		// Loop up or down (should be by at most 1 word in either direction) if the resulting #bits is such that RES_SHIFT maps to a <> word:
 		curr_wd_bits = i + ( (int64)(itmp64<<(63-mod64)) < 0 );
 		// Can gain a few % speed by commenting out this correction-step code, but even though I've encountered

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3098,7 +3098,6 @@ uint64 	shift_word(double a[], int n, const uint64 p, const uint64 shift, const 
 		// Then exactly compute the bitcount at the resulting word, by adding the BIGWORD_NBITS-array-stored exact
 		// total bitcount at the next-lower index-multiple-of-64 to the number of bits in the next (mod64) words,
 		// not including the current word, hence (64-mod64) rather than (63-mod64) as the BIGWORD_BITMAP[w64] shift count.
-		// NOTE: That (64 - ...) shiftcount also necessitates an added AND-mask to zero the result in the mod64 == 0 case:
 		itmp64 = BIGWORD_BITMAP[w64];	i = (int)bits_per_word;
 		ii = BIGWORD_NBITS[w64] + i*mod64 + (mod64 ? popcount64( itmp64<<(64-mod64) ) : 0);
 		// Loop up or down (should be by at most 1 word in either direction) if the resulting #bits is such that RES_SHIFT maps to a <> word:

--- a/src/dft_macro.c
+++ b/src/dft_macro.c
@@ -3274,7 +3274,7 @@ void RADIX_256_DIT(
 			tptr->re,tptr->im,(tptr+0x1)->re,(tptr+0x1)->im,(tptr+0x2)->re,(tptr+0x2)->im,(tptr+0x3)->re,(tptr+0x3)->im,(tptr+0x4)->re,(tptr+0x4)->im,(tptr+0x5)->re,(tptr+0x5)->im,(tptr+0x6)->re,(tptr+0x6)->im,(tptr+0x7)->re,(tptr+0x7)->im,(tptr+0x8)->re,(tptr+0x8)->im,(tptr+0x9)->re,(tptr+0x9)->im,(tptr+0xa)->re,(tptr+0xa)->im,(tptr+0xb)->re,(tptr+0xb)->im,(tptr+0xc)->re,(tptr+0xc)->im,(tptr+0xd)->re,(tptr+0xd)->im,(tptr+0xe)->re,(tptr+0xe)->im,(tptr+0xf)->re,(tptr+0xf)->im,
 			c16,s16	// These = (c16,s16) typically def'd for use in the radix-16 DFT
 		);	tptr += 16;
-		if(i_idx) {	// vvv +2 here because this is setup for next loop pass
+		if(i_idx && i < 15) {	// vvv +2 here because this is setup for next loop pass
 			nshift = i+i+2;	// i_idx shift counts here run as >>2,4,...,30
 			off_ptr = i_offsets_lo + ( ((i_idx>>nshift)&0x3) << 4 );
 			p0  = off_ptr[0x0];p1  = off_ptr[0x1];p2  = off_ptr[0x2];p3  = off_ptr[0x3];p4  = off_ptr[0x4];p5  = off_ptr[0x5];p6  = off_ptr[0x6];p7  = off_ptr[0x7];p8  = off_ptr[0x8];p9  = off_ptr[0x9];pa  = off_ptr[0xa];pb  = off_ptr[0xb];pc  = off_ptr[0xc];pd  = off_ptr[0xd];pe  = off_ptr[0xe];pf  = off_ptr[0xf];
@@ -4272,7 +4272,7 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		// Intermediates pointers:
 		vec_dbl *tmp, *v0,*v1,*v2,*v3,*v4,*v5,*v6,*v7,
 			// Each of these rhi-ptrs points to next 8 vec_cmplx= 16 vec_dbl data sets:
-			*r10 = r00+0x10,*r20 = r00+0x20,*r30 = r00+0x30,*r40 = r00+0x40,*r50 = r00+0x50,*r60 = r00+0x60,*r70 = r00+0x70,
+			*r10,*r20,*r30,*r40,*r50,*r60,*r70,
 			*w[14], **twid_ptrs = &(w[0]);	// Array of 14 SIMD twiddles-pointers for the reduced-#args version of SSE2_RADIX8_DIF_TWIDDLE_OOP
 		/* Addresses into array sections */
 		double *add0, *add1, *add2, *add3, *add4, *add5, *add6, *add7;
@@ -4441,6 +4441,11 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		} else {
 			ASSERT(sc_arr != 0, "This function requires an initial Init-consts-mode call (in 1-thread mode only) before use!");
 		}	/* end of inits */
+
+		// Each of these rhi-ptrs points to next 8 vec_cmplx = 16 vec_dbl data sets; done here (rather than
+		// in the above declarations) since r00 == 0x0 on the (thr_id == -1) init-mode calls above, and
+		// forming pointer offsets from a null base pointer is undefined behavior:
+		r10 = r00+0x10; r20 = r00+0x20; r30 = r00+0x30; r40 = r00+0x40; r50 = r00+0x50; r60 = r00+0x60; r70 = r00+0x70;
 
 		/* If multithreaded, set the local-store pointers needed for the current thread; */
 	#ifdef MULTITHREAD
@@ -5054,7 +5059,7 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 				isrt2,two,
 				tm0,OFF1,OFF2,OFF3,OFF4
 			); tm0 += 32;
-			if(i_idx) {	// vvv +2 here because this is setup for next loop pass
+			if(i_idx && i < 15) {	// vvv +2 here because this is setup for next loop pass
 				nshift = i+i+2;	// i_idx shift counts here run as >>2,4,...,30
 				off_ptr = i_offsets_lo + ( ((i_idx>>nshift)&0x3) << 4 );
 			}


### PR DESCRIPTION
## Problem (#28, #9)

Two categories of executed undefined behavior:
- **Shift-exponent UB (#28)**, three sites:
  - `shift_word()` (`Mlucas.c`) evaluated `itmp64 << (64-mod64)` when `mod64 == 0` (i.e. `<< 64`) before masking the result to 0.
  - `RADIX_256_DIT` and `SSE2_RADIX256_DIT` (`dft_macro.c`) each compute `i_idx >> nshift` with `nshift = i+i+2` as setup for the *next* loop pass, so on the last pass (`i == 15`) they shift a `uint32` by 32 — the result is unused, but the shift is still evaluated.
- **Null-pointer-offset UB (#9):** in `SSE2_RADIX_64_DIT` (`dft_macro.c`), the seven `rhi`-pointers `*r10 = r00+0x10, … *r70 = r00+0x70` were formed in the declaration list, but `r00` is NULL on the init-mode (`thr_id == -1`) calls — forming a pointer offset from a null base is UB. This is the file's only live instance of the construct; the sibling in `SSE2_RADIX_64_DIF` sits in a `#else` block whose third line is an `#error`, so it never compiles.

## Fix

- Compute the `mod64==0` result directly via a conditional (no out-of-range shift).
- Guard the two last-pass setups with `i < 15`.
- Move `SSE2_RADIX_64_DIT`'s `r10..r70` assignments past the init-mode early-return. They are used later in the function, so they are moved rather than deleted.

## Verification (AVX2)

- Radix-256 residue **byte-identical to baseline** (`95AFD7A5269F14F6`).
- UBSan (`-fsanitize=undefined`): **0 runtime errors** on the radix-256 path and full `-s tiny`, no residue mismatches.

## Verification (ARM hardware, ASan + UBSan, full `-s medium`)

Before/after A/B on a Raspberry Pi 4B (aarch64), built with the CI's `-fsanitize=address,undefined -Og` flags and run over the full medium self-test (FFT lengths 2M–15M, `-cpu 0:2`). "before" = base `main` without this PR; "after" = this PR applied. Both: EXIT 0, 24/24 FFT lengths, **no ASan memory errors**.

| UBSan errors | before | after |
|---|---|---|
| shift-exponent (#28) — the three sites above: `shift_word()`, `RADIX_256_DIT`, `SSE2_RADIX256_DIT` | 3 | **0** |
| null-ptr-offset (#9) — the seven `r00+0x10 … r00+0x70` offsets (256–1792) in `SSE2_RADIX_64_DIT` | 14 (clang) | **0** |

- **gcc-12** flags the 3 shift-exponent errors (#28); after the fix, 0.
- **clang-15** additionally flags the 14 null-pointer-offset errors (#9) at the init-mode (`r00==NULL`) sites this PR moves past the early-return; after the fix, 0.

So both UB classes are confirmed eliminated on real ARM hardware across the whole medium tier, with residues unchanged.

*Two corrections to an earlier revision of this description: the null-pointer-offset fix is in `SSE2_RADIX_64_DIT`, not in the `RADIX_256` routines (those get the `i < 15` shift guards), and the UBSan table's per-site line numbers named `#endif` lines rather than the offending statements, so they have been replaced with function names.*

One stale artefact to flag: commit `72df6f7e`'s message describes deleting genuinely-unused `rhi`-pointers from `dft_macro.c`. That is not what landed — the commit touches only `Mlucas.c`, dropping one now-inaccurate comment line — and the `dft_macro.c` approach in this PR is the move-past-the-early-return described above. I will amend the message if you would rather the log read straight.

Fixes #9. Fixes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

