### PR TITLE
Fix corrupted carryout in mi64_mul_scalar_add_vec2 asm (crashes final PRP-determination)

### DIFF
--- a/src/mi64.c
+++ b/src/mi64.c
@@ -2835,8 +2835,8 @@ uint64	mi64_mul_scalar_add_vec2(const uint64 x[], uint64 a, const uint64 y[], ui
 		"leaq	0x8(%%rsi), %%rsi	\n\t"\
 	"decq	%%rcx \n\t"\
 	"jnz 0b 	\n\t"/* loop1 end; continue is via jump-back if rcx != 0 */\
-		"adcq	%%r9 ,%[__cy]	\n\t"/* Carryout. */\
-		: [__cy] "=m" (cy) /* outputs: cy */\
+		"adcq	%%r9 ,%[__cy]	\n\t"/* Carryout: cy (pre-set to 0 by caller) += r9 + final CF. MUST be "+m", not "=m": this adcq READS cy, so a write-only "=m" lets the compiler leave that memory uninitialized -> spurious nonzero carryout. */\
+		: [__cy] "+m" (cy) /* outputs: cy (read-modify-write) */\
 		: [__x0] "g" (x)	/* All inputs from memory/register here */\
 		 ,[__y0] "g" (y)	\
 		 ,[__z0] "g" (z)	\


### PR DESCRIPTION
## Problem

Every completed Mersenne PRP test on a recent compiler aborts at the very end:
```
Assertion `rmodb == 0ull' failed: After short-div, R != 0 (mod B)
```
in the Suyama final-residue extraction (`Mlucas.c`), which divides `residue + k·m` by `PRP_BASE^2` and asserts the division is exact.

## Root cause

The x86-64 `YES_ASM` path of `mi64_mul_scalar_add_vec2` (`mi64.c`) ends with `adcq %%r9,%[__cy]`, which **reads** the `cy` memory operand — but `cy` was declared **`"=m"` (write-only)**. The compiler is not required to materialize the callers `cy = 0` init into that stack slot, so the `adcq` adds `r9 + CF` to leftover **stack garbage**, yielding a spurious nonzero carryout. The low result limbs are always correct; only the returned carryout is wrong.

That bogus carryout breaks the `residue + k·m` divisibility-by-`b²` invariant, tripping the assert. Instrumentation confirmed: the real limbs of `r + k·m` are divisible by `b²`, but the carryout limb was `4` (should be `0`), and `4·(2^64)^j ≡ 1 (mod 9)` exactly produced the observed remainder.

Notes:
- **Not `p mod 64`-specific** — reproduced on `p=250007` (≡23) and `p=250687`/`p=1000639` (≡63). It escaped testing because the `-s` self-tests use `-iters` (partial) and never reach this block; only a full PRP-to-completion does.
- Latent UB, exposed by newer compilers (hit on **GCC 16**); older toolchains happened to zero the slot.
- The protective `rmodb==0` assert makes the PRP path fail **loud** (crash), not silently report a wrong prime/composite verdict. The other caller — `mi64_mul_vector` (`mi64_div_mont`, used in cofactor/factoring paths) — is a genuinely-silent vector this fix also closes.

## Fix

Declare `cy` as **`"+m"`** (read-modify-write) so its `0`-init is honored — matching the already-correct sibling asm at `mi64.c:2374`. Only corrects the buggy case; where it already worked, behavior is unchanged. Two lines.

## Verification (AVX2, GCC 16)

- asm path + fix → `p=250007` and `p=250687` complete with `rmodb==0` and `Res64` **byte-identical to a C-fallback (`#ifndef YES_ASM`) reference build** (`E68EB51E76CFFDF2` / `BB61BB1229A1469A`), ROE 0.
- `-s tiny` regression: 93 tests, 0 failures.
- P-1 of M2000003 finds the known factor 160000241 (GCD path).
- PRP-cofactor runs cleanly through the `mi64_mul_vector` known-factor setup.

Found while verifying the #33 fix (#77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)