### PR TITLE
Fix Mfactor build break: disable the never-implemented USE_FMADD 100-bit modpow path

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -3482,7 +3482,7 @@ MFACTOR_HELP:
 
 						  #else
 
-							#if 0	/* USE_FMADD has no single-candidate twopmodq100_2WORD_DOUBLE
+							#if defined(USE_FMADD) && 0	/* USE_FMADD has no single-candidate twopmodq100_2WORD_DOUBLE
 									variant - the only FMADD-based 100-bit modpow ever implemented is the
 									AVX-512-only, 32-way twopmodq100_2WORD_DOUBLE_q32 in twopmodq100.c (unused
 									by this TRYQ==1 code path, and in any case unreachable here since factor.h
@@ -3540,7 +3540,7 @@ MFACTOR_HELP:
 
 						  #elif(defined(P1WORD))
 
-							#if 0	/* USE_FMADD has no 2-way twopmodq100_2WORD_DOUBLE_q2
+							#if defined(USE_FMADD) && 0	/* USE_FMADD has no 2-way twopmodq100_2WORD_DOUBLE_q2
 									variant - see the longer note at the TRYQ==1 case above. There is no
 									integer-based q2 batch routine either, so unlike TRYQ==1/4 there is no
 									fallback to fall through to; if this is ever hit for real (it currently
@@ -3589,7 +3589,7 @@ MFACTOR_HELP:
 
 						  #else	// Default single-word-p mode:
 
-							#if 0	/* USE_FMADD has no 4-way twopmodq100_2WORD_DOUBLE_q4
+							#if defined(USE_FMADD) && 0	/* USE_FMADD has no 4-way twopmodq100_2WORD_DOUBLE_q4
 									variant - see the longer note at the TRYQ==1 case above (only a
 									never-called, AVX-512-only 32-way _q32 routine was ever completed for
 									this 100-bit FMADD family). This #if 0 previously read '#ifdef USE_FMADD'

--- a/src/factor.c
+++ b/src/factor.c
@@ -3482,8 +3482,12 @@ MFACTOR_HELP:
 
 						  #else
 
-							#ifdef USE_FMADD
-								/* Use 50x50-bit FMADD-based modmul routines, if def'd: */
+							#if 0	/* USE_FMADD has no single-candidate twopmodq100_2WORD_DOUBLE
+									variant - the only FMADD-based 100-bit modpow ever implemented is the
+									AVX-512-only, 32-way twopmodq100_2WORD_DOUBLE_q32 in twopmodq100.c (unused
+									by this TRYQ==1 code path, and in any case unreachable here since factor.h
+									restricts USE_FMADD builds to TRYQ = 1, 2 or 4). Fall through to the
+									already-correct paths below instead of calling a nonexistent function. */
 								res = twopmodq100_2WORD_DOUBLE(p[0],k);
 							#elif(defined(USE_FLOAT))
 								/* Otherwise use 78-bit floating-double-based modmul: */
@@ -3536,14 +3540,19 @@ MFACTOR_HELP:
 
 						  #elif(defined(P1WORD))
 
-							#ifdef USE_FMADD
-								/* Use 50x50-bit FMADD-based modmul routines, if def'd: */
+							#if 0	/* USE_FMADD has no 2-way twopmodq100_2WORD_DOUBLE_q2
+									variant - see the longer note at the TRYQ==1 case above. There is no
+									integer-based q2 batch routine either, so unlike TRYQ==1/4 there is no
+									fallback to fall through to; if this is ever hit for real (it currently
+									is not - factor.h's default TRYQ under USE_FMADD is 2, but makemake.sh's
+									'mfac' target always overrides to TRYQ=4), build with TRYQ=1 or TRYQ=4
+									instead, or use USE_FLOAT instead of USE_FMADD. */
 								res = twopmodq100_2WORD_DOUBLE_q2(p[0],k_to_try[0],k_to_try[1]);
 							#elif(defined(USE_FLOAT))
 								/* Otherwise use 78-bit floating-double-based modmul: */
 								res = twopmodq78_3WORD_DOUBLE_q2(p[0],k_to_try[0],k_to_try[1], 0,tid);
 							#else
-								#error	TRYQ = 2 / P1WORD only allowed if USE_FLOAT or USE_FMADD is defined!
+								#error	TRYQ = 2 / P1WORD requires USE_FLOAT (USE_FMADD's 2-way 100-bit modpow, twopmodq100_2WORD_DOUBLE_q2, was never implemented - use TRYQ=1 or TRYQ=4 with USE_FMADD instead)!
 							#endif	/* #ifdef USE_FMADD */
 
 						  #else
@@ -3580,8 +3589,14 @@ MFACTOR_HELP:
 
 						  #else	// Default single-word-p mode:
 
-							#ifdef USE_FMADD
-								/* Use 50x50-bit FMADD-based modmul routines, if def'd: */
+							#if 0	/* USE_FMADD has no 4-way twopmodq100_2WORD_DOUBLE_q4
+									variant - see the longer note at the TRYQ==1 case above (only a
+									never-called, AVX-512-only 32-way _q32 routine was ever completed for
+									this 100-bit FMADD family). This #if 0 previously read '#ifdef USE_FMADD'
+									and called the nonexistent _q4 function, which is an implicit-declaration
+									hard error on GCC 14+/C23 (was a mere warning on older compilers) - this is
+									what broke the standalone Mfactor build (which always builds with TRYQ=4).
+									Fall through to the already-correct 78-bit/integer paths below instead. */
 								res = twopmodq100_2WORD_DOUBLE_q4(p[0],k_to_try[0],k_to_try[1],k_to_try[2],k_to_try[3]);
 
 							#elif(defined(USE_FLOAT))


### PR DESCRIPTION
## Problem

The standalone **Mfactor** build fails on GCC 14+/C23:
```
factor.c: error: implicit declaration of function `twopmodq100_2WORD_DOUBLE_q4`
```

## Root cause

The `#ifdef USE_FMADD` sites in `factor.c` (for `TRYQ` 1/2/4) call `twopmodq100_2WORD_DOUBLE` / `_q2` / `_q4`, but **that FMADD 100-bit modpow family was never implemented**: only an AVX-512-only `_q32` is defined (plus a `_q64` *declaration*), and neither is ever called. So those calls always referenced nonexistent functions — a **link** error historically, and (because `makemake.sh`’s `mfac` target hardcodes `-DTRYQ=4`) a hard **compile** error once modern GCC upgraded implicit declarations from warning to error. (`factor_test.h`’s "FMADD" self-test calls are already inert — it `#undef`s `USE_FMADD` at its top.)

Mfactor-only: `factor.c` is in `OBJS_MFAC`, not the main Mlucas binary — which is why it went unnoticed, and CI masks Mfactor build failures via `makemake.sh mfac … || true`.

## Fix

Replace the three `#ifdef USE_FMADD` with `#if 0` so each `TRYQ` case falls through to the already-correct **integer `twopmodq*` path** — the exact routines the non-FMADD build and the `TRYQ==4` self-test already use. **Provably lossless**: no FMADD 100-bit path ever worked, so nothing functional is removed (there was simply never any FMA speed-up available for these batch sizes). `factor.c` only, well-commented.

## Verification (GCC 16)

- Unfixed tree fails at the `_q4` call; fixed tree **compiles clean**.
- `Mfactor` `test_fac` → "Factoring self-tests completed successfully", including the `TRYQ==4` integer-`_q4` block the fallback routes to.

## Not covered by this PR (separate, pre-existing)

- A pre-existing **LTO asm-label collision** in `twopmodq96.c` (`LoopBeg`/`LoopEnd`/`twopmodq96_q4_pshiftjmp` collide under parallel `-flto`) still blocks the Mfactor `-flto` **link** stage. This PR clears the compile error; that link bug is tracked separately.
- The Mfactor `test_fac` PRP self-test (M607) also needs the `mi64_mul_scalar_add_vec2` carryout fix in #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)