### PR TITLE
Make inline-asm labels asm-local to fix LTO symbol collisions in the Mfactor build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,9 @@ jobs:
                         else
                             # Exercise Mfactor's built-in self-tests (test_fac), which run during
                             # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                            # run's own exit status and instead assert the self-test success marker,
-                            # so a test_fac regression fails the job.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
+                            # exits nonzero on a test_fac failure, so no extra check is needed here.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20
                         fi
                     fi
                 )
@@ -137,11 +135,9 @@ jobs:
                         else
                             # Exercise Mfactor's built-in self-tests (test_fac), which run during
                             # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                            # run's own exit status and instead assert the self-test success marker,
-                            # so a test_fac regression fails the job.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
+                            # exits nonzero on a test_fac failure, so no extra check is needed here.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20
                         fi
                     fi
                 )
@@ -406,11 +402,9 @@ jobs:
                         else
                             # Exercise Mfactor's built-in self-tests (test_fac), which run during
                             # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                            # run's own exit status and instead assert the self-test success marker,
-                            # so a test_fac regression fails the job.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
+                            # exits nonzero on a test_fac failure, so no extra check is needed here.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20
                         fi
                     fi
                 )
@@ -474,11 +468,9 @@ jobs:
                         else
                             # Exercise Mfactor's built-in self-tests (test_fac), which run during
                             # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                            # run's own exit status and instead assert the self-test success marker,
-                            # so a test_fac regression fails the job.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
+                            # exits nonzero on a test_fac failure, so no extra check is needed here.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20
                         fi
                     fi
                 )
@@ -615,11 +607,9 @@ jobs:
                         else
                             # Exercise Mfactor's built-in self-tests (test_fac), which run during
                             # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                            # run's own exit status and instead assert the self-test success marker,
-                            # so a test_fac regression fails the job.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
+                            # exits nonzero on a test_fac failure, so no extra check is needed here.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20
                         fi
                     fi
                 )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,19 @@ jobs:
                     make clean
                     mv -v build.log build_${word}.log
                     if [[ -x Mfactor${word:+_$word} ]]; then
-                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                        # run's own exit status and instead assert the self-test success marker,
-                        # so a test_fac regression fails the job.
-                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
+                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
+                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
+                            ./Mfactor${word:+_$word} -h
+                        else
+                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                            # run's own exit status and instead assert the self-test success marker,
+                            # so a test_fac regression fails the job.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        fi
                     fi
                 )
             done
@@ -124,13 +130,19 @@ jobs:
                     make clean
                     mv -v build.log build_${word}.log
                     if [[ -x Mfactor${word:+_$word} ]]; then
-                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                        # run's own exit status and instead assert the self-test success marker,
-                        # so a test_fac regression fails the job.
-                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
+                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
+                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
+                            ./Mfactor${word:+_$word} -h
+                        else
+                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                            # run's own exit status and instead assert the self-test success marker,
+                            # so a test_fac regression fails the job.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        fi
                     fi
                 )
             done
@@ -387,13 +399,19 @@ jobs:
                     make clean
                     mv -v build.log build_${word}.log
                     if [[ -x Mfactor${word:+_$word} ]]; then
-                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                        # run's own exit status and instead assert the self-test success marker,
-                        # so a test_fac regression fails the job.
-                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
+                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
+                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
+                            ./Mfactor${word:+_$word} -h
+                        else
+                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                            # run's own exit status and instead assert the self-test success marker,
+                            # so a test_fac regression fails the job.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        fi
                     fi
                 )
             done
@@ -449,13 +467,19 @@ jobs:
                     make clean
                     mv -v build.log build_${word}.log
                     if [[ -x Mfactor${word:+_$word} ]]; then
-                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                        # run's own exit status and instead assert the self-test success marker,
-                        # so a test_fac regression fails the job.
-                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
+                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
+                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
+                            ./Mfactor${word:+_$word} -h
+                        else
+                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                            # run's own exit status and instead assert the self-test success marker,
+                            # so a test_fac regression fails the job.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        fi
                     fi
                 )
             done
@@ -584,13 +608,19 @@ jobs:
                     make clean
                     mv -v build.log build_${word}.log
                     if [[ -x Mfactor${word:+_$word} ]]; then
-                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
-                        # run's own exit status and instead assert the self-test success marker,
-                        # so a test_fac regression fails the job.
-                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
-                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
+                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
+                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
+                            ./Mfactor${word:+_$word} -h
+                        else
+                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                            # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                            # run's own exit status and instead assert the self-test success marker,
+                            # so a test_fac regression fails the job.
+                            ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                            grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                        fi
                     fi
                 )
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,15 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
+                    if [[ -x Mfactor${word:+_$word} ]]; then
+                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                        # run's own exit status and instead assert the self-test success marker,
+                        # so a test_fac regression fails the job.
+                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                    fi
                 )
             done
         done
@@ -115,7 +123,15 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
+                    if [[ -x Mfactor${word:+_$word} ]]; then
+                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                        # run's own exit status and instead assert the self-test success marker,
+                        # so a test_fac regression fails the job.
+                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                    fi
                 )
             done
         done
@@ -370,7 +386,15 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
+                    if [[ -x Mfactor${word:+_$word} ]]; then
+                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                        # run's own exit status and instead assert the self-test success marker,
+                        # so a test_fac regression fails the job.
+                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                    fi
                 )
             done
         done
@@ -424,7 +448,15 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
+                    if [[ -x Mfactor${word:+_$word} ]]; then
+                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                        # run's own exit status and instead assert the self-test success marker,
+                        # so a test_fac regression fails the job.
+                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                    fi
                 )
             done
         done
@@ -551,7 +583,15 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
+                    if [[ -x Mfactor${word:+_$word} ]]; then
+                        # Exercise Mfactor's built-in self-tests (test_fac), which run during
+                        # factoring-init and validate the modpow/sieve machinery. M(127) has no
+                        # factors <= 2^20 so the trial-factoring pass is quick. We tolerate the
+                        # run's own exit status and instead assert the self-test success marker,
+                        # so a test_fac regression fails the job.
+                        ./Mfactor${word:+_$word} -m 127 -bmax 20 2>&1 | tee "mfac_selftest_${word:-none}.log" || true
+                        grep -q 'self-tests completed successfully' "mfac_selftest_${word:-none}.log"
+                    fi
                 )
             done
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,19 +57,7 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    if [[ -x Mfactor${word:+_$word} ]]; then
-                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
-                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
-                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
-                            ./Mfactor${word:+_$word} -h
-                        else
-                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
-                            # exits nonzero on a test_fac failure, so no extra check is needed here.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20
-                        fi
-                    fi
+                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
         done
@@ -127,19 +115,7 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    if [[ -x Mfactor${word:+_$word} ]]; then
-                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
-                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
-                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
-                            ./Mfactor${word:+_$word} -h
-                        else
-                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
-                            # exits nonzero on a test_fac failure, so no extra check is needed here.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20
-                        fi
-                    fi
+                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
         done
@@ -394,19 +370,7 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    if [[ -x Mfactor${word:+_$word} ]]; then
-                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
-                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
-                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
-                            ./Mfactor${word:+_$word} -h
-                        else
-                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
-                            # exits nonzero on a test_fac failure, so no extra check is needed here.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20
-                        fi
-                    fi
+                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
         done
@@ -460,19 +424,7 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    if [[ -x Mfactor${word:+_$word} ]]; then
-                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
-                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
-                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
-                            ./Mfactor${word:+_$word} -h
-                        else
-                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
-                            # exits nonzero on a test_fac failure, so no extra check is needed here.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20
-                        fi
-                    fi
+                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
         done
@@ -599,19 +551,7 @@ jobs:
                     cd obj_mfac${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
-                    if [[ -x Mfactor${word:+_$word} ]]; then
-                        if [[ $HOSTTYPE == aarch64 || $HOSTTYPE == arm64 ]]; then
-                            # Mfactor trial-factoring (hence its test_fac self-test) is not supported on
-                            # ARMv8 - it asserts "No TF support on ARMv8!" - so just smoke-test the binary.
-                            ./Mfactor${word:+_$word} -h
-                        else
-                            # Exercise Mfactor's built-in self-tests (test_fac), which run during
-                            # factoring-init and validate the modpow/sieve machinery. M(127) has no
-                            # factors <= 2^20 so the trial-factoring pass is quick. Mfactor already
-                            # exits nonzero on a test_fac failure, so no extra check is needed here.
-                            ./Mfactor${word:+_$word} -m 127 -bmax 20
-                        fi
-                    fi
+                    [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
         done

--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -1407,8 +1407,8 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 		"movslq	%[__start_index], %%rcx		\n\t"\
 		"subq $1,%%rcx						\n\t"\
 		"test %%rcx, %%rcx					\n\t"\
-		"jl LoopEnd4a		/* Skip if n < 0 */	\n\t"\
-	"LoopBeg4a:								\n\t"\
+		"jl LoopEnd4a%=		/* Skip if n < 0 */	\n\t"\
+	"LoopBeg4a%=:								\n\t"\
 	"/* SQR_LOHI_q4(x*, lo*, hi*): */	\n\t"\
 		"movq	%%r12,%%rax	/* x0-3 in r8-11. */\n\t"\
 		"mulq	%%rax		\n\t"\
@@ -1476,7 +1476,7 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 		"movl	%[__p],%%eax	/* Need to follow this with load-j-into-ecx if use HLL loop control in debug mode */\n\t"\
 		"shrq	%%cl,%%rax				\n\t"\
 		"andq	$0x1,%%rax				\n\t"\
-	"je	twopmmodq64_q4_pjmp			\n\t"\
+	"je	twopmmodq64_q4_pjmp%=			\n\t"\
 		"\n\t"\
 		"movq	%%r12,%%r8 	/* r8  <- Copy of x */\n\t"\
 		"movq	%%r12,%%rax	/* rax <- Copy of x */\n\t"\
@@ -1506,12 +1506,12 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 		"addq	%%rax,%%r11	\n\t"\
 		"cmovcq %%r11,%%r15	\n\t"\
 		"\n\t"\
-	"twopmmodq64_q4_pjmp:					\n\t"\
+	"twopmmodq64_q4_pjmp%=:					\n\t"\
 		"/* } endif((p >> j) & (uint64)1) */						\n\t"\
 		"subq	$1,%%rcx	/* j-- */		\n\t"\
 		"cmpq	$0,%%rcx	/* compare j vs 0 */\n\t"\
-		"jge	LoopBeg4a	/* if (j >= 0), Loop */	\n\t"\
-	"LoopEnd4a:							\n\t"\
+		"jge	LoopBeg4a%=	/* if (j >= 0), Loop */	\n\t"\
+	"LoopEnd4a%=:							\n\t"\
 		"movq	%%r12,%[__x0]	\n\t"\
 		"movq	%%r13,%[__x1]	\n\t"\
 		"movq	%%r14,%[__x2]	\n\t"\

--- a/src/twopmodq64_test.c
+++ b/src/twopmodq64_test.c
@@ -426,8 +426,8 @@ uint64 twopmodq64_q4(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		"movslq	%[__start_index], %%rcx		\n\t"\
 		"subq $2,%%rcx						\n\t"\
 		"test %%rcx, %%rcx					\n\t"\
-		"jl LoopEnd4			\n\t"/* Skip if n < 0 */\
-	"LoopBeg4:								\n\t"\
+		"jl LoopEnd4%=			\n\t"/* Skip if n < 0 */\
+	"LoopBeg4%=:								\n\t"\
 	/* SQR_LOHI_q4(x*, lo*, hi*): */\
 		"movq	%%r12,%%rax	\n\t"/* x0-3 in r8-11. */\
 		"mulq	%%rax		\n\t"\
@@ -490,7 +490,7 @@ uint64 twopmodq64_q4(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		"movq	%[__pshift],%%rax	\n\t"/* Need to follow this with load-j-into-ecx if use HLL loop control in debug mode */\
 		"shrq	%%cl,%%rax				\n\t"\
 		"andq	$0x1,%%rax				\n\t"\
-	"je	twopmodq64_q4_pshiftjmp			\n\t"\
+	"je	twopmodq64_q4_pshiftjmp%=			\n\t"\
 		"\n\t"\
 		"movq	%%r12,%%r8 	\n\t"/* r8  <- Copy of x */\
 		"movq	%%r12,%%rax	\n\t"/* rax <- Copy of x */\
@@ -520,12 +520,12 @@ uint64 twopmodq64_q4(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		"addq	%%rax,%%r11	\n\t"\
 		"cmovcq %%r11,%%r15	\n\t"\
 		"\n\t"\
-	"twopmodq64_q4_pshiftjmp:	\n\t"\
+	"twopmodq64_q4_pshiftjmp%=:	\n\t"\
 		/* } endif((pshift >> j) & (uint64)1) */\
 		"subq	$1,%%rcx	\n\t"/* j-- */\
 		"cmpq	$0,%%rcx	\n\t"/* compare j vs 0 */\
-		"jge	LoopBeg4	\n\t"/* if (j >= 0), Loop */\
-	"LoopEnd4:			\n\t"\
+		"jge	LoopBeg4%=	\n\t"/* if (j >= 0), Loop */\
+	"LoopEnd4%=:			\n\t"\
 		"movq	%%r12,%[__x0]	\n\t"\
 		"movq	%%r13,%[__x1]	\n\t"\
 		"movq	%%r14,%[__x2]	\n\t"\
@@ -697,8 +697,8 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		"movslq	%[__start_index], %%rcx		\n\t"\
 		"subq $2,%%rcx						\n\t"\
 		"test %%rcx, %%rcx					\n\t"\
-		"jl LoopEnd8		\n\t"/* Skip if n < 0 */\
-	"LoopBeg8:								\n\t"\
+		"jl LoopEnd8%=		\n\t"/* Skip if n < 0 */\
+	"LoopBeg8%=:								\n\t"\
 	/* SQR_LOHI_q4(x*, lo*, hi*): */\
 		"movq	%%r8 ,%%rax		\n\t"\
 		"mulq	%%rax			\n\t"\
@@ -832,7 +832,7 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		"movq	%[__pshift],%%rax	\n\t"/* Need to follow this with load-j-into-ecx if use HLL loop control in debug mode */\
 		"shrq	%%cl,%%rax			\n\t"\
 		"andq	$0x1,%%rax			\n\t"\
-	"je	twopmodq64_q8_pshiftjmp		\n\t"\
+	"je	twopmodq64_q8_pshiftjmp%=		\n\t"\
 		"\n\t"\
 		"movq	%[__q0],%%rax  	\n\t"/* rax <- Copy of q */\
 		"leaq (%%r8 ,%%r8 ),%%rbx	\n\t"/* rbx <- x+x, no CF set, leave r8 (x) intact */\
@@ -882,12 +882,12 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		"subq	%%rax,%%r15		\n\t"\
 		"cmovcq %%rbx,%%r15		\n\t"\
 		"\n\t"\
-	"twopmodq64_q8_pshiftjmp:	\n\t"\
+	"twopmodq64_q8_pshiftjmp%=:	\n\t"\
 		/* } endif((pshift >> j) & (uint64)1) */\
 		"subq	$1,%%rcx	\n\t"/* j-- */\
 		"cmpq	$0,%%rcx	\n\t"/* compare j vs 0 */\
-		"jge	LoopBeg8	\n\t"/* if (j >= 0), Loop */\
-	"LoopEnd8:			\n\t"\
+		"jge	LoopBeg8%=	\n\t"/* if (j >= 0), Loop */\
+	"LoopEnd8%=:			\n\t"\
 		"movq	%%r8 ,%[__x0]	\n\t"\
 		"movq	%%r9 ,%[__x1]	\n\t"\
 		"movq	%%r10,%[__x2]	\n\t"\

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -2708,8 +2708,8 @@ if(~pshift != p+78) {
 				"movslq	%[__start_index], %%rcx		\n\t"\
 				"subq $2,%%rcx						\n\t"\
 				"test %%rcx, %%rcx					\n\t"\
-				"jl Loop4End		/* Skip if n < 0 */	\n\t"\
-			"Loop4Beg:								\n\t"\
+				"jl Loop4End%=		/* Skip if n < 0 */	\n\t"\
+			"Loop4Beg%=:								\n\t"\
 			/* SQR_LOHI78_3WORD_DOUBLE_q4(fx, flo,fhi). Inputs flo0,1,2 enter in xmm0,2,4 [lcol] and xmm8,10,12 [rcol]: */\
 				"/* SQR_LOHI78_3WORD_DOUBLE_q4(): */\n\t"\
 				"movq	%[__fx0],%%rax				\n\t"\
@@ -2933,8 +2933,8 @@ if(~pshift != p+78) {
 				"movaps	%%xmm1,%%xmm2 /* fx1 */	\n\t	movaps	%%xmm9 ,%%xmm10	/* hx1 */	\n\t"\
 				"subq	$1,%%rcx	/* j-- */		\n\t"\
 				"cmpq	$0,%%rcx	/* j > 0 ?	*/	\n\t"\
-				"jge	Loop4Beg	/* if (j >= 0), loop */	\n\t"\
-			"Loop4End:							\n\t"\
+				"jge	Loop4Beg%=	/* if (j >= 0), loop */	\n\t"\
+			"Loop4End%=:							\n\t"\
 				:					/* outputs: none */\
 				: [__fqinv0] "m" (fqinv0)	/* All inputs from memory addresses here */\
 				 ,[__two26i] "m" (two26i)	\
@@ -4371,8 +4371,8 @@ if(~pshift != p+78) {
 					"movslq	%[__start_index], %%rcx		/* for(j = start_index-2; j >= 0; j--) { */\n\t"\
 					"subq $2,%%rcx						\n\t"\
 					"test %%rcx, %%rcx					\n\t"\
-					"jl Loop8End		/* Skip if n < 0 */	\n\t"\
-				"Loop8Beg:								\n\t"\
+					"jl Loop8End%=		/* Skip if n < 0 */	\n\t"\
+				"Loop8Beg%=:								\n\t"\
 					"movaps	0x200(%%rsi),%%xmm6	/* two13i shared between both columns */	\n\t		/* SQR_LOHI96_q4(x*, lo*, hi*): */	\n\t"\
 					"																						/* Load the x.d0 data: */	\n\t"\
 					"/* SQR_LOHI78_3WORD_DOUBLE_q4(): */\n\t													movq	0x300(%%rsi),%%rax	/* Dereference the x0 pointer... */\n\t"\
@@ -4601,7 +4601,7 @@ if(~pshift != p+78) {
 					"movq	%[__pshift],%%rax					\n\t"\
 					"shrq	%%cl,%%rax	/* j already in c-reg */\n\t"\
 					"andq	$0x1,%%rax							\n\t"\
-				"je	twopmodq96_q4_pshiftjmp						\n\t"\
+				"je	twopmodq96_q4_pshiftjmp%=						\n\t"\
 					"			/* Int64 code: if h<l carryout of low 64 bits gives hi=2^32 = 0x100000000, need to zero upper 32 bits prior to double step: */\n\t"\
 					"																							movq	$-1,%%rdi	\n\t"\
 					"																							shrq	$32,%%rdi	\n\t"\
@@ -4658,7 +4658,7 @@ if(~pshift != p+78) {
 					"	subpd		%%xmm13,%%xmm9	/* x mod q, low 26 bits */				\n\t				andq	%%rdi,%%rdx	\n\t"\
 					"																							addq	%%rax,%%r11	\n\t"\
 					"																							adcq	%%rdx,%%r15	\n\t"\
-				"twopmodq96_q4_pshiftjmp:													\n\t"\
+				"twopmodq96_q4_pshiftjmp%=:													\n\t"\
 					"/* } */																\n\t"\
 					"/* Normalize the result: */											\n\t"\
 					"movaps	0x210(%%rsi),%%xmm4		\n\t	movaps	0x210(%%rsi),%%xmm12	\n\t"\
@@ -4680,8 +4680,8 @@ if(~pshift != p+78) {
 					"movaps	%%xmm1,%%xmm2 /* fx1 */	\n\t	movaps	%%xmm9 ,%%xmm10	/* hx1 */	\n\t			movq	%%r15,0x338(%%rsi)	\n\t"\
 					"subq	$1,%%rcx	/* j-- */		\n\t"\
 					"cmpq	$0,%%rcx	/* j > 0 ?	*/	\n\t"\
-					"jge	Loop8Beg	/* if (j >= 0), loop */	\n\t"\
-				"Loop8End:							\n\t"\
+					"jge	Loop8Beg%=	/* if (j >= 0), loop */	\n\t"\
+				"Loop8End%=:							\n\t"\
 					:					/* outputs: none */\
 					: [__fq0] "m" (fq0)	/* All inputs from memory addresses here */\
 					 ,[__pshift] "m" (pshift)	\

--- a/src/twopmodq96.c
+++ b/src/twopmodq96.c
@@ -703,8 +703,8 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"movslq	%[__start_index], %%rcx		\n\t"\
 			"subq $2,%%rcx						\n\t"\
 			"test %%rcx, %%rcx					\n\t"\
-			"jl LoopEnd		/* Skip if n < 0 */	\n\t"\
-		"LoopBeg:								\n\t"\
+			"jl LoopEnd%=		/* Skip if n < 0 */	\n\t"\
+		"LoopBeg%=:								\n\t"\
 		"/* SQR_LOHI96_q4(x*, lo*, hi*): */	\n\t"\
 			"movq	%%r8 ,%%rax	/* Low 64 bits of x0-3 in r8-11. */\n\t"\
 			"mulq	%%rax		\n\t"\
@@ -961,7 +961,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"movq	%[__pshift],%%rax		\n\t"\
 			"shrq	%%cl,%%rax				\n\t"\
 			"andq	$0x1,%%rax				\n\t"\
-		"je	twopmodq96_q4_pshiftjmp			\n\t"\
+		"je	twopmodq96_q4_pshiftjmp%=			\n\t"\
 			"\n\t"\
 		"/* if h<l carryout of low 64 bits gives hi=2^32 = 0x100000000, need to zero upper 32 bits prior to double step: */\n\t"\
 			"movq	$-1,%%rdi	\n\t"\
@@ -1021,7 +1021,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"andq	%%rdi,%%rdx	\n\t"\
 			"addq	%%rax,%%r11	\n\t"\
 			"adcq	%%rdx,%%r15	\n\t"\
-		"twopmodq96_q4_pshiftjmp:					\n\t"\
+		"twopmodq96_q4_pshiftjmp%=:					\n\t"\
 			"/* } endif((pshift >> j) & (uint64)1) */						\n\t"\
 			"movq	%%r8 ,0x80(%%rsi)	/* Write lo 64 bits into [__x.d0] */\n\t"\
 			"movq	%%r12,0x88(%%rsi)	/* Write hi 32 bits into [__x.d1] */\n\t"\
@@ -1033,8 +1033,8 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"movq	%%r15,0xb8(%%rsi)	\n\t"\
 			"subq	$1,%%rcx	/* j-- */		\n\t"\
 			"cmpq	$0,%%rcx	/* compare decremented j vs 0 */\n\t"\
-			"jge	LoopBeg	/* if (j >= 0), Loop */	\n\t"\
-		"LoopEnd:							\n\t"\
+			"jge	LoopBeg%=	/* if (j >= 0), Loop */	\n\t"\
+		"LoopEnd%=:							\n\t"\
 			:	/* outputs: none */\
 			: [__q0] "m" (qptr0)	/* All inputs from memory addresses here */\
 			 ,[__pshift] "m" (pshift)	\


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #193 — must be merged after it.** This PR fixes an LTO *link*-stage failure that is only reachable once #193 clears the earlier `factor.c` *compile* error. On its own (without #193), the Mfactor build still fails earlier at `factor.c`, so this branch is intentionally not standalone-buildable — it is scoped to only the label fix. The two PRs are independent diffs (no shared commits) purely so each stays single-purpose.

## Problem

With #193 applied (Mfactor now compiles), `bash makemake.sh mfac` fails at the **LTO link** stage:
```
twopmodq96.c: Error: symbol `LoopBeg` is already defined
twopmodq96.c: Error: symbol `twopmodq96_q4_pshiftjmp` is already defined
twopmodq96.c: Error: symbol `LoopEnd` is already defined
```

## Root cause

Several `twopmodq*.c` inline-asm blocks use **hardcoded non-local labels** (`LoopBeg`, `LoopEnd`, `twopmodqNN_qM_pshiftjmp`, …). Under `-flto` parallel-partition codegen the containing functions are duplicated across partitions, so those labels become duplicate **global** symbols → link failure. (Same class as the parallel-LTO work in #56.) Mfactor-specific in practice; the main Mlucas binary already builds clean with the same files + `-flto`. It was doubly masked: the compile error (#193) aborted before link, and `ci.yml` runs `makemake.sh mfac … || true`.

## Fix

Append GCC’s `%=` (unique-per-instantiation token) to every label definition and jump reference within each affected asm block — **label renames only**, no instruction/operand/constraint changes, control flow identical. Files:
- `twopmodq96.c` — `twopmodq96_q4` block
- `twopmodq64_test.c` — `twopmodq64_q4` and `_q8` blocks
- `twopmodq80.c` — the two live (non-`USE_IMCI512`) q4/q8 blocks (one independently reused the name `twopmodq96_q4_pshiftjmp`)
- `twopmodq.c` — `twopmmodq64_q4` block

Sibling files (`twopmodq100/128/128_96/160/192/256.c`) were checked — no real non-local asm labels. Dead-code (`#if 0`) label duplicates left as-is.

## Verification (GCC 16, `-flto`)

Confirmed via A/B on this exact build: **reverting `twopmodq96.c`** to the unfixed version reproduces the exact `already defined` link errors; **with the fix**, `makemake.sh mfac` links clean and produces `obj_mfac/Mfactor`. Mfactor `test_fac` self-test passes (incl. the 96-bit factor test exercising `twopmodq96_q4`). _(The self-test’s M607 PRP step also needs the mi64 carryout fix in #80.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
