### PR TITLE
Fix operator typo in twopmmodq64 fast path (1ull < p should be 1ull << p)

### DIFF
--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -1198,7 +1198,7 @@ uint64 twopmmodq64(uint64 p, uint64 q)
 	if(debug) printf("twopmmodq64: computing 2^%" PRIu64 " (mod %" PRIu64 ")\n",p,q);
 	// If p <= 64, directly compute 2^p (mod q):
 	if(p < 64)
-		return (1ull < p) % q;
+		return (1ull << p) % q;
 	else if(p == 64) {
 		x = (1ull << 63) % q;
 		MOD_ADD64(x,x,q,x);


### PR DESCRIPTION
### Problem

The `p < 64` fast path in `twopmmodq64()` (`src/twopmodq.c:1201`) is meant to compute `2^p (mod q)` directly, but a typo used the comparison operator `<` instead of the left-shift `<<`:

```c
if(p < 64)
    return (1ull < p) % q;   // (0 or 1) % q  — a boolean, not 2^p
```

`1ull < p` evaluates to `0` or `1`, so the function returned `0 % q` or `1 % q` instead of `2^p mod q` — a wrong result for every `p` in `[1, 63]`.

### Fix

```c
if(p < 64)
    return (1ull << p) % q;
```

The guarding `if(p < 64)` keeps the shift width well-defined (no shift-by-≥64 UB), and the adjacent `p == 64` branch already uses the intended `(1ull << 63) % q` pattern.

### Relationship to #32

Found while investigating #32. **This typo is not the root cause of that report.** Ground-truth computation shows the reporter's savefile residue was genuinely corrupt — produced by the then-broken LTO AArch64 build (since fixed) — so the assert there correctly fired. The reporter should retest on current `main`; this PR just removes a real latent bug uncovered along the way.

### Verification

Compiles clean (`makemake.sh avx2`, plus an independent single-file compile); no other `1ull < <var>` occurrences exist in the file.