### PR TITLE
Fix P-1 error-code plumbing so multi-error batches can't crash a healthy run (fixes #49)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2679,7 +2679,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 					for(i = 0; i < NRADICES; i++) { RADIX_VEC[i] = 0; }		NRADICES = 0;
 					goto SETUP_FFT;
 				} else if(ierr & (1<<ERR_CARRY)) {	// One or more modmuls hit a nonzero-exit-carry (residue-corruption) error
-					sprintf(cbuf,"p-1 stage 2 hit a carry error, retrying from most-recent savefile in case the issue was due to residue-data corruption.\n");
+					snprintf(cbuf,STR_MAX_LEN*2,"p-1 stage 2 hit a carry error, retrying from most-recent savefile in case the issue was due to residue-data corruption.\n");
 					mlucas_fprint(cbuf,1);
 					goto READ_RESTART_FILE;
 				} else if(ierr) {

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2664,15 +2664,24 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				ierr = pm1_stage2(p, pm1_bigstep, pm1_stage2_mem_multiple,
 					a,mult,arrtmp,	// Pointers stage 1 residue in a[], double** scratch storage 4-vector mult[], arrtmp
 					func_mod_square, n, scrnFlag, &tdiff, gcd_str);
-				if(ierr && (ierr % ERR_ROUNDOFF) == 0) {	// Workaround for pthreaded-run issue where a single ROE sometimes shows up as an integer multiple of ERR_ROUNDOFF
+				// pm1_stage2() returns either a single raw ERR_INTERRUPT code (check that first, via exact match) or
+				// a bitmask in which bit ierr_code is set if modmul-error type ierr_code occurred 1-or-more times
+				// among the batch of stage 2 modmuls done since the last such check - so test for specific error
+				// types via bit tests, not equality or (as used pre-bitmask, to work around distinct hits of the
+				// same error type within one batch summing to an integer multiple of it) modulo tests:
+				if(ierr == ERR_INTERRUPT) {
+					// First print the signal-handler-generated message:
+					mlucas_fprint(cbuf,1);
+					exit(1);
+				} else if(ierr & (1<<ERR_ROUNDOFF)) {	// One or more modmuls hit a roundoff error - bump FFT length and restart
 					n = get_nextlarger_fft_length(n);	kblocks = (n >> 10);
 					// Clear out current FFT-radix data, since get_preferred_fft_radix() expects that:
 					for(i = 0; i < NRADICES; i++) { RADIX_VEC[i] = 0; }		NRADICES = 0;
 					goto SETUP_FFT;
-				} else if(ierr == ERR_INTERRUPT) {
-					// First print the signal-handler-generated message:
+				} else if(ierr & (1<<ERR_CARRY)) {	// One or more modmuls hit a nonzero-exit-carry (residue-corruption) error
+					sprintf(cbuf,"p-1 stage 2 hit a carry error, retrying from most-recent savefile in case the issue was due to residue-data corruption.\n");
 					mlucas_fprint(cbuf,1);
-					exit(1);
+					goto READ_RESTART_FILE;
 				} else if(ierr) {
 					sprintf(cbuf,"p-1 stage 2 hit an unhandled error of type[%u] = %s! Aborting.",ierr,returnMlucasErrCode(ierr));
 					ASSERT(0,cbuf);
@@ -4900,7 +4909,12 @@ int	cfgNeedsUpdating(char*in_line)
 
 const char*returnMlucasErrCode(uint32 ierr)
 {
-	ASSERT(ierr < ERR_MAX, "Error code out of range!");
+	// A single well-defined error code is a nonzero value in [1,ERR_MAX]. Anything else - 0 (no error) reaching
+	// here, a value > ERR_MAX, or a bitmask with 2 or more bits set as a result of distinct modmul-error types
+	// having occurred within a single batch of modmuls - is not a simple lookup, so describe it as such rather
+	// than asserting and killing an otherwise-healthy run over a diagnostic-string lookup failure:
+	if(ierr < 1 || ierr > ERR_MAX)
+		return "unknown/composite error code";
 	return err_code[ierr-1];
 }
 

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -857,7 +857,7 @@ int modpow(double a[], double b[], uint32 input_is_int, uint64 pow,
 #endif
 	if(!isPow2_64(pow)) {
 		memcpy(b,a,nbytes);	// b = a           vvvv + 4 to effect "Do in-place forward FFT only; low bit = 0 here implies pure-int input"
-		ierr = func_mod_square(b, 0x0, n, 0,1, 4ull + (uint64)(!input_is_int), p, scrnFlag,&tdif2, FALSE, 0x0); *tdiff += tdif2; nerr += ierr;
+		ierr = func_mod_square(b, 0x0, n, 0,1, 4ull + (uint64)(!input_is_int), p, scrnFlag,&tdif2, FALSE, 0x0); *tdiff += tdif2; if(ierr) nerr |= 1<<ierr;
 		if(ierr == ERR_INTERRUPT) {
 			return ierr;
 		}
@@ -886,7 +886,7 @@ int modpow(double a[], double b[], uint32 input_is_int, uint64 pow,
 		else		// i != 1: bit 0 = 1
 			mode_flag = 3;
 		// y *= y:
-		ierr = func_mod_square(a, 0x0, n, i,i+1, (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); *tdiff += tdif2; nerr += ierr;
+		ierr = func_mod_square(a, 0x0, n, i,i+1, (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); *tdiff += tdif2; if(ierr) nerr |= 1<<ierr;
 		if(ierr == ERR_INTERRUPT) {
 			return ierr;
 		}
@@ -894,7 +894,7 @@ int modpow(double a[], double b[], uint32 input_is_int, uint64 pow,
 		dsum = 0; for(j = 0; j < npad; j++) { dsum += fabs(a[j]); }; fprintf(stderr,"a^2: MME = %8.6f, a[0] = %20.8f, a[1] = %20.8f, L1(a) = %20.8f\n",MME,a[0],a[1],dsum/n); MME = 0;
 	#endif
 	  if(pow&1)	{	// y *= a; mode_flag for this fixed = 3:
-		ierr = func_mod_square(a, 0x0, n, i,i+1, (uint64)b +  3ull, p, scrnFlag,&tdif2, FALSE, 0x0); *tdiff += tdif2; nerr += ierr;
+		ierr = func_mod_square(a, 0x0, n, i,i+1, (uint64)b +  3ull, p, scrnFlag,&tdif2, FALSE, 0x0); *tdiff += tdif2; if(ierr) nerr |= 1<<ierr;
 		if(ierr == ERR_INTERRUPT) {
 			return ierr;
 		}
@@ -1384,14 +1384,14 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	memcpy(mult[1],pow,nbytes);	// A third copy of A^1 into mult[1][] - this will end up holding A^8 in fwd-FFTed form:
 	mode_flag = 2;	// bit 1 of mode_flag = 1 since all FFT-mul outputs will be getting re-used as inputs
 	// 3 mod-squares in-place to get A^8:
-	ierr = func_mod_square(mult[1], 0x0, n, 0,3,        (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+	ierr = func_mod_square(mult[1], 0x0, n, 0,3,        (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 	if(ierr == ERR_INTERRUPT) {
 		return ierr;
 	}
 	mode_flag |= 1;	// Only 1st fft-mul of A and its copies need low bit of mode_flag = 0!
 	memcpy(mult[2] ,mult[1],nbytes);	// mult[2][] holds ascending A^8,16,24,..., in *non*-fwd-FFTed form (that is, fwd-FFT-pass-1-done form)
 	// mult[1] = fwdFFT(A^8):					  vvvv + 4 to effect "Do in-place forward FFT only" of pow^8:
-	ierr = func_mod_square(mult[1], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+	ierr = func_mod_square(mult[1], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 	// And now the big loop to compute the remaining pow^(b[i]^2) terms, each of which goes into buf[i++] in fwd-FFTed form.
 	// Each pass through the loop costs 2.5 modsqr and 1 memcpy, with a 2nd memcpy whenever we hit a b[i] and write a buf[] entry:
 	i = 1;
@@ -1401,11 +1401,11 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	for(j = 3; j < m*(bigstep>>1); j += 2) {
 		memcpy(a,mult[2],nbytes);	// a[] = Copy of fwd-FFT-pass-1-done(A^8,16,24,...) to be fwd-FFTed
 		// a[] = FFT(A^8,16,24,...):
-		ierr = func_mod_square(      a, 0x0, n, 0,1,         4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+		ierr = func_mod_square(      a, 0x0, n, 0,1,         4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 		// mult[0] *= a[]: mult[0] holds result, thus is not fwd-FFTed (that is, in fwd-FFT-pass-1-done form) on entry;
 		// Since mult[0] holds pure-int copy of stage 1 residue A on loop entry, bit 0 of mode_flag = 0 for just its first use:
 		//                                                                                vvvvvvvv
-		ierr = func_mod_square(mult[0], 0x0, n, 0,1, (uint64)a + (uint64)(mode_flag - (j==3)), p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+		ierr = func_mod_square(mult[0], 0x0, n, 0,1, (uint64)a + (uint64)(mode_flag - (j==3)), p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 		if(ierr == ERR_INTERRUPT) {
 			return ierr;
 		}
@@ -1419,7 +1419,7 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 		}
 		// Up-multiply the fwd-FFT-pass-1-done(A^8,16,24,...) by fixed multiplier fwd-FFT(A^8):
 		// mult[2] = A^16,24,... :
-		ierr = func_mod_square(mult[2], 0x0, n, 0,1, (uint64)mult[1] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+		ierr = func_mod_square(mult[2], 0x0, n, 0,1, (uint64)mult[1] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 		if(ierr == ERR_INTERRUPT) {
 			return ierr;
 		}
@@ -1697,7 +1697,7 @@ MME = 0;
 	for(i = 0; i < m*num_b; i++) {
 		// Since buf[0] holds pure-int copy of stage 1 residue A on loop entry, bit 0 of mode_flag = 0 for just it:
 		//                                                                    vvvvvvvv
-		ierr = func_mod_square(buf[i], 0x0, n, 0,1, 4ull + (uint64)(mode_flag - (i==0)), p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+		ierr = func_mod_square(buf[i], 0x0, n, 0,1, 4ull + (uint64)(mode_flag - (i==0)), p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 	}	ASSERT(nerr == 0, "fwdFFT of buf[] entries returns error!");
 
 	// Accumulate the cycle count in a floating double on each pass to avoid problems
@@ -2014,11 +2014,11 @@ MME = 0;
 	}
 	nerr = 0;
 	// mult0-2 need to be fwdFFTed ... if using (p+1)-style multiplier scheme, mult[1] is already so:
-	ierr = func_mod_square(mult[0], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0);	nerr += ierr;
+	ierr = func_mod_square(mult[0], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0);	if(ierr) nerr |= 1<<ierr;
   #if !USE_PP1_MULTS
-	ierr = func_mod_square(mult[1], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+	ierr = func_mod_square(mult[1], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
   #endif
-	ierr = func_mod_square(mult[2], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+	ierr = func_mod_square(mult[2], 0x0, n, 0,1, 4ull + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 	if(nerr != 0) {
 		sprintf(cbuf,"Stage 2 loop-multipliers computation hit one or more fatal errors! Aborting.");
 		mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
@@ -2109,9 +2109,9 @@ MME = 0;
 				vec_double_sub(mult[0],buf[i],a,npad);	// a[] = (mult[0][] - buf[i][])
 			  #endif
 				// pow = pow*(mult[0] - buf[i]) % n: Don't increment nmodmul until after call due to ambiguity in eval order of func(i,++i):
-				ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)a       + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE,    0x0);	nerr += ierr;
+				ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)a       + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE,    0x0);	if(ierr) nerr |= 1<<ierr;
 			 #else
-				ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)mult[0] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, buf[i]); nerr += ierr;
+				ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)mult[0] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, buf[i]); if(ierr) nerr |= 1<<ierr;
 			 #endif
 				if(ierr == ERR_INTERRUPT) {
 					return ierr;
@@ -2162,9 +2162,9 @@ MME = 0;
 						vec_double_sub(mult[0],buf[tmp+j],a,npad);
 					  #endif
 						// pow = pow*(mult[0] - buf[tmp+j]) % n;
-						ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)a       + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE,        0x0); nerr += ierr;
+						ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)a       + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE,        0x0); if(ierr) nerr |= 1<<ierr;
 					 #else
-						ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)mult[0] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, buf[tmp+j]); nerr += ierr;
+						ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)mult[0] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, buf[tmp+j]); if(ierr) nerr |= 1<<ierr;
 					 #endif
 						if(ierr == ERR_INTERRUPT) {
 							return ierr;
@@ -2204,9 +2204,9 @@ MME = 0;
 						vec_double_sub(mult[0],buf[tmp+i],a,npad);
 					  #endif
 						// pow = pow*(mult[0] - buf[tmp+i]) % n:
-						ierr += func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)a       + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE,        0x0); nerr += ierr;
+						ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)a       + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE,        0x0); if(ierr) nerr |= 1<<ierr;
 					 #else
-						ierr += func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)mult[0] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, buf[tmp+i]); nerr += ierr;
+						ierr = func_mod_square(pow, 0x0, n, nmodmul,nmodmul+1, (uint64)mult[0] + (uint64)mode_flag, p, scrnFlag,&tdif2, FALSE, buf[tmp+i]); if(ierr) nerr |= 1<<ierr;
 					 #endif
 						if(ierr == ERR_INTERRUPT) {
 							return ierr;
@@ -2363,16 +2363,16 @@ MME = 0;
 		Since mult[0-2] all fwd-FFTed, this costs 2 x [dyadic-mul, inv-FFT, carry, fwd-FFT] = equivalent of 2 mod-squares.
 		*/
 			// Only increment nmodmul every 2nd call here, since each call is 1-FFT:
-/* [1a]: */	ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1, (uint64)mult[1] + 0xC + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+/* [1a]: */	ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1, (uint64)mult[1] + 0xC + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 			if(ierr == ERR_INTERRUPT) {
 				return ierr;
 			}
-/* [1b]: */	ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1,            4ull       + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
-/* [2a]: */	ierr = func_mod_square(mult[1], 0x0, n, nmodmul,nmodmul+1, (uint64)mult[2] + 0xC + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+/* [1b]: */	ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1,            4ull       + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
+/* [2a]: */	ierr = func_mod_square(mult[1], 0x0, n, nmodmul,nmodmul+1, (uint64)mult[2] + 0xC + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 			if(ierr == ERR_INTERRUPT) {
 				return ierr;
 			}
-/* [2b]: */	ierr = func_mod_square(mult[1], 0x0, n, nmodmul,nmodmul+1,            4ull       + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+/* [2b]: */	ierr = func_mod_square(mult[1], 0x0, n, nmodmul,nmodmul+1,            4ull       + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 			nmodmul += 2;
 
 		  #else	// USE_PP1_MULTS = True, needs just 1 modmul per D-loop:
@@ -2395,11 +2395,11 @@ MME = 0;
 			/******** For initial impl, use the sequence: ********/
 			memcpy(a,mult[0],nbytes);	// Save copy of V[n] = A^(k*D) + A^-(k*D) in a[];
 				// V[n] *= V[j] overwrites mult[0]:
-			ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1, (uint64)mult[2] + 0xC + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+			ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1, (uint64)mult[2] + 0xC + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 			if(ierr == ERR_INTERRUPT) {
 				return ierr;
 			}
-			ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1,            4ull       + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); nerr += ierr;
+			ierr = func_mod_square(mult[0], 0x0, n, nmodmul,nmodmul+1,            4ull       + mode_flag, p, scrnFlag,&tdif2, FALSE, 0x0); if(ierr) nerr |= 1<<ierr;
 			++nmodmul;
 				// Subtract mult[0] -= V[n-1], yielding V[n+1] = V[n]*V[j] - V[n-1];
 		  #ifdef MULTITHREAD
@@ -2423,8 +2423,10 @@ MME = 0;
 		clock2 = clock();	*tdiff += (double)(clock2 - clock1);	clock1 = clock2;
 	  #endif
 		// Only handle errs of type ROE in p-1 stage 2 - we prefer to handle such before doing any savefile-updating.
-		/*** If multiple errs/types per bigstep-loop ever become an issue, change modmul-retval handling to 'nerr |= 1<<ierr;'
-		and in stage-2-return-value-handling code check for various errtypes via e.g. 'if(ierr | (1<<ERR_ROUNDOFF))' ***/
+		/*** nerr is a bitmask, not a sum: each modmul call above sets bit ierr of nerr (via 'nerr |= 1<<ierr') rather
+		than adding ierr, so that 2 or more distinct error types (or repeats of the same type) hitting within a single
+		bigstep-loop pass cannot combine into an out-of-range composite value. Caller must decode the returned code by
+		testing individual bits, e.g. 'if(ierr & (1<<ERR_ROUNDOFF))', not via equality or modulo tests. ***/
 		if(nerr) {
 			retval = nerr; goto ERR_RETURN;
 		}


### PR DESCRIPTION
Fixes #49.

### Problem (#49)

P-1 stage 2 accumulates the per-modmul error code from each `func_mod_square` call into `nerr`. It did so by **adding**:

```c
ierr = func_mod_square(...); nerr += ierr;
```

The `ERR_*` codes are small distinct enum values (`Mdata.h`, `ERR_MAX = ERR_GERBICZ_CHECK = 16`). When two or more errors — of the same or different type — occur within a single bigstep-loop batch, their codes **sum into a meaningless composite** (e.g. two `ERR_CARRY` → 20). That value is then passed to `returnMlucasErrCode()`, which did:

```c
ASSERT(ierr < ERR_MAX, "Error code out of range!");
```

so an otherwise-recoverable run was killed by the diagnostic path. Ernst's own comment at `pm1.c` already predicted this and prescribed the fix.

### Fix

Adopt the prescribed **bitmask** scheme:

- **`pm1.c`** — every `nerr += ierr` becomes `if(ierr) nerr |= 1<<ierr`. Bit *k* is set iff error type *k* occurred at least once in the batch; the `if(ierr)` guard skips the no-error case (bit 0 would otherwise be set on every success).
- **`Mlucas.c` stage-2 return handling** — decode by **bit tests** instead of the old sum/modulo heuristic. The raw `ERR_INTERRUPT` scalar is checked **first** (it is returned unshifted, short-circuiting before any bitmask accumulation), then `1<<ERR_ROUNDOFF`, then a **new** `1<<ERR_CARRY` branch that retries from the most-recent savefile — mirroring the main PRP/LL loop's existing handling of that same residue-corruption error (see `Mlucas.c` main loop) — rather than aborting.
- **`returnMlucasErrCode()`** — return `"unknown/composite error code"` for any out-of-range value instead of asserting. This also corrects a **pre-existing off-by-one**: the old `ierr < ERR_MAX` test rejected the valid top code `ERR_GERBICZ_CHECK` (16); the array has `ERR_MAX` entries indexed `ierr-1`.

### Also fixed (latent, in scope)

The stage-2 "remaining q-singles" loop used `ierr += func_mod_square(...)` where the structurally identical sibling block uses `ierr =`. `ierr` is not reset between passes, so a stale nonzero code from an earlier pass kept accumulating — which under the new mask would set a bit for an error that never actually occurred that pass. Aligned it to `ierr =`.

### Encode/decode consistency

`pm1_stage2()` returns one of: `0` (success); a raw `ERR_INTERRUPT` (returned unshifted, before accumulation); a raw setup-failure sentinel `1` (cannot collide with any bitmask, since bit 0 is never set); or the accumulated bitmask. The decode side matches each shape — exact-match for the scalars, bit-tests for the mask. `modpow()` also uses the mask internally but returns only `(nerr != 0)`, and every caller ignores its return value, so that conversion is behavior-neutral.

### Underlying corruption

The *underlying* `ERR_CARRY` on F33 stage 2 (AVX-512) is a separate residue-corruption issue tracked with the AVX-512 clobber work (#52 / the AVX-512 clobber PR). This change fixes the **error-plumbing crash** that masked it and makes carry errors recoverable via savefile retry.

### Verification

- Diff-reviewed the full encode→decode path; confirmed `err_code[]` has exactly `ERR_MAX` entries (bounds-safe), the `ERR_*` values don't collide across the reordered branches, and `READ_RESTART_FILE` is a valid backward-goto target already used for `ERR_CARRY` in the main loop.
- Builds clean via `makemake.sh avx2`; the `USE_PP1_MULTS` branch (not built by default) also compiles cleanly with `-DUSE_PP1_MULTS`.