### PR TITLE
Fix threadpool_init partial-failure cleanup joining never-created threads (OOM SIGSEGV)

### DIFF
--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -644,11 +644,11 @@ me at: heber.tomer@gmail.com
 		}
 
 		/* Start the worker threads. */
+		pool->num_of_threads = 0;
+		pool->num_of_cores = num_cores;
+
 		for (i = 0; i < num_threads; i++)
 		{
-			pool->num_of_threads = num_threads;
-			pool->num_of_cores = num_cores;
-
 			pool->thr_init[i].thread_num = i;
 			pool->thr_init[i].pool = pool;
 			pool->thr_init[i].control = *t;
@@ -661,6 +661,11 @@ me at: heber.tomer@gmail.com
 				threadpool_free(pool);
 				return NULL;
 			}
+
+			/* Only count a thread once it has actually been created, so that if a
+			 * later pthread_create() call fails, threadpool_free() joins just the
+			 * threads that exist rather than walking uninitialized thr_arr slots. */
+			pool->num_of_threads = i + 1;
 		}
 
 		// Set CPU affinity masks of the threads:


### PR DESCRIPTION
### Problem

`threadpool_init()` in `src/threadpool.c`:
- allocates `thr_arr` with `malloc` (so the `pthread_t` handles start uninitialized), and
- sets `pool->num_of_threads = num_threads` (the full requested count) on the **first** iteration of the worker-creation loop, before the threads are actually created.

If a `pthread_create()` call fails partway through the loop (e.g. `ENOMEM` under memory pressure), the failure branch calls `threadpool_free()`, whose join loop

```c
for (i = 0; i < pool->num_of_threads; i++)
    pthread_join(pool->thr_arr[i], NULL);
```

then walks the **uninitialized** `thr_arr` slots for the never-created threads and calls `pthread_join()` on garbage handles → **SIGSEGV**.

So a recoverable thread-spawn failure — which callers already guard with `ASSERT(0x0 != threadpool_init(...))` — crashed with a wild segfault instead of aborting cleanly.

### Fix

Count threads only once they actually exist: initialize `num_of_threads = 0` before the loop and set it to `i + 1` after each **successful** `pthread_create` (and set `num_of_cores` once, outside the loop, since it never varied per iteration). On the success path `num_of_threads` still ends at `num_threads`; on partial failure it reflects the real created count, so `threadpool_free` joins only threads that exist. Already-created workers tear down safely — the task queues and mutex/cond vars are initialized *before* the creation loop, and `threadpool_free` sets `stop_flag`, broadcasts, then joins.

### Verification

A/B under `ulimit -v 120000` with `-s tt -cpu "0:15"`, which reliably forces a mid-loop `pthread_create` ENOMEM:

| | exit | behavior |
|---|---|---|
| **before** | 139 | SIGSEGV immediately after `pthread_create:: Cannot allocate memory` |
| **after** | 134 | clean SIGABRT: `threadpool_init failed!` via the caller's assertion |

Normal multithreaded self-test (`-s tt -cpu "0:3"`) unaffected. `threadpool.c` only.

Found during OOM testing for the checked-allocation work (#51 / #88).