### PR TITLE
Bound cbuf writes and replace hardcoded cbuf sizes with sizeof(cbuf)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -881,7 +881,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		if(TEST_TYPE == TEST_TYPE_TF) {
 			/* Currently TF only supported for Mersennes: */
 			if(MODULUS_TYPE != MODULUS_TYPE_MERSENNE) {
-				sprintf(cbuf, "ERROR: Trial-factoring Currently only supported for Mersenne numbers. The ini file entry was %s\n",g_in_line);
+				snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Trial-factoring Currently only supported for Mersenne numbers. The ini file entry was %s\n",g_in_line);
 				fprintf(stderr,"%s",cbuf);
 				goto GET_NEXT_ASSIGNMENT;
 			}
@@ -912,12 +912,12 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 			if(char_addr++) {
 				bit_depth_todo = strtoul(char_addr, &endp, 10);
 				if(bit_depth_todo > MAX_FACT_BITS) {
-					sprintf(cbuf, "ERROR: factor-to bit_depth of %u > max. allowed of %u. The ini file entry was %s\n",TF_BITS,MAX_FACT_BITS,g_in_line);
+					snprintf(cbuf, STR_MAX_LEN*2, "ERROR: factor-to bit_depth of %u > max. allowed of %u. The ini file entry was %s\n",TF_BITS,MAX_FACT_BITS,g_in_line);
 					fprintf(stderr,"%s",cbuf);
 					goto GET_NEXT_ASSIGNMENT;
 				}
 				else if(bit_depth_todo <= TF_BITS) {
-					sprintf(cbuf, "ERROR: factor-to bit_depth of %u < already-done depth of %u. The ini file entry was %s\n",TF_BITS,TF_BITS,g_in_line);
+					snprintf(cbuf, STR_MAX_LEN*2, "ERROR: factor-to bit_depth of %u < already-done depth of %u. The ini file entry was %s\n",TF_BITS,TF_BITS,g_in_line);
 					fprintf(stderr,"%s",cbuf);
 					goto GET_NEXT_ASSIGNMENT;
 				}
@@ -931,7 +931,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		}
 		else if(nbits_in_p > MAX_PRIMALITY_TEST_BITS)
 		{
-			sprintf(cbuf, "ERROR: Inputs this large only permitted for trial-factoring. The ini file entry was %s\n",g_in_line);
+			snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Inputs this large only permitted for trial-factoring. The ini file entry was %s\n",g_in_line);
 			fprintf(stderr,"%s",cbuf);
 			goto GET_NEXT_ASSIGNMENT;
 		}
@@ -3464,7 +3464,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 		sprintf(cbuf,"This cofactor is COMPOSITE [C%u]. Checking prime-power-ness via GCD(A - B,C) ... \n",i); mlucas_fprint(cbuf,1);
 		i = gcd(0,0ull,ai,ci,j,gcd_str);	// 1st arg = stage of (p-1 or ecm) just completed, does not apply here
 		if(i)
-			sprintf(cbuf,"Cofactor is a prime power! GCD(A - B,C) = %s.\n",gcd_str);
+			snprintf(cbuf, STR_MAX_LEN*2, "Cofactor is a prime power! GCD(A - B,C) = %s.\n",gcd_str);
 		else
 			sprintf(cbuf,"Cofactor is not a prime power.\n");
 		mlucas_fprint(cbuf,1);
@@ -6414,7 +6414,7 @@ uint32 extract_known_factors(uint64 p, char *fac_start) {
 		cptr = char_addr+1;	// Advance 1-char past the current , or "
 	}
 	if(char_addr != 0x0) {
-		sprintf(cbuf,"%s: Unrecognized token sequence in parsing known-factors portion of assignment: \"%s\".",WORKFILE,fac_start);	ASSERT(0,cbuf);
+		snprintf(cbuf, STR_MAX_LEN*2, "%s: Unrecognized token sequence in parsing known-factors portion of assignment: \"%s\".",WORKFILE,fac_start);	ASSERT(0,cbuf);
 	}
 	ASSERT(nfac != 0,"Must specify at least one known factor!");
 // A bit of just-for-fun code: For smaller moduli N, use mi64 utils to see if cofactor C is a base-3 PRP:
@@ -6685,7 +6685,7 @@ uint32 filegrep(const char *fname, const char *find_str, char *p_cstr, uint32 fi
 		}
 		fclose(fptr);
 	} else {
-		sprintf(cbuf,"filegrep error: file %s not found.\n",fname);
+		snprintf(cbuf, STR_MAX_LEN*2, "filegrep error: file %s not found.\n",fname);
 		ASSERT(0, cbuf);
 	}
 	if(strlen(p_cstr) != 0)

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -881,7 +881,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		if(TEST_TYPE == TEST_TYPE_TF) {
 			/* Currently TF only supported for Mersennes: */
 			if(MODULUS_TYPE != MODULUS_TYPE_MERSENNE) {
-				snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Trial-factoring Currently only supported for Mersenne numbers. The ini file entry was %s\n",g_in_line);
+				snprintf(cbuf, sizeof(cbuf), "ERROR: Trial-factoring Currently only supported for Mersenne numbers. The ini file entry was %s\n",g_in_line);
 				fprintf(stderr,"%s",cbuf);
 				goto GET_NEXT_ASSIGNMENT;
 			}
@@ -912,12 +912,12 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 			if(char_addr++) {
 				bit_depth_todo = strtoul(char_addr, &endp, 10);
 				if(bit_depth_todo > MAX_FACT_BITS) {
-					snprintf(cbuf, STR_MAX_LEN*2, "ERROR: factor-to bit_depth of %u > max. allowed of %u. The ini file entry was %s\n",TF_BITS,MAX_FACT_BITS,g_in_line);
+					snprintf(cbuf, sizeof(cbuf), "ERROR: factor-to bit_depth of %u > max. allowed of %u. The ini file entry was %s\n",TF_BITS,MAX_FACT_BITS,g_in_line);
 					fprintf(stderr,"%s",cbuf);
 					goto GET_NEXT_ASSIGNMENT;
 				}
 				else if(bit_depth_todo <= TF_BITS) {
-					snprintf(cbuf, STR_MAX_LEN*2, "ERROR: factor-to bit_depth of %u < already-done depth of %u. The ini file entry was %s\n",TF_BITS,TF_BITS,g_in_line);
+					snprintf(cbuf, sizeof(cbuf), "ERROR: factor-to bit_depth of %u < already-done depth of %u. The ini file entry was %s\n",TF_BITS,TF_BITS,g_in_line);
 					fprintf(stderr,"%s",cbuf);
 					goto GET_NEXT_ASSIGNMENT;
 				}
@@ -931,7 +931,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		}
 		else if(nbits_in_p > MAX_PRIMALITY_TEST_BITS)
 		{
-			snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Inputs this large only permitted for trial-factoring. The ini file entry was %s\n",g_in_line);
+			snprintf(cbuf, sizeof(cbuf), "ERROR: Inputs this large only permitted for trial-factoring. The ini file entry was %s\n",g_in_line);
 			fprintf(stderr,"%s",cbuf);
 			goto GET_NEXT_ASSIGNMENT;
 		}
@@ -3464,7 +3464,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 		sprintf(cbuf,"This cofactor is COMPOSITE [C%u]. Checking prime-power-ness via GCD(A - B,C) ... \n",i); mlucas_fprint(cbuf,1);
 		i = gcd(0,0ull,ai,ci,j,gcd_str);	// 1st arg = stage of (p-1 or ecm) just completed, does not apply here
 		if(i)
-			snprintf(cbuf, STR_MAX_LEN*2, "Cofactor is a prime power! GCD(A - B,C) = %s.\n",gcd_str);
+			snprintf(cbuf, sizeof(cbuf), "Cofactor is a prime power! GCD(A - B,C) = %s.\n",gcd_str);
 		else
 			sprintf(cbuf,"Cofactor is not a prime power.\n");
 		mlucas_fprint(cbuf,1);
@@ -6414,7 +6414,7 @@ uint32 extract_known_factors(uint64 p, char *fac_start) {
 		cptr = char_addr+1;	// Advance 1-char past the current , or "
 	}
 	if(char_addr != 0x0) {
-		snprintf(cbuf, STR_MAX_LEN*2, "%s: Unrecognized token sequence in parsing known-factors portion of assignment: \"%s\".",WORKFILE,fac_start);	ASSERT(0,cbuf);
+		snprintf(cbuf, sizeof(cbuf), "%s: Unrecognized token sequence in parsing known-factors portion of assignment: \"%s\".",WORKFILE,fac_start);	ASSERT(0,cbuf);
 	}
 	ASSERT(nfac != 0,"Must specify at least one known factor!");
 // A bit of just-for-fun code: For smaller moduli N, use mi64 utils to see if cofactor C is a base-3 PRP:
@@ -6685,7 +6685,7 @@ uint32 filegrep(const char *fname, const char *find_str, char *p_cstr, uint32 fi
 		}
 		fclose(fptr);
 	} else {
-		snprintf(cbuf, STR_MAX_LEN*2, "filegrep error: file %s not found.\n",fname);
+		snprintf(cbuf, sizeof(cbuf), "filegrep error: file %s not found.\n",fname);
 		ASSERT(0, cbuf);
 	}
 	if(strlen(p_cstr) != 0)

--- a/src/factor.c
+++ b/src/factor.c
@@ -1318,7 +1318,7 @@ exit(0);
 	// Note: return value of read_savefile is signed:
 	itmp = read_savefile(RESTARTFILE, pstring, &bmin_file,&bmax_file, &kmin_file,&know_file,&kmax_file, &passmin_file,&passnow_file,&passmax_file, &count);
 	if(itmp == -1) {
-		snprintf(cbuf, STR_MAX_LEN*2, "INFO: No factoring savefile %s found ... starting from scratch.\n",RESTARTFILE);
+		snprintf(cbuf, sizeof(cbuf), "INFO: No factoring savefile %s found ... starting from scratch.\n",RESTARTFILE);
 		fprintf(stderr,"%s",cbuf);
 	#ifndef FACTOR_STANDALONE
 		fq = mlucas_fopen(STATFILE,"a"); fprintf(fq,"%s",cbuf); fclose(fq); fq = 0x0;
@@ -2776,7 +2776,7 @@ MFACTOR_HELP:
 
 			/* bmin */
 			++curr_line;
-			if(!fgets(cbuf, STR_MAX_LEN*2, fp)) {
+			if(!fgets(cbuf, sizeof(cbuf), fp)) {
 				fprintf(stderr,"ERROR: unable to read Line %d (bmin) of factoring restart file %s!\n", curr_line, RESTARTFILE);		ASSERT(0,"0");
 			}
 			itmp = sscanf(cbuf, "%lf", &bmin_file);
@@ -2786,7 +2786,7 @@ MFACTOR_HELP:
 
 			/* bmax */
 			++curr_line;
-			if(!fgets(cbuf, STR_MAX_LEN*2, fp)) {
+			if(!fgets(cbuf, sizeof(cbuf), fp)) {
 				fprintf(stderr,"ERROR: unable to read Line %d (bmax) of factoring restart file %s!\n", curr_line, RESTARTFILE);		ASSERT(0,"0");
 			}
 			itmp = sscanf(cbuf, "%lf", &bmax_file);
@@ -3369,14 +3369,14 @@ MFACTOR_HELP:
 							mi64_clear(u64_arr, lenQ);	// Use q2 for quotient [i.e. factor-candidate k] and u64_arr for remainder
 							mi64_div(q,two_p,lenQ,lenQ,q2,u64_arr);
 							if(mi64_getlen(q2, lenQ) != 1) {
-								snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: k must be 64-bit!\n",
+								snprintf(cbuf, sizeof(cbuf), "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: k must be 64-bit!\n",
 									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
 								ASSERT(0, cbuf);
 							}
 							if(!mi64_cmp_eq_scalar(u64_arr, 1ull, lenQ))
 							{
-								snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: q mod (2p) = %s != 1!\n",
+								snprintf(cbuf, sizeof(cbuf), "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: q mod (2p) = %s != 1!\n",
 									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)],
 									&cbuf2[convert_mi64_base10_char(cbuf2, u64_arr, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
@@ -3405,7 +3405,7 @@ MFACTOR_HELP:
 										printf("%" PRIu64 " has a small divisor: %u\n",q[0], l);
 										ASSERT(0, "Abort...");
 									#else
-										snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s has a small divisor: %u\n",
+										snprintf(cbuf, sizeof(cbuf), "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s has a small divisor: %u\n",
 											(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)],l);
 										fprintf(fp,"%s", cbuf);
 										ASSERT(0, cbuf);
@@ -3796,16 +3796,16 @@ MFACTOR_HELP:
 										if(mi64_pprimeF(q, 3ull, lenQ)) {
 											factor_k[(*nfactor)++] = k_to_try[l];
 											if(MODULUS_TYPE == MODULUS_TYPE_FERMAT)
-												snprintf(cbuf, STR_MAX_LEN*2, "\n\tFactor found: q = %s = 2^(%u+2)*%" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],findex,k_to_try[l]/2);
+												snprintf(cbuf, sizeof(cbuf), "\n\tFactor found: q = %s = 2^(%u+2)*%" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],findex,k_to_try[l]/2);
 											else
-												snprintf(cbuf, STR_MAX_LEN*2, "\n\tFactor found: q = %s = 2*p*k + 1 with k = %" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],k_to_try[l]);
+												snprintf(cbuf, sizeof(cbuf), "\n\tFactor found: q = %s = 2*p*k + 1 with k = %" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],k_to_try[l]);
 										#ifdef FAC_DEBUG
 											if(TRYQM1 > 1)
 												printf("factor was number %u of 0-%u in current batch.\n", l, TRYQM1);
 										#endif
 										} else {	// Composite factor; this should only occur in "single-word" (q < 2^96) mode:
 											if(known_factor_div_check_done) {	// Already divided out all pvsly-found factors
-												snprintf(cbuf, STR_MAX_LEN*2, "\n\tComposite Factor found: q = %s; you will have to factor this one separately.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)]);
+												snprintf(cbuf, sizeof(cbuf), "\n\tComposite Factor found: q = %s; you will have to factor this one separately.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)]);
 											} else {
 												printf("\n\tComposite Factor found: q = %s; checking if any previously-found ones divide it...\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)]);
 												for(j = 0; j < *nfactor; j++) {
@@ -4445,7 +4445,7 @@ uint64*kmin, uint64*know, uint64*kmax, uint32*passmin, uint32*passnow, uint32*pa
 	if(!fp) {
 		return -1;
 	} else {
-		snprintf(cbuf, STR_MAX_LEN*2, "Factoring savefile %s found ... reading ...\n",fname);
+		snprintf(cbuf, sizeof(cbuf), "Factoring savefile %s found ... reading ...\n",fname);
 		fprintf(stderr,"%s",cbuf);
 	#ifndef FACTOR_STANDALONE
 		fq = mlucas_fopen(STATFILE,"a"); fprintf(fq,"%s",cbuf); fclose(fq); fq = 0x0;

--- a/src/factor.c
+++ b/src/factor.c
@@ -1318,7 +1318,7 @@ exit(0);
 	// Note: return value of read_savefile is signed:
 	itmp = read_savefile(RESTARTFILE, pstring, &bmin_file,&bmax_file, &kmin_file,&know_file,&kmax_file, &passmin_file,&passnow_file,&passmax_file, &count);
 	if(itmp == -1) {
-		sprintf(cbuf,"INFO: No factoring savefile %s found ... starting from scratch.\n",RESTARTFILE);
+		snprintf(cbuf, STR_MAX_LEN*2, "INFO: No factoring savefile %s found ... starting from scratch.\n",RESTARTFILE);
 		fprintf(stderr,"%s",cbuf);
 	#ifndef FACTOR_STANDALONE
 		fq = mlucas_fopen(STATFILE,"a"); fprintf(fq,"%s",cbuf); fclose(fq); fq = 0x0;
@@ -3369,14 +3369,14 @@ MFACTOR_HELP:
 							mi64_clear(u64_arr, lenQ);	// Use q2 for quotient [i.e. factor-candidate k] and u64_arr for remainder
 							mi64_div(q,two_p,lenQ,lenQ,q2,u64_arr);
 							if(mi64_getlen(q2, lenQ) != 1) {
-								sprintf(cbuf, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: k must be 64-bit!\n",
+								snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: k must be 64-bit!\n",
 									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
 								ASSERT(0, cbuf);
 							}
 							if(!mi64_cmp_eq_scalar(u64_arr, 1ull, lenQ))
 							{
-								sprintf(cbuf, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: q mod (2p) = %s != 1!\n",
+								snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s: q mod (2p) = %s != 1!\n",
 									(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)],
 									&cbuf2[convert_mi64_base10_char(cbuf2, u64_arr, lenQ, 0)]);
 								fprintf(fp,"%s", cbuf);
@@ -3405,7 +3405,7 @@ MFACTOR_HELP:
 										printf("%" PRIu64 " has a small divisor: %u\n",q[0], l);
 										ASSERT(0, "Abort...");
 									#else
-										sprintf(cbuf, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s has a small divisor: %u\n",
+										snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Count = %u * 2^%u: k = %" PRIu64 ", Current q = %s has a small divisor: %u\n",
 											(uint32)(count >> CMASKBITS),CMASKBITS,k,&cbuf[convert_mi64_base10_char(cbuf, q, lenQ, 0)],l);
 										fprintf(fp,"%s", cbuf);
 										ASSERT(0, cbuf);
@@ -3796,16 +3796,16 @@ MFACTOR_HELP:
 										if(mi64_pprimeF(q, 3ull, lenQ)) {
 											factor_k[(*nfactor)++] = k_to_try[l];
 											if(MODULUS_TYPE == MODULUS_TYPE_FERMAT)
-												sprintf(cbuf,"\n\tFactor found: q = %s = 2^(%u+2)*%" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],findex,k_to_try[l]/2);
+												snprintf(cbuf, STR_MAX_LEN*2, "\n\tFactor found: q = %s = 2^(%u+2)*%" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],findex,k_to_try[l]/2);
 											else
-												sprintf(cbuf,"\n\tFactor found: q = %s = 2*p*k + 1 with k = %" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],k_to_try[l]);
+												snprintf(cbuf, STR_MAX_LEN*2, "\n\tFactor found: q = %s = 2*p*k + 1 with k = %" PRIu64 ". This factor is a probable prime.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)],k_to_try[l]);
 										#ifdef FAC_DEBUG
 											if(TRYQM1 > 1)
 												printf("factor was number %u of 0-%u in current batch.\n", l, TRYQM1);
 										#endif
 										} else {	// Composite factor; this should only occur in "single-word" (q < 2^96) mode:
 											if(known_factor_div_check_done) {	// Already divided out all pvsly-found factors
-												sprintf(cbuf,"\n\tComposite Factor found: q = %s; you will have to factor this one separately.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)]);
+												snprintf(cbuf, STR_MAX_LEN*2, "\n\tComposite Factor found: q = %s; you will have to factor this one separately.\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)]);
 											} else {
 												printf("\n\tComposite Factor found: q = %s; checking if any previously-found ones divide it...\n",&g_cstr[convert_mi64_base10_char(g_cstr, q, lenQ, 0)]);
 												for(j = 0; j < *nfactor; j++) {
@@ -4445,7 +4445,7 @@ uint64*kmin, uint64*know, uint64*kmax, uint32*passmin, uint32*passnow, uint32*pa
 	if(!fp) {
 		return -1;
 	} else {
-		sprintf(cbuf,"Factoring savefile %s found ... reading ...\n",fname);
+		snprintf(cbuf, STR_MAX_LEN*2, "Factoring savefile %s found ... reading ...\n",fname);
 		fprintf(stderr,"%s",cbuf);
 	#ifndef FACTOR_STANDALONE
 		fq = mlucas_fopen(STATFILE,"a"); fprintf(fq,"%s",cbuf); fclose(fq); fq = 0x0;

--- a/src/get_preferred_fft_radix.c
+++ b/src/get_preferred_fft_radix.c
@@ -127,14 +127,14 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 						ASSERT(tcurr >= 0, "tcurr < 0!");
 						if((tbest == 0.0) || ((tcurr > 0.0) && (tcurr < tbest))) {
 							if((char_addr = strstr(g_in_line, "radices =")) == 0x0) {
-								snprintf(cbuf,STR_MAX_LEN*2,"get_preferred_fft_radix: invalid format for %s file: 'radices =' not found in timing-data line %s", CONFIGFILE, g_in_line);
+								snprintf(cbuf, sizeof(cbuf),"get_preferred_fft_radix: invalid format for %s file: 'radices =' not found in timing-data line %s", CONFIGFILE, g_in_line);
 								ASSERT(0, cbuf);
 							}
 							char_addr += 9;	// 9 chars in "radices ="
 							kprod = 1;	/* accumulate product of radices */
 							for(j = 0; j < 10; j++) {	/* Read in the radices */
 								if(sscanf(char_addr, "%d", &k) != 1) {
-									snprintf(cbuf,STR_MAX_LEN*2,"get_preferred_fft_radix: invalid format for %s file: failed to read %dth element of radix set, offending input line %s", CONFIGFILE, j, g_in_line);
+									snprintf(cbuf, sizeof(cbuf),"get_preferred_fft_radix: invalid format for %s file: failed to read %dth element of radix set, offending input line %s", CONFIGFILE, j, g_in_line);
 									ASSERT(0, cbuf);
 								} else {
 									// Advance to next WS char following the current numeric token - since sscanf skips leading WS,
@@ -184,7 +184,7 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 							*/
 							kprod *= 2;
 							if((kprod & 1023) != 0) {
-								snprintf(cbuf,STR_MAX_LEN*2,"get_preferred_fft_radix: illegal data in %s file: product of complex radices (%d) not a multiple of 1K! Offending input line %s", CONFIGFILE, kprod, g_in_line);
+								snprintf(cbuf, sizeof(cbuf),"get_preferred_fft_radix: illegal data in %s file: product of complex radices (%d) not a multiple of 1K! Offending input line %s", CONFIGFILE, kprod, g_in_line);
 								ASSERT(0, cbuf);
 							}
 							kprod >>= 10;
@@ -192,7 +192,7 @@ uint32	get_preferred_fft_radix(uint32 kblocks)
 							if(i == kblocks) {
 								/* Product of radices must equal complex vector length (n/2): */
 								if(kprod != kblocks) {
-									snprintf(cbuf,STR_MAX_LEN*2,"get_preferred_fft_radix: mismatching data in %s file: (product of complex radices)/2^10 (%d) != kblocks/2 (%d), offending input line %s", CONFIGFILE, kprod, kblocks/2, g_in_line);
+									snprintf(cbuf, sizeof(cbuf),"get_preferred_fft_radix: mismatching data in %s file: (product of complex radices)/2^10 (%d) != kblocks/2 (%d), offending input line %s", CONFIGFILE, kprod, kblocks/2, g_in_line);
 									ASSERT(0, cbuf);
 								}
 								retval = i;			/* Preferred FFT length */

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -2519,7 +2519,7 @@ S2_RETURN:
 #endif
 	// (k - k0) = #bigstep-blocks (passes thru above loop) used in stage 2; np + ns + 2*(k - k0) = #modmul:
 	nmodmul = np + ns + 2*(k - k0);	// This is actually redundant, but just to spell it out
-	snprintf(cbuf, sizeof(cbuf),"M = %2u: #buf = %4u, #pairs: %u, #single: %u (%5.2f%% paired), #blocks: %u, #modmul: %u\n",m,m*num_b,np,ns,100.0*2*np/(2*np+ns),k-k0,nmodmul);
+	snprintf(cbuf,STR_MAX_LEN*2,"M = %2u: #buf = %4u, #pairs: %u, #single: %u (%5.2f%% paired), #blocks: %u, #modmul: %u\n",m,m*num_b,np,ns,100.0*2*np/(2*np+ns),k-k0,nmodmul);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 #ifndef PM1_STANDALONE
 

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -393,7 +393,7 @@ uint32 compute_pm1_s1_product(const uint64 p) {
   #ifndef PM1_STANDALONE
 		// Write result to savefile:
 		if(!write_pm1_s1_prod(savefile, p, PM1_S1_PROD_BITS, PM1_S1_PRODUCT, PM1_S1_PROD_RES64)) {
-			snprintf(cbuf,STR_MAX_LEN*2,"WARN: Unable to write precomputed/bit-reversed Stage 1 prime-powers product to savefile %s.\n",savefile);
+			snprintf(cbuf, sizeof(cbuf),"WARN: Unable to write precomputed/bit-reversed Stage 1 prime-powers product to savefile %s.\n",savefile);
 			mlucas_fprint(cbuf,pm1_standlone+1);
 		}
 	} 	// endif(read_pm1_s1_prod)
@@ -546,7 +546,7 @@ PM1_S1P_READ_RETURN:
 
 		FILE*fptr = mlucas_fopen(fname, "wb");
 		if(!fptr) {
-			snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Unable to open precomputed p-1 stage 1 primes-product file %s for writing.\n",fname);
+			snprintf(cbuf, sizeof(cbuf), "ERROR: Unable to open precomputed p-1 stage 1 primes-product file %s for writing.\n",fname);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0, cbuf);
 		}
 		fprintf(stderr,"INFO: Opened precomputed p-1 stage 1 primes-product file %s for writing...\n",fname);
@@ -1470,14 +1470,14 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 			if(strstr(cbuf, "read_ppm1_savefiles"))
 				mlucas_fprint(cbuf,pm1_standlone+1);
 			// And now for the official spokesmessage:
-			snprintf(cbuf,STR_MAX_LEN*2, "Read of stage 1 residue-inverse savefile %s failed for reasons unknown. Computing inverse...\n",inv_file);
+			snprintf(cbuf, sizeof(cbuf), "Read of stage 1 residue-inverse savefile %s failed for reasons unknown. Computing inverse...\n",inv_file);
 			mlucas_fprint(cbuf,pm1_standlone+1);
 		} else {
 			s1_inverse = TRUE;
 		}
 	}
 	if(!s1_inverse) {
-		snprintf(cbuf,STR_MAX_LEN*2, "Stage 2: Computing mod-inverse of Stage 1 residue...\n");	mlucas_fprint(cbuf,pm1_standlone+1);
+		snprintf(cbuf, sizeof(cbuf), "Stage 2: Computing mod-inverse of Stage 1 residue...\n");	mlucas_fprint(cbuf,pm1_standlone+1);
 		modinv(p,vec1,vec2,nlimb);	// Result in vec2
 		Res64 = vec2[0];
 		Res35m1 = mi64_div_by_scalar64(vec2,two35m1,nlimb,0x0);
@@ -1488,7 +1488,7 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 			write_ppm1_savefiles(inv_file,p,n,fp, 0ull, (uint8*)vec2,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
 			fclose(fp);	fp = 0x0;
 		} else {
-			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: unable to open restart file %s for write of checkpoint data.\n",inv_file);
+			snprintf(cbuf, sizeof(cbuf), "ERROR: unable to open restart file %s for write of checkpoint data.\n",inv_file);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 		}
 	}
@@ -1732,7 +1732,7 @@ MME = 0;
 	clock2 = getRealTime();
   #endif
 	*tdiff = clock2 - clock1; clock1 = clock2;
-	snprintf(cbuf,STR_MAX_LEN*2, "Buffer-init done; clocks =%s, MaxErr = %10.9f.\n",get_time_str(*tdiff), MME);
+	snprintf(cbuf, sizeof(cbuf), "Buffer-init done; clocks =%s, MaxErr = %10.9f.\n",get_time_str(*tdiff), MME);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 
 	/********************* RESTART FILE STUFF: **********************/
@@ -1763,9 +1763,9 @@ MME = 0;
 			}
 			// If nsquares > B2_start, arrtmp holds the S2 interim residue for q = nsquares; set up to restart S2 at that point.
 			if(qlo >= B2_start) {
-				snprintf(cbuf,STR_MAX_LEN*2, "Read stage 2 savefile %s ... restarting stage 2 from q = %" PRIu64 ".\n",savefile,qlo);
+				snprintf(cbuf, sizeof(cbuf), "Read stage 2 savefile %s ... restarting stage 2 from q = %" PRIu64 ".\n",savefile,qlo);
 			} else {	// If user running a new partial S2 interval with bounds larger than a previous S2 run, allow but info-print to that effect:
-				snprintf(cbuf,STR_MAX_LEN*2, "INFO: %s savefile has qlo[%" PRIu64 "] <= B2_start[%" PRIu64 "] ... Stage 2 interval will skip intervening primes.\n",func,qlo,B2_start);
+				snprintf(cbuf, sizeof(cbuf), "INFO: %s savefile has qlo[%" PRIu64 "] <= B2_start[%" PRIu64 "] ... Stage 2 interval will skip intervening primes.\n",func,qlo,B2_start);
 			}
 			mlucas_fprint(cbuf,pm1_standlone+1);
 			restart = TRUE;
@@ -1837,7 +1837,7 @@ MME = 0;
 	*/
 	// At this point pow = A[stage 1 residue]; need either A^(D^2) or (A^D + A^-D), where D = bigstep:
 #ifndef PM1_STANDALONE
-	snprintf(cbuf,STR_MAX_LEN*2, "Computing Stage 2 loop-multipliers...\n");	mlucas_fprint(cbuf,pm1_standlone+1);
+	snprintf(cbuf, sizeof(cbuf), "Computing Stage 2 loop-multipliers...\n");	mlucas_fprint(cbuf,pm1_standlone+1);
 	MME = 0.0;	// Reset maxROE
 	// Raise A to power D^2, using mult[0] as a scratch array; again crap-API forces us to specify an "input is pure-int?" flag:
 	input_is_int = TRUE;
@@ -2014,7 +2014,7 @@ MME = 0;
 
 	if(restart) {	// If restart, convert bytewise-residue S2 accumulator read from file to floating-point form:
 		if(!convert_res_bytewise_FP((uint8*)arrtmp, pow, n, p)) {
-			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: convert_res_bytewise_FP Failed on primality-test residue read from savefile %s!\n",savefile);
+			snprintf(cbuf, sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on primality-test residue read from savefile %s!\n",savefile);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 		}
 		// Restart-file-read S2 interim residue in pow[] needs fwd-weight and FFT-pass1-done:
@@ -2027,7 +2027,7 @@ MME = 0;
 	   #if 0	// A: No, because pow = A^(k0*D) + A^-(k0*D) is perfectly fine as S2 init-accumulator
 		vec1[nlimb-1] = 0ull;
 		if(!convert_res_bytewise_FP((uint8*)vec1, pow, n, p)) {
-			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: convert_res_bytewise_FP Failed on S1 residue in vec1!\n");
+			snprintf(cbuf, sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on S1 residue in vec1!\n");
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 		}
 		// Pure-int S1 residue in pow[] needs fwd-weight and FFT-pass1-done:
@@ -2053,7 +2053,7 @@ MME = 0;
 	clock2 = getRealTime();
   #endif
 	*tdiff = clock2 - clock1; clock1 = clock2;
-	snprintf(cbuf,STR_MAX_LEN*2, "Stage 2 loop-multipliers: clocks =%s, MaxErr = %10.9f.\n",get_time_str(*tdiff), MME);
+	snprintf(cbuf, sizeof(cbuf), "Stage 2 loop-multipliers: clocks =%s, MaxErr = %10.9f.\n",get_time_str(*tdiff), MME);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 	*tdiff = AME = MME = 0.0;	// Reset timer and maxROE, now also init AvgROE
 	AME_ITER_START = 0;	// For p-1 stage 2, start collecting AvgROE data immediately, no need t wait for residue to "fill in"
@@ -2474,7 +2474,7 @@ MME = 0;
 			strftime(timebuffer,SIZE,"%Y-%m-%d %H:%M:%S",local_time);
 			AME /= (nmodmul - nmodmul_save);
 			// Print [date in hh:mm:ss | p | stage progress | %-complete | time | per-iter time | Res64 | max ROE:
-			snprintf(cbuf,STR_MAX_LEN*2, "[%s] %s %s = %" PRIu64 " [%5.2f%% complete] clocks =%s [%8.4f msec/iter] Res64: %016" PRIX64 ". AvgMaxErr = %10.9f. MaxErr = %10.9f.\n"
+			snprintf(cbuf, sizeof(cbuf), "[%s] %s %s = %" PRIu64 " [%5.2f%% complete] clocks =%s [%8.4f msec/iter] Res64: %016" PRIX64 ". AvgMaxErr = %10.9f. MaxErr = %10.9f.\n"
 				, timebuffer, PSTRING, "S2 at q", q+bigstep, (float)(q-B2_start)/(float)(B2-B2_start) * 100,get_time_str(*tdiff)
 				, 1000*get_time(*tdiff)/(nmodmul - nmodmul_save), Res64, AME, MME);
 			mlucas_fprint(cbuf,pm1_standlone+scrnFlag);
@@ -2486,7 +2486,7 @@ MME = 0;
 				write_ppm1_savefiles(savefile,p,n,fp, ((uint64)psmall<<56) + q + bigstep, (uint8*)arrtmp,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
 				fclose(fp);	fp = 0x0;
 			} else {
-				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: unable to open restart file %s for write of checkpoint data.\n",savefile);
+				snprintf(cbuf, sizeof(cbuf), "ERROR: unable to open restart file %s for write of checkpoint data.\n",savefile);
 				mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
 			}
 			// If interim-GCDs enabled (default) and latest S2 interval crossed a 10M mark, take a GCD; if factor found, early-return;
@@ -2519,7 +2519,7 @@ S2_RETURN:
 #endif
 	// (k - k0) = #bigstep-blocks (passes thru above loop) used in stage 2; np + ns + 2*(k - k0) = #modmul:
 	nmodmul = np + ns + 2*(k - k0);	// This is actually redundant, but just to spell it out
-	snprintf(cbuf,STR_MAX_LEN*2,"M = %2u: #buf = %4u, #pairs: %u, #single: %u (%5.2f%% paired), #blocks: %u, #modmul: %u\n",m,m*num_b,np,ns,100.0*2*np/(2*np+ns),k-k0,nmodmul);
+	snprintf(cbuf, sizeof(cbuf),"M = %2u: #buf = %4u, #pairs: %u, #single: %u (%5.2f%% paired), #blocks: %u, #modmul: %u\n",m,m*num_b,np,ns,100.0*2*np/(2*np+ns),k-k0,nmodmul);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 #ifndef PM1_STANDALONE
 
@@ -2550,9 +2550,9 @@ S2_RETURN:
 
 	// In case of normal (non-early) return, caller will handle the GCD:
 	if(strlen(gcd_str)) {
-		snprintf(cbuf,STR_MAX_LEN*2, "Stage 2 early-return due to factor found; MaxErr = %10.9f.\n",MME);
+		snprintf(cbuf, sizeof(cbuf), "Stage 2 early-return due to factor found; MaxErr = %10.9f.\n",MME);
 	} else {
-		snprintf(cbuf,STR_MAX_LEN*2, "Stage 2 done; MaxErr = %10.9f. Taking GCD...\n",MME);
+		snprintf(cbuf, sizeof(cbuf), "Stage 2 done; MaxErr = %10.9f. Taking GCD...\n",MME);
 	}
 	mlucas_fprint(cbuf,pm1_standlone+scrnFlag);
 #endif

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -546,7 +546,7 @@ PM1_S1P_READ_RETURN:
 
 		FILE*fptr = mlucas_fopen(fname, "wb");
 		if(!fptr) {
-			sprintf(cbuf,"ERROR: Unable to open precomputed p-1 stage 1 primes-product file %s for writing.\n",fname);
+			snprintf(cbuf, STR_MAX_LEN*2, "ERROR: Unable to open precomputed p-1 stage 1 primes-product file %s for writing.\n",fname);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0, cbuf);
 		}
 		fprintf(stderr,"INFO: Opened precomputed p-1 stage 1 primes-product file %s for writing...\n",fname);

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -349,14 +349,14 @@ me at: heber.tomer@gmail.com
 		if (obj) {
 			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
 		} else {
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
+			snprintf(cbuf, sizeof(cbuf),"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
 			fprintf(stderr,"%s",cbuf);
 		}
 		// Set affinity to specified logical CPUs:
 		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
 			int error = errno;
 			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
-			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
+			snprintf(cbuf, sizeof(cbuf),"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
 			fprintf(stderr,"%s",cbuf);
 	  #if THREAD_POOL_DEBUG
 		} else {

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -349,14 +349,14 @@ me at: heber.tomer@gmail.com
 		if (obj) {
 			hwloc_bitmap_or(cpuset, cpuset, obj->cpuset);
 		} else {
-			snprintf(cbuf, sizeof(cbuf),"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
+			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_PU[%u] not found.\n",i);
 			fprintf(stderr,"%s",cbuf);
 		}
 		// Set affinity to specified logical CPUs:
 		if (hwloc_set_cpubind(hw_topology, cpuset, HWLOC_CPUBIND_THREAD)) {
 			int error = errno;
 			hwloc_bitmap_snprintf (str, sizeof (str), cpuset);
-			snprintf(cbuf, sizeof(cbuf),"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
+			snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Warning: Unable to set affinity to cpuset %s: %s; leaving up to OS to manage thread/core binding.\n",str,strerror(error));
 			fprintf(stderr,"%s",cbuf);
 	  #if THREAD_POOL_DEBUG
 		} else {

--- a/src/util.c
+++ b/src/util.c
@@ -9121,14 +9121,14 @@ exit(0);
 		nobjs1 = hwloc_get_nbobjs_by_type (topology, HWLOC_OBJ_CORE);
 		nobjs2 = hwloc_get_nbobjs_by_depth(topology, depth);
 		if(nobjs1 != nobjs2) {
-			snprintf(cbuf,STR_MAX_LEN*2,"#objects of type CORE (%d) mismatches #objects (%d) at depth %d (topo depth = %d).",nobjs1,nobjs2,depth,topodepth);
+			snprintf(cbuf, sizeof(cbuf),"#objects of type CORE (%d) mismatches #objects (%d) at depth %d (topo depth = %d).",nobjs1,nobjs2,depth,topodepth);
 			ASSERT(0,cbuf);
 		}
 		// Loop over HWLOC_OBJ_CORE objects corr. to index range:
 		for (i = lidx_lo; i <= lidx_hi; i++) {
 			hwloc_obj_t obj = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
 			if (!obj) {
-				snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_CORE[%u] not found.\n",i);	ASSERT(0,cbuf);
+				snprintf(cbuf, sizeof(cbuf),"[hwloc] Error: HWLOC_OBJ_CORE[%u] not found.\n",i);	ASSERT(0,cbuf);
 			}
 			ASSERT(obj->type == HWLOC_OBJ_CORE, "[hwloc] Error: Object not of expected type CORE.");
 			while(obj && (obj->type != HWLOC_OBJ_PACKAGE)) {
@@ -9190,7 +9190,7 @@ exit(0);
 				hwloc_obj_t obj_core, obj_pu;
 				obj_core = hwloc_get_obj_by_type(hw_topology, HWLOC_OBJ_CORE, i);
 				if (!obj_core) {
-					snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: HWLOC_OBJ_CORE[%u] not found.\n",i);	ASSERT(0,cbuf);
+					snprintf(cbuf, sizeof(cbuf),"[hwloc] Error: HWLOC_OBJ_CORE[%u] not found.\n",i);	ASSERT(0,cbuf);
 				}
 				// 2. for each HWLOC_OBJ_CORE object in the above set, verify that it has at least (n) children
 				/*
@@ -9201,7 +9201,7 @@ exit(0);
 					'-cpu 0:11', or even more simply '-nthread 12') to use all 12 threads.
 				*/
 				if (obj_core->arity < incr) {
-					snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: Requested threads_per_core (%u) exceeds arity (%u) of HWLOC_OBJ_CORE[%u].\n",incr,obj_core->arity,i);	ASSERT(0,cbuf);
+					snprintf(cbuf, sizeof(cbuf),"[hwloc] Error: Requested threads_per_core (%u) exceeds arity (%u) of HWLOC_OBJ_CORE[%u].\n",incr,obj_core->arity,i);	ASSERT(0,cbuf);
 				}
 				for (int j = 0; j < incr; j++) {
 					obj_pu = obj_core->children[j];


### PR DESCRIPTION
The global diagnostic buffer `cbuf` is `char[STR_MAX_LEN*3]` — 3072 bytes (`extern` in `Mdata.h`, defined in `Mlucas.c`). Most of the ~528 `sprintf(cbuf, …)` calls in the tree format fixed messages or only integers/floats and **cannot** overflow it; those are left alone.

The PR does two related things, 41 changed lines across 5 files.

### 1. Bound the writes that interpolate variable-length input

16 `sprintf(cbuf, …)` → `snprintf(cbuf, sizeof(cbuf), …)` conversions — `Mlucas.c` 7, `factor.c` 8, `pm1.c` 1 — at the sites where the formatted output could exceed the buffer:

- a full worktodo/ini input line (`%s`, `in_line`);
- a **cofactor GCD result** string (`gcd_str`) — can be many digits;
- a **known-factors token** from an assignment line (`fac_start`);
- **factor-candidate / remainder decimal strings** in the Mfactor diagnostics (`q`, `u64_arr`);
- filename parameters passed into helpers (`fname`, `RESTARTFILE`).

Format string and arguments are unchanged in every case.

### 2. Replace hardcoded `cbuf` sizes with `sizeof(cbuf)`

25 further sites that were *already* bounded, but by a hand-written `STR_MAX_LEN*2`: 15 `snprintf`s in `pm1.c`, 4 in `get_preferred_fft_radix.c`, 4 in `util.c`, and the two `fgets(cbuf, STR_MAX_LEN*2, fp)` reads in `factor.c`.

This half matters because **`cbuf` is not one object everywhere**, which is exactly what makes a repeated literal the wrong way to spell its size. The global is `STR_MAX_LEN*3`; `factor.c`'s `PerPass_tfSieve()` declares a function-local `char cbuf[STR_MAX_LEN*2]` shadow, and `pm1.c` declares its own `char cbuf[STR_MAX_LEN*2]` under `#ifdef PM1_STANDALONE`. `sizeof(cbuf)` resolves to whichever one is in scope; the literal did not.

Effect on the truncation point, stated precisely rather than as "no change to the emitted text":

| sites | truncation point before | after |
|---|---|---|
| the 16 newly-bounded writes | none — unbounded | 3072, except the 6 `factor.c` ones inside `PerPass_tfSieve()`, which take its 2048 shadow |
| the 15 `pm1.c` / 4 `util.c` / 4 `get_preferred_fft_radix.c` re-spellings | 2048 | 3072 |
| the 2 `factor.c` `fgets` reads (also inside `PerPass_tfSieve()`) | 2048 | 2048 |

No message any of these emit comes anywhere near either bound, so the text a user sees is unchanged; the bound itself is not literally identical, and saying so seems better than claiming it is.

**Deliberately not touched** (to keep the diff to the actual risk): the many fixed-message / integer-only `sprintf(cbuf)` calls — short constant filenames (`CONFIGFILE`/`WORKFILE`/`MLUCAS_INI_FILE`), per-function `const char func[]` name literals (~91 sites across the radix/carry files), the bounded 32-char assignment-ID buffer, `returnMlucasErrCode()` fixed diagnostic names, etc. — plus three sites yielded to the in-flight PRs that own those lines.

Noticed while doing this and **not** fixed here, since it is pre-existing and unrelated to the sweep: `qfcheb.h` declares `extern char cbuf[STR_MAX_LEN*2]`, contradicting `Mdata.h`'s `STR_MAX_LEN*3`. Worth a one-liner of its own.

### Verification

Builds clean (`makemake.sh avx2`); `-s tt` self-test passes (radix-sets pass, no assertion/segfault). Purely mechanical (only a size argument added or corrected), so no behavioral change.

*Corrections to earlier revisions of this description: the scope was given as "16 sites across 3 files" (that is the `sprintf`→`snprintf` count only — the diff is 41 lines across 5 files, the rest being the `sizeof(cbuf)` re-spelling added later); the conversion target was given as `STR_MAX_LEN*2` (it is `sizeof(cbuf)`); and `cbuf` was described as 2048 bytes (the global is 3072).*

_Final piece of a review-driven `sprintf`→`snprintf` hardening effort; the small number of such calls that in-flight PRs add/modify were already bounded within those PRs, so this one stays conflict-free._
