### PR TITLE
Fix && -> & typo in LEADZ*/QLEADZ leading-zero macros

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -729,10 +729,10 @@ If the shift count (__n) is >= the width of the integer type, 0 is returned.
 
 /* Macros for 96/128/160/192-bit unsigned integer leading-zeros counting. For > 192-bit, call mi64_leadz instead.
 Cast the result of the high-part-equals-zero test to a signed 32-bit (-1) because leadz* returns a 32-bit value for inputs of all sizes: */
-#define LEADZ128(__x)	( leadz64(__x.d1) + ((-(sint32)(__x.d1 == 0)) && leadz64(__x.d0)) )
-#define LEADZ96(__x)	( leadz32(__x.d1) + ((-(sint32)(__x.d1 == 0)) && leadz64(__x.d0)) )
+#define LEADZ128(__x)	( leadz64(__x.d1) + ((-(sint32)(__x.d1 == 0)) & leadz64(__x.d0)) )
+#define LEADZ96(__x)	( leadz32(__x.d1) + ((-(sint32)(__x.d1 == 0)) & leadz64(__x.d0)) )
 
-#define LEADZ192(__x)	( leadz64(__x.d2) + ((-(sint32)(__x.d2 == 0)) && leadz64(__x.d1))+ ((-(sint32)(__x.d2 == 0 && __x.d1 == 0)) && leadz64(__x.d0)) )
+#define LEADZ192(__x)	( leadz64(__x.d2) + ((-(sint32)(__x.d2 == 0)) & leadz64(__x.d1))+ ((-(sint32)(__x.d2 == 0 && __x.d1 == 0)) & leadz64(__x.d0)) )
 #define LEADZ160(__x)	LEADZ192(__x)
 
 /* For larger operands it's more convenient to use a conditional + leadz64: */

--- a/src/qfloat.h
+++ b/src/qfloat.h
@@ -200,7 +200,7 @@ struct qfloat qfsn1	(struct qfloat q);
 struct qfloat qfcos_or_sin1(struct qfloat q, int cos_or_sin);
 
 // Utility macros:
-#define QLEADZ(__x)	( leadz64(__x.hi) + ((-(sint32)(__x.hi == 0)) && leadz64(__x.lo)) )
+#define QLEADZ(__x)	( leadz64(__x.hi) + ((-(sint32)(__x.hi == 0)) & leadz64(__x.lo)) )
 
 /* Left-shift: This should move at most a bit into the lowest exp-field, so check that on output: */
 #define QLSHIFT(__x, __n, __y)\


### PR DESCRIPTION
## Problem

The leading-zero-count macros `LEADZ96`/`LEADZ128`/`LEADZ192` (`imul_macro1.h`) and `QLEADZ` (`qfloat.h`) use the mask idiom their own header comment describes — *"cast the high-part-equals-zero test to a signed 32-bit (-1) because leadz\* returns a 32-bit value"* — i.e. build an all-ones mask when the high limb is zero and **bitwise-AND** it against the low-limb leading-zero count to conditionally pass that count through. But they were written with logical `&&` instead of bitwise `&`:

```c
#define LEADZ128(__x) ( leadz64(__x.d1) + ((-(sint32)(__x.d1 == 0)) && leadz64(__x.d0)) )
```

`&&` short-circuits its right operand to a boolean 0/1, so the `-1` mask is pointless and the low-limb count collapses. When the high limb is zero the macro returns a wrong count:

| input | correct | with `&&` (buggy) |
|---|---|---|
| `LEADZ128({d1=0, d0=1})` | 127 | 65 |
| `LEADZ128({d1=0, d0=0})` | 128 | 65 |
| `LEADZ128({d1=0, d0=0xFFFFFFFF})` | 96 | 65 |

When the high limb is nonzero the mask is 0 and `&`/`&&` agree, so the bug is silent — it only bites on the zero-high-limb branch the mask exists to serve.

## Impact — latent, not currently reachable

To be clear about severity: this is a **real defect in the macros but a latent one** — I traced every consumer and none currently feed the buggy branch a triggering input, so no present-day computation (primality tests, residues, P-1, DWT weights, FFT twiddles) is affected. Details:

- **`LEADZ128`** — its only consumer is `i128_to_q` (`qfloat.c:493`), whose only caller in the tree is one self-test assertion (`qtest()`, `qfloat.c:3749`) that passes `NIL128 = {0,0}`. `i128_to_q` early-returns `QZRO` on an all-zero input *before* reaching `LEADZ128`, and the trigger condition (`d1==0 && d0!=0`) is never produced by any caller. So `LEADZ128` never executes on a bug-triggering value.
- **`LEADZ96` / `LEADZ192` / `LEADZ160`** — no callers anywhere; currently dead code.
- **`QLEADZ`** — its consumer `qfmul_pow2` *is* hot (DWT weights in `mers_mod_square.c`, plus π/√2/trig/AGM constant computation), but the `QLEADZ` call sits inside the *denormal-input* branch (`exp0 == 0`, i.e. `|x| < 2^-1022`). Mlucas only scales normal-magnitude values (weights ≈ 1, constants ≈ ±1) by powers of two, so that branch is never entered (no "DENORM in qfmul_pow2" in practice).

So this is worth fixing as **correctness hygiene / removing a landmine**, not because it repairs broken results. It would silently corrupt output the moment a triggering input appears — e.g. if `i128_to_q` is later used to convert a real sub-2⁶² 128-bit value, or if qfloat arithmetic ever yields a denormal: a wrong leading-zero count there → wrong exponent/normalization of a high-precision constant → potentially wrong FFT weights → wrong residues.

## Fix

Change the five mask-application `&&` → `&`. The intended **inner** logical `&&` in `LEADZ192`'s `(d2 == 0 && d1 == 0)` sub-condition is preserved.

## Verification

- **Correctness:** a standalone test of all four fixed macros against a brute-force leading-zero reference matches on every high/low-limb combination (0 mismatches); the old `&&` form returned 65 instead of 127/128/96 for zero-high-limb inputs.
- **No regression:** AVX2 build + `-s tt` self-test pass (15/15 teensy FFT lengths, residues match the reference vectors).

Found via a codebase-wide operator-typo scan (same bug class as the `twopmmodq64` `<`-should-be-`<<` typo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
