### PR TITLE
Free per-FFT-length index arrays on re-init instead of leaking them (fixes #96)

### DIFF
--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -275,6 +275,18 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			ASSERT(0, cbuf);
 		}
 		first_entry=FALSE;
+		// On a runlength/radix-set change this init block re-runs (see the first_entry=TRUE resets above),
+		// re-allocating the static per-FFT-length index arrays below. Free any previous allocation first so
+		// those static pointers don't leak it (fixes #96); free(NULL) on the first-ever pass is a no-op:
+		free(block_index);     block_index     = 0x0;
+		free(ws_i);            ws_i            = 0x0;
+		free(ws_j1);           ws_j1           = 0x0;
+		free(ws_j2);           ws_j2           = 0x0;
+		free(ws_j2_start);     ws_j2_start     = 0x0;
+		free(ws_k);            ws_k            = 0x0;
+		free(ws_m);            ws_m            = 0x0;
+		free(ws_blocklen);     ws_blocklen     = 0x0;
+		free(ws_blocklen_sum); ws_blocklen_sum = 0x0;
 		psave = p;
 		nsave = n;
 		N2 =n/2;		/* Complex vector length.	*/


### PR DESCRIPTION
Fixes #96.

LeakSanitizer reports several leaks from `mers_mod_square()` after the medium self-test (issue #96), at `mers_mod_square.c:1132` and `1251-1258`.

Those sites allocate the **static** per-FFT-length index arrays `block_index` and `ws_i`/`ws_j1`/`ws_j2`/`ws_j2_start`/`ws_k`/`ws_m`/`ws_blocklen`/`ws_blocklen_sum` inside the `first_entry` init block. That block re-runs whenever the exponent, runlength or radix set changes (it resets `first_entry=TRUE` just above), re-allocating those static pointers **without freeing the previous allocation** — so each FFT-length change leaks all nine arrays. The self-test sweeps many lengths, hence the "144 objects" LSan sees.

This frees them at the top of the init block before the re-allocation below (`free(NULL)` on the first pass is a no-op) — the same free-on-reinit pattern as #70.

Builds clean; the change is a straightforward free-before-realloc of pointers that are only ever allocated in this one block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)