### PR TITLE
Fix two multi-length self-test heap-buffer-overflows (residue-array sizing; radix-12 scalar index)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1436,8 +1436,8 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		// the limb-count [ #limbs for x bits = (x+63)>>6, doubled => (x+63)>>5 ] of the largest exponent that can
 		// run against these arrays: pmax at the allocated (max) FFT length, or the current p if the warn-path
 		// above admitted a p slightly above that pmax:
-		uint32 alloc_n = (maxFFT > kblocks) ? (maxFFT << 10) : n;	// max unpadded FFT length these arrays serve
-		arrtmp_alloc = (MAX((uint64)p, given_N_get_maxP(alloc_n)) + 63) >> 5;
+		// Size for the largest exponent supported at the largest FFT length these arrays will serve:
+		arrtmp_alloc = (MAX((uint64)p, given_N_get_maxP(maxFFT > kblocks ? maxFFT << 10 : n)) + 63) >> 5;
 		arrtmp = ALLOC_UINT64(arrtmp, arrtmp_alloc);if(!arrtmp ){ sprintf(cbuf, "ERROR: unable to allocate array ARRTMP with %" PRIu64 " limbs in main.\n",arrtmp_alloc); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
 
 		// For an n-word main-array, BIGWORD_BITMAP and BIGWORD_NBITS have (n/64) elts each, thus need 1/64 + 1/32 the total

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1427,11 +1427,18 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 			b_uint64_ptr = (uint64*)b; c_uint64_ptr = (uint64*)c; d_uint64_ptr = (uint64*)d; e_uint64_ptr = (uint64*)e;
 		}
 
-		// For this residue (and scratch) byte-array, conservatively figure at least 4 bits per float-double residue word.
-		// For multi-FFT-length self-tests, conservatively figure as many as 20 bits (2.5 bytes) per float-double residue word:
-		// v20: for largest currently supported FFT of 512Mdoubles, i still -barely - fits in a uint32, but 2.5*i does not:
-		arrtmp_alloc = i; arrtmp_alloc = MAX((p+63)>>2, (uint64)(arrtmp_alloc*2.5)) >> 3;	// #limb needed to store p bits = (p+63)>>6, so alloc at least 2x this
-		arrtmp = ALLOC_UINT64(arrtmp, arrtmp_alloc);if(!arrtmp ){ sprintf(cbuf, "ERROR: unable to allocate array ARRTMP with %u bytes in main.\n",i); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
+		// This residue/scratch byte-array is allocated once and reused for every exponent in the run. In a
+		// multi-FFT-length self-test the arrays are sized for the largest FFT length used (maxFFT), and the
+		// largest exponent processed can be as high as pmax(maxFFT) - not the current (first, smallest) p. The
+		// old "2.5 bytes per float-double word" heuristic underestimated the storage: max bits/word is ~21
+		// (~2.6 bytes) at these lengths, so a large exponent near pmax overran arrtmp (heap-buffer-overflow
+		// writing e.g. M320851's 40107-byte residue into a 38400-byte arrtmp sized for a 15K FFT). Size for 2x
+		// the limb-count [ #limbs for x bits = (x+63)>>6, doubled => (x+63)>>5 ] of the largest exponent that can
+		// run against these arrays: pmax at the allocated (max) FFT length, or the current p if the warn-path
+		// above admitted a p slightly above that pmax:
+		uint32 alloc_n = (maxFFT > kblocks) ? (maxFFT << 10) : n;	// max unpadded FFT length these arrays serve
+		arrtmp_alloc = (MAX((uint64)p, given_N_get_maxP(alloc_n)) + 63) >> 5;
+		arrtmp = ALLOC_UINT64(arrtmp, arrtmp_alloc);if(!arrtmp ){ sprintf(cbuf, "ERROR: unable to allocate array ARRTMP with %" PRIu64 " limbs in main.\n",arrtmp_alloc); fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf); }
 
 		// For an n-word main-array, BIGWORD_BITMAP and BIGWORD_NBITS have (n/64) elts each, thus need 1/64 + 1/32 the total
 		// storage of the main-array. Use uint64 alloc-macro for both, so halve the num-elts arg for the BIGWORD_NBITS alloc.

--- a/src/radix12_ditN_cy_dif1.c
+++ b/src/radix12_ditN_cy_dif1.c
@@ -1399,6 +1399,8 @@ void radix12_dif_pass1(double a[], int n)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
+	#else
+		j1 = j;
 	#endif
 		j1 = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* padded-array fetch index is here */
 		j2 = j1+RE_IM_STRIDE;
@@ -1662,6 +1664,8 @@ void radix12_dit_pass1(double a[], int n)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
+	#else
+		j1 = j;
 	#endif
 		j1 = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* padded-array fetch index is here */
 		j2 = j1+RE_IM_STRIDE;


### PR DESCRIPTION
Two independent heap-buffer-overflows that surface in multi-FFT-length self-tests, each in its own commit. The first is the ASan crash reported on mersenneforum; the second I found while reproducing it under a NOSIMD+ASan build.

## Commit 1 — residue byte-array sized for the first exponent instead of the largest

Reported (arm64):
```
M320851: using FFT length 15K = 15360 8-byte floats ...
Using complex FFT radices 60 8 16
==ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 8
0x... is located 1448 bytes after 38656-byte region  (allocated by realloc in ernstMain)
```

`ernstMain` allocates the packed-byte residue/scratch array `arrtmp` **once** and reuses it for every exponent in the run. In a multi-FFT-length self-test the residue arrays are sized for the largest FFT length used (`maxFFT`), and the largest exponent processed can be as high as `pmax(maxFFT)` — but `arrtmp` was sized from the **first (smallest)** exponent's `p` plus a *"2.5 bytes per float-double word"* floor:
```c
arrtmp_alloc = MAX((p+63)>>2, (uint64)((maxFFT<<10)*2.5)) >> 3;
```
At ~15K and above the true bits-per-word is ~21 (~2.6 bytes/word), so `2.5·words` underestimates. For the **teensy** self-test (`maxFFT = 15K`, first exponent 22679) the floor gives `2.5·15360 = 38400` bytes (≈ the reported 38656-byte region incl. padding), but the range's largest member **M320851** needs `⌈320851/8⌉ = 40107` bytes — overrunning `arrtmp` by ~1.7 KB.

**Fix:** size `arrtmp` for 2× the limb-count of the largest exponent that can run against these arrays — `pmax` at the allocated (max) FFT length via `given_N_get_maxP()`, or the current `p` if the FFT-too-small warn-path admitted a `p` slightly above that `pmax`:
```c
uint32 alloc_n = (maxFFT > kblocks) ? (maxFFT << 10) : n;
arrtmp_alloc = (MAX((uint64)p, given_N_get_maxP(alloc_n)) + 63) >> 5;
```
No-op-or-larger for single-length runs (`maxFFT = 0`).

**Verified:** `./Mlucas -s tt -iters 100` now runs the exact reported sequence — `14K passed → M320851 at 15K, radices 60 8 16, 100 iters → 15K passed` — to completion (`arrtmp` 80608 vs 38400 bytes). 8K single-length still reproduces reference residue `85301536E4CA9B11`.

## Commit 2 — radix-12 scalar pass missing `#else j1 = j;`

While reproducing Commit 1 under a NOSIMD+ASan build I hit a **second, unrelated** heap-buffer-overflow in `radix12_di{f,t}_pass1` at NOSIMD radix-12 FFT lengths (e.g. 48K). Root cause: the radix-12 pass loops compute the padded fetch index `j1` as
```c
#ifdef USE_AVX
    j1 = (j & mask02) + br8[j&7];
#elif defined(USE_SSE2)
    j1 = (j & mask01) + br4[j&3];
#endif        // <-- no #else
```
`radix12_ditN_cy_dif1.c` is the **only one of the 42 `radix*_ditN_cy_dif1.c` files** lacking the scalar `#else j1 = j;` (present in both its `dif`/`dit` pass1 loops in every other radix). In a NOSIMD build `j1` was never set from `j`, so it retained stale state and `a[j1 + p*]` ran off the residue array.

**Fix:** add the scalar `#else j1 = j;` to both loops, matching the other 41 radix files. **Verified:** NOSIMD+ASan `-fft 48 -iters 100` completes with reference residue `6B1C76AB5431FDA4`; `-s t` runs past 48K/60K/72K (previously it overran at 48K). SIMD builds are unaffected.

The two commits are independent — happy to split into separate PRs if preferred.