### PR TITLE
twopmodq96: work around GCC-11 AVX-512 register-allocator miscompile

### DIFF
--- a/src/twopmodq96.c
+++ b/src/twopmodq96.c
@@ -36,6 +36,20 @@
 	#define YES_ASM
 #endif
 
+/* Work around a GCC 11 register-allocator bug: when AVX-512 is enabled (-mavx512f adds the
+zmm16-31 and k0-7 registers to the allocatable file, changing IRA's decisions), GCC 11.x
+miscompiles the register-pressure-heavy, multi-q GPR-inline-asm routines in this file -
+twopmodq96_q4()/twopmodq96_q8() - returning a wrong result for one or more of the parallel
+q-lanes (lane 0 stays correct; e.g. test_fac's twopmodq96_q4(16446217, k=639280514687, x4)
+returns 0xD instead of 0xF). These routines contain no SIMD, so the AVX-512 register file is
+irrelevant to them: the bug is a GCC 11 regression - it does not occur with -mavx2, nor on
+GCC 10, GCC 12+, or Clang (all verified under Intel SDE). Forcing IRA's older 'priority'
+allocator for this translation unit restores correct codegen; scope to GCC 11 + AVX-512 so no
+other compiler or configuration is affected. */
+#if defined(USE_AVX512) && defined(__GNUC__) && !defined(__clang__) && (__GNUC__ == 11)
+	#pragma GCC optimize ("-fira-algorithm=priority")
+#endif
+
 #ifdef __CUDACC__
 
 	// Simple GPU-ized version of twopmodq96.


### PR DESCRIPTION
## Summary

The Mfactor `test_fac` self-test fails on the **GCC 11 + AVX-512** build only:

```
ERROR: twopmodq96_q4(16446217, k = 639280514687 x 4) failed to find factor, res = 0XD.
ERROR: Function test_fac, at line 1237 of file ../src/factor_test.h
Assertion '0' failed: 0
```

`twopmodq96_q4()` tests four trial-factor candidates ("q-lanes") in parallel. The self-test
passes **identical** inputs for all four lanes (`p, k, k, k, k`), so the result must be `0xF`
(all four report "is a factor"). GCC 11 returns `0xD` — **lane 1 is wrong while lanes 0/2/3 are
correct**, despite identical inputs. This aborts the AVX-512 Mfactor build's factoring-init
self-test on the `ubuntu-22.04, gcc` CI job.

This PR adds a narrowly-scoped compiler workaround. One-line functional change:

```c
#if defined(USE_AVX512) && defined(__GNUC__) && !defined(__clang__) && (__GNUC__ == 11)
	#pragma GCC optimize ("-fira-algorithm=priority")
#endif
```

## Root cause: a GCC 11 register-allocator regression (not a bug in Mlucas)

`twopmodq96_q4()`/`twopmodq96_q8()` are pure scalar/GPR hand-written inline-asm routines — they
use **no SIMD at all** (`YES_ASM` path). The defect is in GCC's register allocator, not in the
asm or its clobber list:

* Identical per-lane inputs, yet only lane 0 stays correct — a data/logic bug is impossible; this
  is register-level corruption.
* The **same source compiles correctly** with `-mavx2 -mfma`, and on GCC 10, GCC 12+, and Clang.
* It reproduces at `-O1`/`-O2`/`-O3`, **with and without LTO**, and **with or without**
  vectorization — so it is not an optimizer-pass or LTO artifact.
* Enabling `-mavx512f` alone is sufficient to trigger it. AVX-512F adds the `zmm16-31` and `k0-7`
  registers to the allocatable register file, which perturbs IRA's default (Chaitin-Briggs)
  allocation of these register-pressure-heavy multi-lane routines even though they never touch a
  vector/mask register.
* It is a Heisenbug: inserting a debug `fprintf`, or `__asm__ volatile("":::"memory")` barriers,
  changes *which* lanes corrupt (`0xD` → `0x9` → `0x1`) rather than fixing it — the signature of a
  register-allocation-pressure defect.

### Compiler bisection

Built the (unfixed) AVX-512 Mfactor with each compiler and ran the `test_fac` self-test:

| Compiler | `twopmodq96_q4` self-test |
| --- | --- |
| GCC 10 | pass |
| **GCC 11** (11.4, Ubuntu 22.04) | **FAIL — `res = 0xD`** |
| GCC 12 (Ubuntu 22.04 and 24.04) | pass |
| GCC 13 | pass |
| GCC 14 | pass |
| GCC 16 | pass |
| Clang | pass |

A single-release regression: introduced in GCC 11, fixed in GCC 12 — matching the exact compiler
on the failing CI job (`ubuntu-22.04, gcc` → GCC 11.4).

## The fix

Force IRA's older `priority` register-allocation algorithm for this one translation unit. That
sidesteps the buggy allocation and restores correct codegen. It is gated to **GCC 11 + AVX-512**
only, so GCC 10 / GCC 12+ / Clang and all non-AVX-512 builds are byte-for-byte unaffected. The
routines' hot inner loop is hand-written asm (untouched by the C optimizer), so there is no
meaningful performance impact even on the one affected configuration.

Other workarounds were tried and rejected: `__attribute__((target("avx2")))` on the function had
no effect; `target("no-avx512*")` breaks `always_inline` builtins (target mismatch);
`optimize("O0")` breaks the asm frame; `-fno-ira-share-spill-slots` and compiler memory barriers
did not help. The `priority`-allocator pragma is the minimal change that reliably fixes it.

## Verification

This machine has no AVX-512 hardware, so the fix was reproduced and verified with **Intel SDE**
(software AVX-512 emulation): built the static AVX-512 Mfactor with GCC 11 and ran
`sde64 -skx -- ./Mfactor -m 127 -bmax 20`.

* Before: `... failed to find factor, res = 0XD` → assertion abort.
* After: `Testing 96-bit factors...` → `Factoring self-tests completed successfully.`

The bisection table above was produced the same way. Final CI confirmation on the real
`ubuntu-22.04, gcc` runner is the last check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
