### PR TITLE
Fix Pépin+Gerbicz-check runs being unable to resume from their savefile

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1640,6 +1640,15 @@ READ_RESTART_FILE:
 		if(TEST_TYPE == TEST_TYPE_PM1) {
 			ASSERT(RES_SHIFT == 0ull, "Shifted residues unsupported for p-1!\n");
 			RES_SHIFT = 0ull; a[0] = iseed;
+		} else if(MODULUS_TYPE == MODULUS_TYPE_FERMAT && TEST_TYPE == TEST_TYPE_PRIMALITY && DO_GCHECK && !INTERACT) {
+			// A Pépin test with Gerbicz check does not support shifted residues (the random-shift
+			// error-detection scheme is incompatible with the G-check residue-product scheme), and the
+			// resume path below asserts RES_SHIFT==0. Randomizing the shift here (as done for the other
+			// primality tests) would leave a nonzero shift in the savefile and make the run un-resumable
+			// from its own checkpoint (see #99). So force shift 0 for the non-interactive Pépin+G-check
+			// case; as in the p-1 branch above, a zero shift just means the seed goes straight into a[0]
+			// (no need for the random-shift selection or shift_word() carry-in of the else-branch below):
+			RES_SHIFT = 0ull; a[0] = iseed;
 		} else {
 			// Apply initial-residue shift - if user has not set one via cmd-line or current value >= p, randomly choose a value in [0,p).
 			// [Note that the RNG is inited as part of the standard program-start-sequence, via function host_init().]


### PR DESCRIPTION
## Summary

A Pépin test (Fermat primality) run with the Gerbicz check enabled cannot resume from its own savefile — any restart aborts:

```
ERROR: Function ernstMain, at line 1666 of file ../src/Mlucas.c
Assertion 'RES_SHIFT == 0ull' failed: Shifted residues unsupported for Pépin test with Gerbicz check!
```

## Cause

At run-from-scratch, a primality test seeds a random residue shift (the v18 shifted-residue error-detection scheme). But a **non-interactive Pépin test with the Gerbicz check** does not support shifted residues — the restart path asserts `RES_SHIFT == 0`. The from-scratch path randomizes the shift anyway, so the run:

1. picks a random shift (e.g. `RES_SHIFT = 745425` by iter 1000),
2. evolves and checkpoints it into the savefile,
3. and then aborts on the assertion above the moment it is restarted.

This affects **every** Pépin+G-check run — e.g. a `Fermat,Test=<n>` worktodo assignment. It reproduces on the first checkpoint-and-restart and is independent of how the run is stopped (SIGINT/SIGTERM or a hard `kill -9`), so it is not specific to the interrupt-savefile path. Mersenne PRP is unaffected (the assert is Fermat-Pépin-only), and the interactive `-f` timing-test mode is deliberately excluded (it legitimately allows a shift).

## Fix

For the non-interactive Pépin+G-check case, force `RES_SHIFT = 0` at run-from-scratch rather than randomizing it — matching what the restart path already requires:

```c
if(MODULUS_TYPE == MODULUS_TYPE_FERMAT && TEST_TYPE == TEST_TYPE_PRIMALITY && DO_GCHECK && !INTERACT) {
    RES_SHIFT = 0ull;
} else if(RES_SHIFT == -1ull || RES_SHIFT >= p) {
    ...
```

## Verification

On an avx2 build, a from-scratch `Fermat,Test=20` run:

- **Before:** initial shift randomized to a nonzero value, checkpoints it, and every resume aborts on the `RES_SHIFT == 0ull` assertion.
- **After:** `initial residue shift count = 0`, and it resumes correctly from its checkpoint with clean forward progress:

```
F20: using FFT length 64K ... initial residue shift count = 0
F20 Iter# = 10000 ... Residue shift count = 0.
Restarting F20 at iteration = 10000, residue shift count = 0.
F20 Iter# = 20000 ... Residue shift count = 0.
... 30000 ... 40000 ... 50000 ... 60000 ...
```

Found while validating #100/#108 (savefile-on-interrupt) across worktypes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
