### PR TITLE
types.h aliasing helper + strict-aliasing fixes (from #34)

### DIFF
--- a/src/dft_macro.c
+++ b/src/dft_macro.c
@@ -3920,8 +3920,8 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 				VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 				tmp = sqrt2+1;	// Unnamed copy of isrt2
 				// Alternate "rounded the other way" copies of sqrt2,isrt2:
-				dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-				dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+				dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+				dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 			//	VEC_DBL_INIT(sqrt2, SQRT2);	VEC_DBL_INIT(tmp, ISRT2);
 				VEC_DBL_INIT(nisrt2,-dtmp);
 				VEC_DBL_INIT( isrt2, dtmp);									// Copies of +ISRT2 needed for 30-asm-macro-operand-GCC-limit workaround:
@@ -4008,8 +4008,8 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 			VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 			tmp = sqrt2+1;	// Unnamed copy of isrt2
 			// Alternate "rounded the other way" copies of sqrt2,isrt2:
-			dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-			dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+			dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+			dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		//	VEC_DBL_INIT(sqrt2, SQRT2);	VEC_DBL_INIT(tmp, ISRT2);
 			VEC_DBL_INIT(nisrt2,-dtmp);
 			VEC_DBL_INIT( isrt2, dtmp);									// Copies of +ISRT2 needed for 30-asm-macro-operand-GCC-limit workaround:
@@ -4323,8 +4323,8 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 				VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 				tmp = sqrt2+1;	// Unnamed copy of isrt2
 				// Alternate "rounded the other way" copies of sqrt2,isrt2:
-				dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-				dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+				dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+				dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 			//	VEC_DBL_INIT(sqrt2, SQRT2);	VEC_DBL_INIT(tmp, ISRT2);
 				VEC_DBL_INIT(nisrt2,-dtmp);
 				VEC_DBL_INIT( isrt2, dtmp);									// Copies of +ISRT2 needed for 30-asm-macro-operand-GCC-limit workaround:
@@ -4411,8 +4411,8 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 			VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );	tmp = sqrt2+1;
 			tmp = sqrt2+1;	// Unnamed copy of isrt2
 			// Alternate "rounded the other way" copies of sqrt2,isrt2:
-			dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-			dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+			dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+			dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		//	VEC_DBL_INIT(sqrt2, SQRT2);	VEC_DBL_INIT(tmp, ISRT2);
 			VEC_DBL_INIT(nisrt2,-dtmp);
 			VEC_DBL_INIT( isrt2, dtmp);									// Copies of +ISRT2 needed for 30-asm-macro-operand-GCC-limit workaround:

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -646,8 +646,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -666,8 +666,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 					max_adiff = adiff;
 				if(adiff > err_threshold)
 				{
-					i1 = *(uint64 *)&t1;
-					i2 = *(uint64 *)&t2;
+					i1 = f64_to_u64(t1);
+					i2 = f64_to_u64(t2);
 					idiff = ABS(i1-i2);
 					if(idiff > max_idiff)
 						max_idiff = idiff;
@@ -679,15 +679,15 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				wt1[i] = qfdbl(qfinv(qwt));
 				t1 = wt1[i];
 				t2 = 1.0/wt0[i];
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				adiff = ABS(t1-t2);
 				if(adiff > max_adiff)
 					max_adiff = adiff;
 				if(adiff > err_threshold)
 				{
-					i1 = *(uint64 *)&t1;
-					i2 = *(uint64 *)&t2;
+					i1 = f64_to_u64(t1);
+					i2 = f64_to_u64(t2);
 					idiff = ABS(i1-i2);
 					if(idiff > max_idiff)
 						max_idiff = idiff;
@@ -730,8 +730,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -747,8 +747,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -769,8 +769,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -788,8 +788,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -831,8 +831,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -848,8 +848,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -870,8 +870,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -889,8 +889,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -932,8 +932,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -948,8 +948,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -970,8 +970,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -988,8 +988,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -1028,8 +1028,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -1044,8 +1044,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -1066,8 +1066,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -1084,8 +1084,8 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -696,8 +696,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -716,8 +716,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -759,8 +759,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -779,8 +779,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -855,8 +855,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -872,8 +872,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -894,8 +894,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -913,8 +913,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -956,8 +956,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -973,8 +973,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			max_adiff = adiff;
 		if(adiff > err_threshold)
 		{
-			i1 = *(uint64 *)&t1;
-			i2 = *(uint64 *)&t2;
+			i1 = f64_to_u64(t1);
+			i2 = f64_to_u64(t2);
 			idiff = ABS(i1-i2);
 			if(idiff > max_idiff)
 				max_idiff = idiff;
@@ -996,8 +996,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;
@@ -1015,8 +1015,8 @@ The scratch array (2nd input argument) is only needed for data table initializat
 				max_adiff = adiff;
 			if(adiff > err_threshold)
 			{
-				i1 = *(uint64 *)&t1;
-				i2 = *(uint64 *)&t2;
+				i1 = f64_to_u64(t1);
+				i2 = f64_to_u64(t2);
 				idiff = ABS(i1-i2);
 				if(idiff > max_idiff)
 					max_idiff = idiff;

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -1973,7 +1973,7 @@ double	mi64_cvt_double(const uint64 x[], uint32 len)
 	itmp64 += lead64_rnd;
 	ASSERT(itmp64 > lead64_rnd , "mi64_cvt_double: Exponent overflows IEEE64 field");
 	/* GCC bug: needed to add the explicit sign-check below, otherwise GCC 'optimizes' away the (*(double *)&itmp64): */
-	retval = *(double *)&itmp64;
+	retval = u64_to_f64(itmp64);
 	if(retval < 0.0) {
 		sprintf(cbuf, "rng_isaac_rand_double_norm_pos: lead64 = %16" PRIx64 ", itmp64 = %16" PRIx64 ", retval = %lf not in [0,1]!\n", lead64, itmp64, retval);
 		ASSERT(0, cbuf);

--- a/src/qfloat.c
+++ b/src/qfloat.c
@@ -362,7 +362,7 @@ double qfdbl(struct qfloat q)
 	b) If number was denormalized, MSB of significand now gets treated as exponent
 		field of 1, which again is what we wanted to do anyway.
 	*/
-	return *(double *)&hi;
+	return u64_to_f64(hi);
 }
 
 // Same as above, but deliberately round the LSB the wrong way, e.g. for sensitivity analysis of a const doubles:
@@ -371,16 +371,16 @@ double qfdbl_wrong_way_rnd(struct qfloat q)
 	uint64 hi,lo;
 	lo = (q.lo >> 63) ^ 0x1;
 	hi = q.hi + lo;
-	return *(double *)&hi;
+	return u64_to_f64(hi);
 }
 
 // For generic doubles (i.e. we do not know what the less-significant bits were which were rounded in),
 // simply provide a function which toggles the LSB:
 double dbl_flip_lsb(double d)
 {
-	uint64 c = *(uint64 *)&d;
+	uint64 c = f64_to_u64(d);
 	BIT_FLIP(c,0);
-	return *(double *)&c;
+	return u64_to_f64(c);
 }
 
 /* qfloat --> long double conversion utility.
@@ -437,7 +437,7 @@ struct qfloat dbl_to_q(double d)
 {
 	struct qfloat q;
 
-	q.hi = *(uint64 *)&d;	/* Copy bit pattern of double into a uint64. */
+	q.hi = f64_to_u64(d);	/* Copy bit pattern of double into a uint64. */
 	q.lo = (uint64)0;
 	return q;
 }
@@ -2053,7 +2053,7 @@ struct qfloat qflog(struct qfloat x)
 	y = ldbl_to_q(ld);
   #else
 	lnx = log(qfdbl(x));
-	y.hi = *(uint64 *)&lnx; y.lo = 0ull;
+	y.hi = f64_to_u64(lnx); y.lo = 0ull;
   #endif
 
 	// Iter #1:
@@ -2156,7 +2156,7 @@ struct qfloat qfexp(struct qfloat x)
 	#error *** need to add x87 high-prec exp() init ***
 	double expx = exp(qfdbl(x));
 	struct qfloat y, logy;
-	y.hi = *(uint64 *)&expx; y.lo = 0ull;
+	y.hi = f64_to_u64(expx); y.lo = 0ull;
 	// Iter #1:
 	logy = qflog(y);
 	y = qfsub(y, qfmul( qfsub(logy,x) , y ) );	/*** If could get ~4 more bits in initial guess, could do just 1 iter ***/
@@ -2293,7 +2293,7 @@ struct qfloat qfatan(struct qfloat x)
 	y = ldbl_to_q(ld);
 #else
 	double darct = atan(qfdbl(x));
-	y.hi = *(uint64 *)&darct; y.lo = 0ull;
+	y.hi = f64_to_u64(darct); y.lo = 0ull;
 #endif
 
 	// Iter #1:
@@ -3069,52 +3069,52 @@ int qtest(void)
 #endif
 	c = 0.0;	d = qfdbl(QZRO);
 #if QFDEBUG
-		printf("dble(0.0) = %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(0.0) = %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 12 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 12 in qfloat.c");
 
 	c = 1.0;	d = qfdbl(QONE);
 #if QFDEBUG
-		printf("dble(1.0) = %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(1.0) = %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 14 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 14 in qfloat.c");
 
 	c = 2.0;	d = qfdbl(QTWO);
 #if QFDEBUG
-		printf("dble(2.0) = %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(2.0) = %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 16 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 16 in qfloat.c");
 
 	c =-2.0;	d = qfdbl(qfneg(QTWO));
 #if QFDEBUG
-		printf("dble(-2.0)= %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(-2.0)= %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 18 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(hidiff == (int64)0)) ASSERT(0,"ERROR 18 in qfloat.c");
 
 	c = 2*pi;	d = qfdbl(Q2PI);
 #if QFDEBUG
-		printf("dble(2pi) = %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(2pi) = %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 20 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 20 in qfloat.c");
 
 	c =log(2.0);d = qfdbl(QLN2);
 #if QFDEBUG
-		printf("dble(ln2) = %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(ln2) = %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 22 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 22 in qfloat.c");
 
 	c = exp(1.0);
 	d = qfdbl(QEXP);
 #if QFDEBUG
-		printf("dble(exp) = %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(exp) = %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 24 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 24 in qfloat.c");
 
 	c = -c;		d = qfdbl(qfneg(QEXP));
 #if QFDEBUG
-		printf("dble(-exp)= %16" PRIX64 "  %16" PRIX64 "\n",*(int64 *)&c, *(int64 *)&d);
+		printf("dble(-exp)= %16" PRIX64 "  %16" PRIX64 "\n",f64_to_i64(c), f64_to_i64(d));
 #endif
-	hidiff = *(int64 *)&c - *(int64 *)&d;	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 26 in qfloat.c");
+	hidiff = f64_to_i64(c) - f64_to_i64(d);	if(!(ABS(hidiff) < (int64)2)) ASSERT(0,"ERROR 26 in qfloat.c");
 
 	/*********** TEST THE MULTIPLY ALGORITHM ************/
 #if TIMING_TEST

--- a/src/radix1008_ditN_cy_dif1.c
+++ b/src/radix1008_ditN_cy_dif1.c
@@ -663,14 +663,14 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		tm2 = tmp + RADIX/2 - 1;
 		// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 		tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = radix1008_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-		tmp64 = radix1008_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-		tmp64 = radix1008_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+		tmp64 = radix1008_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+		tmp64 = radix1008_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+		tmp64 = radix1008_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 		for(j = 4; j < RADIX; j += 4) {
-			tmp64 = radix1008_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-			tmp64 = radix1008_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix1008_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix1008_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix1008_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+			tmp64 = radix1008_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix1008_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix1008_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 		}
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -683,26 +683,26 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-7:
 		tmp = base_negacyclic_root + 16;	// First 16 slots reserved for Re/Im parts of the 8 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix1008_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      4];	tmp->d4 = *(double *)&tmp64;	// cos(04*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      5];	tmp->d5 = *(double *)&tmp64;	// cos(05*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      6];	tmp->d6 = *(double *)&tmp64;	// cos(06*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      7];	tmp->d7 = *(double *)&tmp64;	// cos(07*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      4];	tmp->d4 = u64_to_f64(tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      5];	tmp->d5 = u64_to_f64(tmp64);	// cos(05*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      6];	tmp->d6 = u64_to_f64(tmp64);	// cos(06*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      7];	tmp->d7 = u64_to_f64(tmp64);	// cos(07*I*Pi/(2*RADIX))
 		++tmp;
 		tmp->d0 = 0.0;
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-4];	tmp->d4 = *(double *)&tmp64;	// sin(04*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-5];	tmp->d5 = *(double *)&tmp64;	// sin(05*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-6];	tmp->d6 = *(double *)&tmp64;	// sin(06*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-7];	tmp->d7 = *(double *)&tmp64;	// sin(07*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-4];	tmp->d4 = u64_to_f64(tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-5];	tmp->d5 = u64_to_f64(tmp64);	// sin(05*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-6];	tmp->d6 = u64_to_f64(tmp64);	// sin(06*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-7];	tmp->d7 = u64_to_f64(tmp64);	// sin(07*I*Pi/(2*RADIX))
 		++tmp;	// 0x480(base_negacyclic_root)
-		tmp64 = radix1008_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(08*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(08*I*Pi/(2*RADIX))
 		++tmp;	// 0x4c0(base_negacyclic_root)
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(08*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(08*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 16;	// reset to point to start of above block
 
 	   #elif defined(USE_AVX)
@@ -710,18 +710,18 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix1008_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix1008_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix1008_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix1008_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 
 	   #endif

--- a/src/radix1024_ditN_cy_dif1.c
+++ b/src/radix1024_ditN_cy_dif1.c
@@ -686,22 +686,22 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			tm2 = tmp + RADIX/4 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix1024_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = radix1024_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = radix1024_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = radix1024_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = radix1024_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix1024_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix1024_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix1024_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = radix1024_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = radix1024_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = radix1024_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = radix1024_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix1024_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix1024_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			for(j = 8; j < RADIX; j += 8) {
-				tmp64 = radix1024_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix1024_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix1024_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix1024_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 
@@ -711,14 +711,14 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 			tm2 = tmp + RADIX/2 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix1024_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-			tmp64 = radix1024_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-			tmp64 = radix1024_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+			tmp64 = radix1024_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+			tmp64 = radix1024_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+			tmp64 = radix1024_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 			for(j = 4; j < RADIX; j += 4) {
-				tmp64 = radix1024_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix1024_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix1024_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix1024_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix1024_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix1024_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block

--- a/src/radix128_ditN_cy_dif1.c
+++ b/src/radix128_ditN_cy_dif1.c
@@ -612,8 +612,8 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		tmp = sqrt2+1;
 	  #if 1
 		// Use alternate "rounded the other way" copies of sqrt2,isrt2 for greater accuracy:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(tmp  , dtmp);	// This copy of isrt2 only gets assigned the same-name ptr in compact-obj_code mode
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(tmp  , dtmp);	// This copy of isrt2 only gets assigned the same-name ptr in compact-obj_code mode
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(tmp  , ISRT2);	// This copy of isrt2 only gets assigned the same-name ptr in compact-obj_code mode
 	  #endif
@@ -767,22 +767,22 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			tm2 = tmp + RADIX/4 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix128_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = radix128_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = radix128_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = radix128_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = radix128_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix128_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix128_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix128_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = radix128_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = radix128_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = radix128_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = radix128_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix128_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix128_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			for(j = 8; j < RADIX; j += 8) {
-				tmp64 = radix128_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix128_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix128_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix128_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 
@@ -792,14 +792,14 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			tm2 = tmp + RADIX/2 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix128_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-			tmp64 = radix128_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-			tmp64 = radix128_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+			tmp64 = radix128_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+			tmp64 = radix128_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+			tmp64 = radix128_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 			for(j = 4; j < RADIX; j += 4) {
-				tmp64 = radix128_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix128_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix128_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix128_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix128_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix128_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block

--- a/src/radix144_ditN_cy_dif1.c
+++ b/src/radix144_ditN_cy_dif1.c
@@ -557,8 +557,8 @@ int radix144_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		VEC_DBL_INIT(two  , 2.0  );		VEC_DBL_INIT(one, 1.0  );
 	  #if 0	// Here this trick actually degrades accuracy ... must be interaction with the radix-9 DFTs of some kind
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif

--- a/src/radix160_ditN_cy_dif1.c
+++ b/src/radix160_ditN_cy_dif1.c
@@ -526,8 +526,8 @@ int radix160_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif

--- a/src/radix16_ditN_cy_dif1.c
+++ b/src/radix16_ditN_cy_dif1.c
@@ -745,21 +745,21 @@ half_arr+5*radix	radix		[LOACC-only] inv_mult-lut
 		tm2 = tmp + RADIX/4 - 1;	// tmp+3
 		// Use tmp-pointer to init tmp+0,2; use tm2 to init tmp+3,1:
 										tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-		tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-		tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-		tmp64 = 0x3FED906BCF328D46ull;	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-		tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-		tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-		tmp64 = 0x3FE8BC806B151741ull;	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;	// tmp+2
-		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;	// tmp+1
-		tmp64 = 0x3FE44CF325091DD6ull;	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-		tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-		tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-		tmp64 = 0x3FD294062ED59F06ull;	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-		tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-		tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;	// tmp+4 (unused)
+		tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+		tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+		tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+		tmp64 = 0x3FED906BCF328D46ull;	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+		tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+		tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+		tmp64 = 0x3FE8BC806B151741ull;	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;	// tmp+2
+		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;	// tmp+1
+		tmp64 = 0x3FE44CF325091DD6ull;	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+		tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+		tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+		tmp64 = 0x3FD294062ED59F06ull;	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+		tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+		tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;	// tmp+4 (unused)
 
 		tmp = base_negacyclic_root + 2*RADIX;	// reset to point to start of above block
 
@@ -777,21 +777,21 @@ half_arr+5*radix	radix		[LOACC-only] inv_mult-lut
 		tm2 = tmp + RADIX/2 - 1;	// tmp+7
 		// Use tmp-pointer to init tmp+0,2,4,6; use tm2 to init tmp+7,5,3,1:
 										tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(01*I*Pi/32) = sin(31*I*Pi/32) */
-		tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(02*I*Pi/32) = sin(30*I*Pi/32) */
-		tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(03*I*Pi/32) = sin(29*I*Pi/32) */	tmp += 2;	// tmp+2
-		tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(04*I*Pi/32) = sin(28*I*Pi/32) */	tm2 -= 2;	// tmp+5
-		tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(05*I*Pi/32) = sin(27*I*Pi/32) */
-		tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(06*I*Pi/32) = sin(26*I*Pi/32) */
-		tmp64 = 0x3FE8BC806B151741ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(07*I*Pi/32) = sin(25*I*Pi/32) */	tmp += 2;	// tmp+4
-		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(08*I*Pi/32) = sin(24*I*Pi/32) */	tm2 -= 2;	// tmp+3
-		tmp64 = 0x3FE44CF325091DD6ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(09*I*Pi/32) = sin(23*I*Pi/32) */
-		tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(10*I*Pi/32) = sin(22*I*Pi/32) */
-		tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(11*I*Pi/32) = sin(21*I*Pi/32) */	tmp += 2;	// tmp+6
-		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(12*I*Pi/32) = sin(20*I*Pi/32) */	tm2 -= 2;	// tmp+1
-		tmp64 = 0x3FD294062ED59F06ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(13*I*Pi/32) = sin(19*I*Pi/32) */
-		tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(14*I*Pi/32) = sin(18*I*Pi/32) */
-		tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(15*I*Pi/32) = sin(17*I*Pi/32) */	tmp += 2;	// tmp+8 (unused)
+		tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(01*I*Pi/32) = sin(31*I*Pi/32) */
+		tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(02*I*Pi/32) = sin(30*I*Pi/32) */
+		tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(03*I*Pi/32) = sin(29*I*Pi/32) */	tmp += 2;	// tmp+2
+		tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(04*I*Pi/32) = sin(28*I*Pi/32) */	tm2 -= 2;	// tmp+5
+		tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(05*I*Pi/32) = sin(27*I*Pi/32) */
+		tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(06*I*Pi/32) = sin(26*I*Pi/32) */
+		tmp64 = 0x3FE8BC806B151741ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(07*I*Pi/32) = sin(25*I*Pi/32) */	tmp += 2;	// tmp+4
+		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(08*I*Pi/32) = sin(24*I*Pi/32) */	tm2 -= 2;	// tmp+3
+		tmp64 = 0x3FE44CF325091DD6ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(09*I*Pi/32) = sin(23*I*Pi/32) */
+		tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(10*I*Pi/32) = sin(22*I*Pi/32) */
+		tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(11*I*Pi/32) = sin(21*I*Pi/32) */	tmp += 2;	// tmp+6
+		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(12*I*Pi/32) = sin(20*I*Pi/32) */	tm2 -= 2;	// tmp+1
+		tmp64 = 0x3FD294062ED59F06ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(13*I*Pi/32) = sin(19*I*Pi/32) */
+		tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(14*I*Pi/32) = sin(18*I*Pi/32) */
+		tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(15*I*Pi/32) = sin(17*I*Pi/32) */	tmp += 2;	// tmp+8 (unused)
 
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 

--- a/src/radix176_ditN_cy_dif1.c
+++ b/src/radix176_ditN_cy_dif1.c
@@ -672,8 +672,8 @@ int radix176_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif

--- a/src/radix208_ditN_cy_dif1.c
+++ b/src/radix208_ditN_cy_dif1.c
@@ -553,8 +553,8 @@ const double cc1=  0.88545602565320989590,	/* Real part of exp(i*2*pi/13), the r
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif

--- a/src/radix224_ditN_cy_dif1.c
+++ b/src/radix224_ditN_cy_dif1.c
@@ -655,8 +655,8 @@ int radix224_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif
@@ -762,14 +762,14 @@ int radix224_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		tm2 = tmp + RADIX/2 - 1;
 		// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 		tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = radix224_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-		tmp64 = radix224_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-		tmp64 = radix224_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+		tmp64 = radix224_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+		tmp64 = radix224_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+		tmp64 = radix224_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 		for(j = 4; j < RADIX; j += 4) {
-			tmp64 = radix224_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-			tmp64 = radix224_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix224_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix224_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix224_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+			tmp64 = radix224_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix224_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix224_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 		}
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -782,26 +782,26 @@ int radix224_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-7:
 		tmp = base_negacyclic_root + 16;	// First 16 slots reserved for Re/Im parts of the 8 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix224_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      4];	tmp->d4 = *(double *)&tmp64;	// cos(04*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      5];	tmp->d5 = *(double *)&tmp64;	// cos(05*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      6];	tmp->d6 = *(double *)&tmp64;	// cos(06*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      7];	tmp->d7 = *(double *)&tmp64;	// cos(07*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      4];	tmp->d4 = u64_to_f64(tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      5];	tmp->d5 = u64_to_f64(tmp64);	// cos(05*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      6];	tmp->d6 = u64_to_f64(tmp64);	// cos(06*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      7];	tmp->d7 = u64_to_f64(tmp64);	// cos(07*I*Pi/(2*RADIX))
 		++tmp;
 		tmp->d0 = 0.0;
-		tmp64 = radix224_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-4];	tmp->d4 = *(double *)&tmp64;	// sin(04*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-5];	tmp->d5 = *(double *)&tmp64;	// sin(05*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-6];	tmp->d6 = *(double *)&tmp64;	// sin(06*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-7];	tmp->d7 = *(double *)&tmp64;	// sin(07*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-4];	tmp->d4 = u64_to_f64(tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-5];	tmp->d5 = u64_to_f64(tmp64);	// sin(05*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-6];	tmp->d6 = u64_to_f64(tmp64);	// sin(06*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-7];	tmp->d7 = u64_to_f64(tmp64);	// sin(07*I*Pi/(2*RADIX))
 		++tmp;	// 0x480(base_negacyclic_root)
-		tmp64 = radix224_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(08*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(08*I*Pi/(2*RADIX))
 		++tmp;	// 0x4c0(base_negacyclic_root)
-		tmp64 = radix224_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(08*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(08*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 16;	// reset to point to start of above block
 
 	   #elif defined(USE_AVX)
@@ -809,18 +809,18 @@ int radix224_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix224_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = radix224_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix224_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
 		++tmp;	// 0x140(base_negacyclic_root)
-		tmp64 = radix224_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/(2*RADIX))
 		++tmp;	// 0x160(base_negacyclic_root)
-		tmp64 = radix224_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix224_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 
 	   #endif

--- a/src/radix240_ditN_cy_dif1.c
+++ b/src/radix240_ditN_cy_dif1.c
@@ -765,14 +765,14 @@ int radix240_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		tm2 = tmp + RADIX/2 - 1;
 		// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 		tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = radix240_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-		tmp64 = radix240_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-		tmp64 = radix240_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+		tmp64 = radix240_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+		tmp64 = radix240_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+		tmp64 = radix240_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 		for(j = 4; j < RADIX; j += 4) {
-			tmp64 = radix240_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-			tmp64 = radix240_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix240_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix240_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix240_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+			tmp64 = radix240_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix240_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix240_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 		}
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -785,26 +785,26 @@ int radix240_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-7:
 		tmp = base_negacyclic_root + 16;	// First 16 slots reserved for Re/Im parts of the 8 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix240_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      4];	tmp->d4 = *(double *)&tmp64;	// cos(04*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      5];	tmp->d5 = *(double *)&tmp64;	// cos(05*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      6];	tmp->d6 = *(double *)&tmp64;	// cos(06*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      7];	tmp->d7 = *(double *)&tmp64;	// cos(07*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      4];	tmp->d4 = u64_to_f64(tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      5];	tmp->d5 = u64_to_f64(tmp64);	// cos(05*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      6];	tmp->d6 = u64_to_f64(tmp64);	// cos(06*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      7];	tmp->d7 = u64_to_f64(tmp64);	// cos(07*I*Pi/(2*RADIX))
 		++tmp;
 		tmp->d0 = 0.0;
-		tmp64 = radix240_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-4];	tmp->d4 = *(double *)&tmp64;	// sin(04*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-5];	tmp->d5 = *(double *)&tmp64;	// sin(05*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-6];	tmp->d6 = *(double *)&tmp64;	// sin(06*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-7];	tmp->d7 = *(double *)&tmp64;	// sin(07*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-4];	tmp->d4 = u64_to_f64(tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-5];	tmp->d5 = u64_to_f64(tmp64);	// sin(05*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-6];	tmp->d6 = u64_to_f64(tmp64);	// sin(06*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-7];	tmp->d7 = u64_to_f64(tmp64);	// sin(07*I*Pi/(2*RADIX))
 		++tmp;	// 0x480(base_negacyclic_root)
-		tmp64 = radix240_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(08*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(08*I*Pi/(2*RADIX))
 		++tmp;	// 0x4c0(base_negacyclic_root)
-		tmp64 = radix240_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(08*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(08*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 16;	// reset to point to start of above block
 
 	   #elif defined(USE_AVX)
@@ -812,18 +812,18 @@ int radix240_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix240_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = radix240_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix240_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
 		++tmp;	// 0x140(base_negacyclic_root)
-		tmp64 = radix240_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/(2*RADIX))
 		++tmp;	// 0x160(base_negacyclic_root)
-		tmp64 = radix240_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix240_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 
 	   #endif

--- a/src/radix256_ditN_cy_dif1.c
+++ b/src/radix256_ditN_cy_dif1.c
@@ -672,8 +672,8 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one  , 1.0  );
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
 	  #if 1
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);	VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif
@@ -829,22 +829,22 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			tm2 = tmp + RADIX/4 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix256_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = radix256_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = radix256_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = radix256_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = radix256_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix256_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix256_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix256_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = radix256_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = radix256_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = radix256_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = radix256_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix256_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix256_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			for(j = 8; j < RADIX; j += 8) {
-				tmp64 = radix256_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix256_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix256_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix256_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 
@@ -854,14 +854,14 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 			tm2 = tmp + RADIX/2 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix256_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-			tmp64 = radix256_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-			tmp64 = radix256_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+			tmp64 = radix256_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+			tmp64 = radix256_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+			tmp64 = radix256_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 			for(j = 4; j < RADIX; j += 4) {
-				tmp64 = radix256_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix256_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix256_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix256_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix256_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix256_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block

--- a/src/radix28_ditN_cy_dif1.c
+++ b/src/radix28_ditN_cy_dif1.c
@@ -829,39 +829,39 @@ int radix28_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		tmp = base_negacyclic_root + RADIX*2;	// First 56 = 2*RADIX slots reserved for RADIX/4 copies of the Re/Im parts of the 4 base multipliers
 		tm2 = tmp + RADIX/2 - 1;
 										tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = 0x3FEFF31CCABE6E4Cull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(01*I*Pi/56) = sin(27*I*Pi/56) */
-		tmp64 = 0x3FEFCC7D8C64135Full;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(02*I*Pi/56) = sin(26*I*Pi/56) */
-		tmp64 = 0x3FEF8C4160D38565ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(03*I*Pi/56) = sin(25*I*Pi/56) */
+		tmp64 = 0x3FEFF31CCABE6E4Cull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(01*I*Pi/56) = sin(27*I*Pi/56) */
+		tmp64 = 0x3FEFCC7D8C64135Full;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(02*I*Pi/56) = sin(26*I*Pi/56) */
+		tmp64 = 0x3FEF8C4160D38565ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(03*I*Pi/56) = sin(25*I*Pi/56) */
 		tmp += 2;
-		tmp64 = 0x3FEF329C0558E969ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(04*I*Pi/56) = sin(24*I*Pi/56) */	tm2 -= 2;
-		tmp64 = 0x3FEEBFD5AEFD405Aull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(05*I*Pi/56) = sin(23*I*Pi/56) */
-		tmp64 = 0x3FEE344AD05D3F86ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(06*I*Pi/56) = sin(22*I*Pi/56) */
-		tmp64 = 0x3FED906BCF328D46ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(07*I*Pi/56) = sin(21*I*Pi/56) */
+		tmp64 = 0x3FEF329C0558E969ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(04*I*Pi/56) = sin(24*I*Pi/56) */	tm2 -= 2;
+		tmp64 = 0x3FEEBFD5AEFD405Aull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(05*I*Pi/56) = sin(23*I*Pi/56) */
+		tmp64 = 0x3FEE344AD05D3F86ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(06*I*Pi/56) = sin(22*I*Pi/56) */
+		tmp64 = 0x3FED906BCF328D46ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(07*I*Pi/56) = sin(21*I*Pi/56) */
 		tmp += 2;
-		tmp64 = 0x3FECD4BCA9CB5C71ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(08*I*Pi/56) = sin(20*I*Pi/56) */	tm2 -= 2;
-		tmp64 = 0x3FEC01D48CB95263ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(09*I*Pi/56) = sin(19*I*Pi/56) */
-		tmp64 = 0x3FEB185D590D5A44ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(10*I*Pi/56) = sin(18*I*Pi/56) */
-		tmp64 = 0x3FEA19131B8279C4ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(11*I*Pi/56) = sin(17*I*Pi/56) */
+		tmp64 = 0x3FECD4BCA9CB5C71ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(08*I*Pi/56) = sin(20*I*Pi/56) */	tm2 -= 2;
+		tmp64 = 0x3FEC01D48CB95263ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(09*I*Pi/56) = sin(19*I*Pi/56) */
+		tmp64 = 0x3FEB185D590D5A44ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(10*I*Pi/56) = sin(18*I*Pi/56) */
+		tmp64 = 0x3FEA19131B8279C4ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(11*I*Pi/56) = sin(17*I*Pi/56) */
 		tmp += 2;
-		tmp64 = 0x3FE904C37505DE4Bull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(12*I*Pi/56) = sin(16*I*Pi/56) */	tm2 -= 2;
-		tmp64 = 0x3FE7DC4CF5162385ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(13*I*Pi/56) = sin(15*I*Pi/56) */
-		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(14*I*Pi/56) = sin(14*I*Pi/56) */
-		tmp64 = 0x3FE552B60F035F34ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(15*I*Pi/56) = sin(13*I*Pi/56) */
+		tmp64 = 0x3FE904C37505DE4Bull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(12*I*Pi/56) = sin(16*I*Pi/56) */	tm2 -= 2;
+		tmp64 = 0x3FE7DC4CF5162385ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(13*I*Pi/56) = sin(15*I*Pi/56) */
+		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(14*I*Pi/56) = sin(14*I*Pi/56) */
+		tmp64 = 0x3FE552B60F035F34ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(15*I*Pi/56) = sin(13*I*Pi/56) */
 		tmp += 2;
-		tmp64 = 0x3FE3F3A0E28BEDD1ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(16*I*Pi/56) = sin(12*I*Pi/56) */	tm2 -= 2;
-		tmp64 = 0x3FE28479AA873CFEull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(17*I*Pi/56) = sin(11*I*Pi/56) */
-		tmp64 = 0x3FE106682221CD8Aull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(18*I*Pi/56) = sin(10*I*Pi/56) */
-		tmp64 = 0x3FDEF5401024C4F4ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(19*I*Pi/56) = sin(09*I*Pi/56) */
+		tmp64 = 0x3FE3F3A0E28BEDD1ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(16*I*Pi/56) = sin(12*I*Pi/56) */	tm2 -= 2;
+		tmp64 = 0x3FE28479AA873CFEull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(17*I*Pi/56) = sin(11*I*Pi/56) */
+		tmp64 = 0x3FE106682221CD8Aull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(18*I*Pi/56) = sin(10*I*Pi/56) */
+		tmp64 = 0x3FDEF5401024C4F4ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(19*I*Pi/56) = sin(09*I*Pi/56) */
 		tmp += 2;
-		tmp64 = 0x3FDBC4C04D71ABC1ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(20*I*Pi/56) = sin(08*I*Pi/56) */	tm2 -= 2;
-		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(21*I*Pi/56) = sin(07*I*Pi/56) */
-		tmp64 = 0x3FD5234ACA69A9FEull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(22*I*Pi/56) = sin(06*I*Pi/56) */
-		tmp64 = 0x3FD1B7AC4AFC3C02ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(23*I*Pi/56) = sin(05*I*Pi/56) */
+		tmp64 = 0x3FDBC4C04D71ABC1ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(20*I*Pi/56) = sin(08*I*Pi/56) */	tm2 -= 2;
+		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(21*I*Pi/56) = sin(07*I*Pi/56) */
+		tmp64 = 0x3FD5234ACA69A9FEull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(22*I*Pi/56) = sin(06*I*Pi/56) */
+		tmp64 = 0x3FD1B7AC4AFC3C02ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(23*I*Pi/56) = sin(05*I*Pi/56) */
 		tmp += 2;
-		tmp64 = 0x3FCC7B90E3024582ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(24*I*Pi/56) = sin(04*I*Pi/56) */	tm2 -= 2;
-		tmp64 = 0x3FC570D80B7C3350ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(25*I*Pi/56) = sin(03*I*Pi/56) */
-		tmp64 = 0x3FBCA9B4332D6F61ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(26*I*Pi/56) = sin(02*I*Pi/56) */
-		tmp64 = 0x3FACB544024FC940ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(27*I*Pi/56) = sin(01*I*Pi/56) */
+		tmp64 = 0x3FCC7B90E3024582ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(24*I*Pi/56) = sin(04*I*Pi/56) */	tm2 -= 2;
+		tmp64 = 0x3FC570D80B7C3350ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(25*I*Pi/56) = sin(03*I*Pi/56) */
+		tmp64 = 0x3FBCA9B4332D6F61ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(26*I*Pi/56) = sin(02*I*Pi/56) */
+		tmp64 = 0x3FACB544024FC940ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(27*I*Pi/56) = sin(01*I*Pi/56) */
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// 7 AVX-register-sized complex data
 
@@ -890,17 +890,17 @@ int radix28_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		// Init exp(j*I*Pi/2)/28, for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = 0x3FEFF31CCABE6E4Cull;	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/56)
-		tmp64 = 0x3FEFCC7D8C64135Full;	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/56)
-		tmp64 = 0x3FEF8C4160D38565ull;	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/56)
+		tmp64 = 0x3FEFF31CCABE6E4Cull;	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/56)
+		tmp64 = 0x3FEFCC7D8C64135Full;	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/56)
+		tmp64 = 0x3FEF8C4160D38565ull;	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/56)
 		(++tmp)->d0 = 0.0;
-		tmp64 = 0x3FC570D80B7C3350ull;	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/120)
-		tmp64 = 0x3FBCA9B4332D6F61ull;	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/120)
-		tmp64 = 0x3FACB544024FC940ull;	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/120)
+		tmp64 = 0x3FC570D80B7C3350ull;	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/120)
+		tmp64 = 0x3FBCA9B4332D6F61ull;	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/120)
+		tmp64 = 0x3FACB544024FC940ull;	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/120)
 		++tmp;
-		tmp64 = 0x3FEF329C0558E969ull;	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/56)
+		tmp64 = 0x3FEF329C0558E969ull;	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/56)
 		++tmp;
-		tmp64 = 0x3FCC7B90E3024582ull;	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/56)
+		tmp64 = 0x3FCC7B90E3024582ull;	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/56)
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 		nbytes = 4*SZ_VD;	// 2 AVX-register-sized complex data
 

--- a/src/radix32_ditN_cy_dif1.c
+++ b/src/radix32_ditN_cy_dif1.c
@@ -496,8 +496,8 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		VEC_DBL_INIT(two  , 2.0  );		VEC_DBL_INIT(one, 1.0  );
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif
@@ -578,37 +578,37 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			tm2 = tmp + RADIX/4 - 1;	// tmp+7
 			// Use tmp-pointer to init tmp+0,2; use tm2 to init tmp+3,1:
 											tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = 0x3FEFF621E3796D7Eull;	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = 0x3FEFA7557F08A517ull;	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = 0x3FEF0A7EFB9230D7ull;	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = 0x3FEE212104F686E5ull;	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;	// tmp+2
-			tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;	// tmp+5
-			tmp64 = 0x3FECED7AF43CC773ull;	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = 0x3FEB728345196E3Eull;	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = 0x3FE9B3E047F38741ull;	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = 0x3FE8BC806B151741ull;	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = 0x3FE7B5DF226AAFAFull;	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;	// tmp+4
-			tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;	// tmp+3
-			tmp64 = 0x3FE57D69348CECA0ull;	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = 0x3FE44CF325091DD6ull;	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = 0x3FE30FF7FCE17035ull;	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = 0x3FE073879922FFEEull;	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = 0x3FDB5D1009E15CC0ull;	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;	// tmp+6
-			tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;	// tmp+1
-			tmp64 = 0x3FD58F9A75AB1FDDull;	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = 0x3FD294062ED59F06ull;	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = 0x3FCF19F97B215F1Bull;	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = 0x3FC2C8106E8E613Aull;	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = 0x3FA91F65F10DD814ull;	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;	// tmp+8 (unused)
+			tmp64 = 0x3FEFF621E3796D7Eull;	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEFA7557F08A517ull;	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEF0A7EFB9230D7ull;	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEE212104F686E5ull;	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;	// tmp+2
+			tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;	// tmp+5
+			tmp64 = 0x3FECED7AF43CC773ull;	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEB728345196E3Eull;	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = 0x3FE9B3E047F38741ull;	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = 0x3FE8BC806B151741ull;	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = 0x3FE7B5DF226AAFAFull;	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;	// tmp+4
+			tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;	// tmp+3
+			tmp64 = 0x3FE57D69348CECA0ull;	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = 0x3FE44CF325091DD6ull;	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = 0x3FE30FF7FCE17035ull;	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = 0x3FE073879922FFEEull;	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = 0x3FDB5D1009E15CC0ull;	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;	// tmp+6
+			tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;	// tmp+1
+			tmp64 = 0x3FD58F9A75AB1FDDull;	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = 0x3FD294062ED59F06ull;	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = 0x3FCF19F97B215F1Bull;	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = 0x3FC2C8106E8E613Aull;	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = 0x3FA91F65F10DD814ull;	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;	// tmp+8 (unused)
 
 			tmp = base_negacyclic_root + 2*RADIX;	// reset to point to start of above block
 
@@ -640,37 +640,37 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			tmp = base_negacyclic_root + RADIX*2;	// First 2*RADIX slots reserved for RADIX/4 copies of the Re/Im parts of the 4 base multipliers
 			tm2 = tmp + RADIX/2 - 1;
 											tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = 0x3FEFF621E3796D7Eull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(01*I*Pi/64) = sin(63*I*Pi/64) */
-			tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(02*I*Pi/64) = sin(62*I*Pi/64) */
-			tmp64 = 0x3FEFA7557F08A517ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(03*I*Pi/64) = sin(61*I*Pi/64) */	tmp += 2;
-			tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(04*I*Pi/64) = sin(60*I*Pi/64) */	tm2 -= 2;
-			tmp64 = 0x3FEF0A7EFB9230D7ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(05*I*Pi/64) = sin(59*I*Pi/64) */
-			tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(06*I*Pi/64) = sin(58*I*Pi/64) */
-			tmp64 = 0x3FEE212104F686E5ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(07*I*Pi/64) = sin(57*I*Pi/64) */	tmp += 2;
-			tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(08*I*Pi/64) = sin(56*I*Pi/64) */	tm2 -= 2;
-			tmp64 = 0x3FECED7AF43CC773ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(09*I*Pi/64) = sin(55*I*Pi/64) */
-			tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(10*I*Pi/64) = sin(54*I*Pi/64) */
-			tmp64 = 0x3FEB728345196E3Eull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(11*I*Pi/64) = sin(53*I*Pi/64) */	tmp += 2;
-			tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(12*I*Pi/64) = sin(52*I*Pi/64) */	tm2 -= 2;
-			tmp64 = 0x3FE9B3E047F38741ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(13*I*Pi/64) = sin(51*I*Pi/64) */
-			tmp64 = 0x3FE8BC806B151741ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(14*I*Pi/64) = sin(50*I*Pi/64) */
-			tmp64 = 0x3FE7B5DF226AAFAFull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(15*I*Pi/64) = sin(49*I*Pi/64) */	tmp += 2;
-			tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(16*I*Pi/64) = sin(48*I*Pi/64) */	tm2 -= 2;
-			tmp64 = 0x3FE57D69348CECA0ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(17*I*Pi/64) = sin(47*I*Pi/64) */
-			tmp64 = 0x3FE44CF325091DD6ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(18*I*Pi/64) = sin(46*I*Pi/64) */
-			tmp64 = 0x3FE30FF7FCE17035ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(19*I*Pi/64) = sin(45*I*Pi/64) */	tmp += 2;
-			tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(20*I*Pi/64) = sin(44*I*Pi/64) */	tm2 -= 2;
-			tmp64 = 0x3FE073879922FFEEull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(21*I*Pi/64) = sin(43*I*Pi/64) */
-			tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(22*I*Pi/64) = sin(42*I*Pi/64) */
-			tmp64 = 0x3FDB5D1009E15CC0ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(23*I*Pi/64) = sin(41*I*Pi/64) */	tmp += 2;
-			tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(24*I*Pi/64) = sin(40*I*Pi/64) */	tm2 -= 2;
-			tmp64 = 0x3FD58F9A75AB1FDDull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(25*I*Pi/64) = sin(39*I*Pi/64) */
-			tmp64 = 0x3FD294062ED59F06ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(26*I*Pi/64) = sin(38*I*Pi/64) */
-			tmp64 = 0x3FCF19F97B215F1Bull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(27*I*Pi/64) = sin(37*I*Pi/64) */	tmp += 2;
-			tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(28*I*Pi/64) = sin(36*I*Pi/64) */	tm2 -= 2;
-			tmp64 = 0x3FC2C8106E8E613Aull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(29*I*Pi/64) = sin(35*I*Pi/64) */
-			tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(30*I*Pi/64) = sin(34*I*Pi/64) */
-			tmp64 = 0x3FA91F65F10DD814ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(31*I*Pi/64) = sin(33*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FEFF621E3796D7Eull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(01*I*Pi/64) = sin(63*I*Pi/64) */
+			tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(02*I*Pi/64) = sin(62*I*Pi/64) */
+			tmp64 = 0x3FEFA7557F08A517ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(03*I*Pi/64) = sin(61*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(04*I*Pi/64) = sin(60*I*Pi/64) */	tm2 -= 2;
+			tmp64 = 0x3FEF0A7EFB9230D7ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(05*I*Pi/64) = sin(59*I*Pi/64) */
+			tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(06*I*Pi/64) = sin(58*I*Pi/64) */
+			tmp64 = 0x3FEE212104F686E5ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(07*I*Pi/64) = sin(57*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(08*I*Pi/64) = sin(56*I*Pi/64) */	tm2 -= 2;
+			tmp64 = 0x3FECED7AF43CC773ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(09*I*Pi/64) = sin(55*I*Pi/64) */
+			tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(10*I*Pi/64) = sin(54*I*Pi/64) */
+			tmp64 = 0x3FEB728345196E3Eull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(11*I*Pi/64) = sin(53*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(12*I*Pi/64) = sin(52*I*Pi/64) */	tm2 -= 2;
+			tmp64 = 0x3FE9B3E047F38741ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(13*I*Pi/64) = sin(51*I*Pi/64) */
+			tmp64 = 0x3FE8BC806B151741ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(14*I*Pi/64) = sin(50*I*Pi/64) */
+			tmp64 = 0x3FE7B5DF226AAFAFull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(15*I*Pi/64) = sin(49*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(16*I*Pi/64) = sin(48*I*Pi/64) */	tm2 -= 2;
+			tmp64 = 0x3FE57D69348CECA0ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(17*I*Pi/64) = sin(47*I*Pi/64) */
+			tmp64 = 0x3FE44CF325091DD6ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(18*I*Pi/64) = sin(46*I*Pi/64) */
+			tmp64 = 0x3FE30FF7FCE17035ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(19*I*Pi/64) = sin(45*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(20*I*Pi/64) = sin(44*I*Pi/64) */	tm2 -= 2;
+			tmp64 = 0x3FE073879922FFEEull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(21*I*Pi/64) = sin(43*I*Pi/64) */
+			tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(22*I*Pi/64) = sin(42*I*Pi/64) */
+			tmp64 = 0x3FDB5D1009E15CC0ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(23*I*Pi/64) = sin(41*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(24*I*Pi/64) = sin(40*I*Pi/64) */	tm2 -= 2;
+			tmp64 = 0x3FD58F9A75AB1FDDull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(25*I*Pi/64) = sin(39*I*Pi/64) */
+			tmp64 = 0x3FD294062ED59F06ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(26*I*Pi/64) = sin(38*I*Pi/64) */
+			tmp64 = 0x3FCF19F97B215F1Bull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(27*I*Pi/64) = sin(37*I*Pi/64) */	tmp += 2;
+			tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(28*I*Pi/64) = sin(36*I*Pi/64) */	tm2 -= 2;
+			tmp64 = 0x3FC2C8106E8E613Aull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(29*I*Pi/64) = sin(35*I*Pi/64) */
+			tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(30*I*Pi/64) = sin(34*I*Pi/64) */
+			tmp64 = 0x3FA91F65F10DD814ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(31*I*Pi/64) = sin(33*I*Pi/64) */	tmp += 2;
 
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 

--- a/src/radix352_ditN_cy_dif1.c
+++ b/src/radix352_ditN_cy_dif1.c
@@ -593,8 +593,8 @@ int radix352_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif

--- a/src/radix384_ditN_cy_dif1.c
+++ b/src/radix384_ditN_cy_dif1.c
@@ -553,8 +553,8 @@ int radix384_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 
 		/* These remain fixed: */
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		VEC_DBL_INIT(cc0  ,  c16);
 		VEC_DBL_INIT(ss0  ,  s16);
 		/* cc0 = (cc1+cc2+cc3)/3 - 1; subtract 1 from Nussbaumer's definition in order to ease in-place computation */

--- a/src/radix4032_ditN_cy_dif1.c
+++ b/src/radix4032_ditN_cy_dif1.c
@@ -616,14 +616,14 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		tm2 = tmp + RADIX/2 - 1;
 		// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 		tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = radix4032_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-		tmp64 = radix4032_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-		tmp64 = radix4032_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+		tmp64 = radix4032_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+		tmp64 = radix4032_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+		tmp64 = radix4032_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 		for(j = 4; j < RADIX; j += 4) {
-			tmp64 = radix4032_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-			tmp64 = radix4032_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix4032_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix4032_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix4032_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+			tmp64 = radix4032_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix4032_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix4032_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 		}
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -636,26 +636,26 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-7:
 		tmp = base_negacyclic_root + 16;	// First 16 slots reserved for Re/Im parts of the 8 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix4032_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      4];	tmp->d4 = *(double *)&tmp64;	// cos(04*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      5];	tmp->d5 = *(double *)&tmp64;	// cos(05*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      6];	tmp->d6 = *(double *)&tmp64;	// cos(06*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      7];	tmp->d7 = *(double *)&tmp64;	// cos(07*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      4];	tmp->d4 = u64_to_f64(tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      5];	tmp->d5 = u64_to_f64(tmp64);	// cos(05*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      6];	tmp->d6 = u64_to_f64(tmp64);	// cos(06*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      7];	tmp->d7 = u64_to_f64(tmp64);	// cos(07*I*Pi/(2*RADIX))
 		++tmp;
 		tmp->d0 = 0.0;
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-4];	tmp->d4 = *(double *)&tmp64;	// sin(04*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-5];	tmp->d5 = *(double *)&tmp64;	// sin(05*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-6];	tmp->d6 = *(double *)&tmp64;	// sin(06*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-7];	tmp->d7 = *(double *)&tmp64;	// sin(07*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-4];	tmp->d4 = u64_to_f64(tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-5];	tmp->d5 = u64_to_f64(tmp64);	// sin(05*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-6];	tmp->d6 = u64_to_f64(tmp64);	// sin(06*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-7];	tmp->d7 = u64_to_f64(tmp64);	// sin(07*I*Pi/(2*RADIX))
 		++tmp;	// 0x480(base_negacyclic_root)
-		tmp64 = radix4032_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(08*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(08*I*Pi/(2*RADIX))
 		++tmp;	// 0x4c0(base_negacyclic_root)
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(08*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(08*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 16;	// reset to point to start of above block
 
 	   #elif defined(USE_AVX)
@@ -663,18 +663,18 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix4032_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix4032_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix4032_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix4032_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 
 	   #endif

--- a/src/radix40_ditN_cy_dif1.c
+++ b/src/radix40_ditN_cy_dif1.c
@@ -532,8 +532,8 @@ int radix40_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		/* These remain fixed: */
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 		// Alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		VEC_DBL_INIT(xcc1 , cc1  );
 		VEC_DBL_INIT(xcc2 , cc2  );
 		VEC_DBL_INIT(xss1 , s2   );

--- a/src/radix48_ditN_cy_dif1.c
+++ b/src/radix48_ditN_cy_dif1.c
@@ -562,8 +562,8 @@ int radix48_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 
 		/* These remain fixed: */
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		VEC_DBL_INIT(cc0, c16  );	VEC_DBL_INIT(ss0, s16);	// Radix-16 DFT macros assume [isrt2,cc0,ss0] memory ordering
 		/* cc0 = (cc1+cc2+cc3)/3 - 1; subtract 1 from Nussbaumer's definition in order to ease in-place computation */
 		VEC_DBL_INIT(cc1, c3m1);	VEC_DBL_INIT(ss1, s  );

--- a/src/radix56_ditN_cy_dif1.c
+++ b/src/radix56_ditN_cy_dif1.c
@@ -663,8 +663,8 @@ int radix56_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif
@@ -767,14 +767,14 @@ int radix56_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		tm2 = tmp + RADIX/2 - 1;
 		// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 		tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = radix56_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-		tmp64 = radix56_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-		tmp64 = radix56_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+		tmp64 = radix56_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+		tmp64 = radix56_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+		tmp64 = radix56_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 		for(j = 4; j < RADIX; j += 4) {
-			tmp64 = radix56_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-			tmp64 = radix56_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix56_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix56_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix56_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+			tmp64 = radix56_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix56_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix56_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 		}
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -787,26 +787,26 @@ int radix56_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-7:
 		tmp = base_negacyclic_root + 16;	// First 16 slots reserved for Re/Im parts of the 8 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix56_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      4];	tmp->d4 = *(double *)&tmp64;	// cos(04*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      5];	tmp->d5 = *(double *)&tmp64;	// cos(05*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      6];	tmp->d6 = *(double *)&tmp64;	// cos(06*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      7];	tmp->d7 = *(double *)&tmp64;	// cos(07*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      4];	tmp->d4 = u64_to_f64(tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      5];	tmp->d5 = u64_to_f64(tmp64);	// cos(05*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      6];	tmp->d6 = u64_to_f64(tmp64);	// cos(06*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      7];	tmp->d7 = u64_to_f64(tmp64);	// cos(07*I*Pi/(2*RADIX))
 		++tmp;
 		tmp->d0 = 0.0;
-		tmp64 = radix56_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-4];	tmp->d4 = *(double *)&tmp64;	// sin(04*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-5];	tmp->d5 = *(double *)&tmp64;	// sin(05*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-6];	tmp->d6 = *(double *)&tmp64;	// sin(06*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-7];	tmp->d7 = *(double *)&tmp64;	// sin(07*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-4];	tmp->d4 = u64_to_f64(tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-5];	tmp->d5 = u64_to_f64(tmp64);	// sin(05*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-6];	tmp->d6 = u64_to_f64(tmp64);	// sin(06*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-7];	tmp->d7 = u64_to_f64(tmp64);	// sin(07*I*Pi/(2*RADIX))
 		++tmp;	// 0x480(base_negacyclic_root)
-		tmp64 = radix56_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(08*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(08*I*Pi/(2*RADIX))
 		++tmp;	// 0x4c0(base_negacyclic_root)
-		tmp64 = radix56_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(08*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(08*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 16;	// reset to point to start of above block
 
 	   #elif defined(USE_AVX)
@@ -814,18 +814,18 @@ int radix56_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix56_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = radix56_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix56_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix56_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix56_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix56_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 
 	   #endif

--- a/src/radix60_ditN_cy_dif1.c
+++ b/src/radix60_ditN_cy_dif1.c
@@ -802,14 +802,14 @@ int radix60_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		tm2 = tmp + RADIX/2 - 1;
 		// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 		tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = radix60_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-		tmp64 = radix60_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-		tmp64 = radix60_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+		tmp64 = radix60_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+		tmp64 = radix60_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+		tmp64 = radix60_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 		for(j = 4; j < RADIX; j += 4) {
-			tmp64 = radix60_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-			tmp64 = radix60_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix60_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix60_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix60_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+			tmp64 = radix60_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix60_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix60_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 		}
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -822,26 +822,26 @@ int radix60_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-7:
 		tmp = base_negacyclic_root + 16;	// First 16 slots reserved for Re/Im parts of the 8 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix60_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      4];	tmp->d4 = *(double *)&tmp64;	// cos(04*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      5];	tmp->d5 = *(double *)&tmp64;	// cos(05*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      6];	tmp->d6 = *(double *)&tmp64;	// cos(06*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      7];	tmp->d7 = *(double *)&tmp64;	// cos(07*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      4];	tmp->d4 = u64_to_f64(tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      5];	tmp->d5 = u64_to_f64(tmp64);	// cos(05*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      6];	tmp->d6 = u64_to_f64(tmp64);	// cos(06*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      7];	tmp->d7 = u64_to_f64(tmp64);	// cos(07*I*Pi/(2*RADIX))
 		++tmp;
 		tmp->d0 = 0.0;
-		tmp64 = radix60_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-4];	tmp->d4 = *(double *)&tmp64;	// sin(04*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-5];	tmp->d5 = *(double *)&tmp64;	// sin(05*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-6];	tmp->d6 = *(double *)&tmp64;	// sin(06*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-7];	tmp->d7 = *(double *)&tmp64;	// sin(07*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-4];	tmp->d4 = u64_to_f64(tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-5];	tmp->d5 = u64_to_f64(tmp64);	// sin(05*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-6];	tmp->d6 = u64_to_f64(tmp64);	// sin(06*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-7];	tmp->d7 = u64_to_f64(tmp64);	// sin(07*I*Pi/(2*RADIX))
 		++tmp;	// 0x480(base_negacyclic_root)
-		tmp64 = radix60_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(08*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(08*I*Pi/(2*RADIX))
 		++tmp;	// 0x4c0(base_negacyclic_root)
-		tmp64 = radix60_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(08*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(08*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 16;	// reset to point to start of above block
 
 	   #elif defined(USE_AVX)
@@ -849,18 +849,18 @@ int radix60_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix60_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = radix60_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix60_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix60_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix60_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix60_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 
 	   #endif

--- a/src/radix64_ditN_cy_dif1.c
+++ b/src/radix64_ditN_cy_dif1.c
@@ -687,8 +687,8 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
 		tmp = sqrt2+1;
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		VEC_DBL_INIT(nisrt2,-dtmp);
 		VEC_DBL_INIT( isrt2, dtmp);									// Copies of +ISRT2 needed for 30-asm-macro-operand-GCC-limit workaround:
 		VEC_DBL_INIT( cc0,   1.0);		VEC_DBL_INIT( ss0,   0.0);	//	tmp =  cc0-1; ASSERT(tmp->d0 == ISRT2 && tmp->d1 == ISRT2, "tmp->d0,1 != ISRT2");	Disable to allow "round down" variant
@@ -813,22 +813,22 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			tm2 = tmp + RADIX/4 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix64_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-			tmp64 = radix64_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-			tmp64 = radix64_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-			tmp64 = radix64_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-			tmp64 = radix64_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix64_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix64_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix64_avx_negadwt_consts[1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+			tmp64 = radix64_avx_negadwt_consts[2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+			tmp64 = radix64_avx_negadwt_consts[3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+			tmp64 = radix64_avx_negadwt_consts[4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+			tmp64 = radix64_avx_negadwt_consts[5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix64_avx_negadwt_consts[6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix64_avx_negadwt_consts[7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			for(j = 8; j < RADIX; j += 8) {
-				tmp64 = radix64_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix64_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix64_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix64_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d7 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d6 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d5 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+4];	tmp->d4 = tm2->d4 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+5];	tmp->d5 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+6];	tmp->d6 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+7];	tmp->d7 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 
@@ -838,14 +838,14 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 			tm2 = tmp + RADIX/2 - 1;
 			// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 			tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-			tmp64 = radix64_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;				/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-			tmp64 = radix64_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;				/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-			tmp64 = radix64_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */
+			tmp64 = radix64_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);				/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+			tmp64 = radix64_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);				/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+			tmp64 = radix64_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */
 			for(j = 4; j < RADIX; j += 4) {
-				tmp64 = radix64_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-				tmp64 = radix64_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-				tmp64 = radix64_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+				tmp64 = radix64_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+				tmp64 = radix64_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+				tmp64 = radix64_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 			}
 			tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 

--- a/src/radix768_ditN_cy_dif1.c
+++ b/src/radix768_ditN_cy_dif1.c
@@ -546,8 +546,8 @@ int radix768_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 
 		/* These remain fixed: */
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one, 1.0  );
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		VEC_DBL_INIT(cc0  ,  c16);
 		VEC_DBL_INIT(ss0  ,  s16);
 		/* cc0 = (cc1+cc2+cc3)/3 - 1; subtract 1 from Nussbaumer's definition in order to ease in-place computation */

--- a/src/radix8_dif_dit_pass.c
+++ b/src/radix8_dif_dit_pass.c
@@ -124,8 +124,8 @@ void radix8_dif_pass(double a[], int n, struct complex rt0[], struct complex rt1
 			/* These remain fixed within each per-thread local store: */
 		  #if 1
 			// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-			dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-			dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+			dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+			dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		  #else
 			VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 		  #endif
@@ -151,8 +151,8 @@ void radix8_dif_pass(double a[], int n, struct complex rt0[], struct complex rt1
 		/* These remain fixed: */
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif
@@ -180,8 +180,8 @@ void radix8_dif_pass(double a[], int n, struct complex rt0[], struct complex rt1
 		/* These remain fixed: */
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif
@@ -584,8 +584,8 @@ void radix8_dit_pass(double a[], int n, struct complex rt0[], struct complex rt1
 			/* These remain fixed within each per-thread local store: */
 		  #if 1
 			// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-			dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-			dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+			dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+			dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 		  #else
 			VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 		  #endif
@@ -611,8 +611,8 @@ void radix8_dit_pass(double a[], int n, struct complex rt0[], struct complex rt1
 		/* These remain fixed: */
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif
@@ -643,8 +643,8 @@ void radix8_dit_pass(double a[], int n, struct complex rt0[], struct complex rt1
 		/* These remain fixed: */
 	  #if 1
 		// 2 unnamed slots for alternate "rounded the other way" copies of sqrt2,isrt2:
-		dtmp = *(double *)&sqrt2_dn;	VEC_DBL_INIT(sqrt2, dtmp);
-		dtmp = *(double *)&isrt2_dn;	VEC_DBL_INIT(isrt2, dtmp);
+		dtmp = u64_to_f64(sqrt2_dn);	VEC_DBL_INIT(sqrt2, dtmp);
+		dtmp = u64_to_f64(isrt2_dn);	VEC_DBL_INIT(isrt2, dtmp);
 	  #else
 		VEC_DBL_INIT(sqrt2, SQRT2);		VEC_DBL_INIT(isrt2, ISRT2);
 	  #endif

--- a/src/radix960_ditN_cy_dif1.c
+++ b/src/radix960_ditN_cy_dif1.c
@@ -771,14 +771,14 @@ int radix960_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		tm2 = tmp + RADIX/2 - 1;
 		// First elt-pair needs special handling - have the 1.0 in avx_negadwt_consts[0] but the sine term buggers things
 		tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = radix960_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
-		tmp64 = radix960_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
-		tmp64 = radix960_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
+		tmp64 = radix960_avx_negadwt_consts[1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/(2*RADIX)) = sin((RADIX-  1)*I*Pi/(2*RADIX)) */
+		tmp64 = radix960_avx_negadwt_consts[2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/(2*RADIX)) = sin((RADIX-  2)*I*Pi/(2*RADIX)) */
+		tmp64 = radix960_avx_negadwt_consts[3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/(2*RADIX)) = sin((RADIX-  3)*I*Pi/(2*RADIX)) */	tmp += 2;
 		for(j = 4; j < RADIX; j += 4) {
-			tmp64 = radix960_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = *(double *)&tmp64;	tm2 -= 2;
-			tmp64 = radix960_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = *(double *)&tmp64;
-			tmp64 = radix960_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = *(double *)&tmp64;
-			tmp64 = radix960_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = *(double *)&tmp64;	tmp += 2;
+			tmp64 = radix960_avx_negadwt_consts[j+0];	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	tm2 -= 2;
+			tmp64 = radix960_avx_negadwt_consts[j+1];	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);
+			tmp64 = radix960_avx_negadwt_consts[j+2];	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);
+			tmp64 = radix960_avx_negadwt_consts[j+3];	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	tmp += 2;
 		}
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -791,26 +791,26 @@ int radix960_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-7:
 		tmp = base_negacyclic_root + 16;	// First 16 slots reserved for Re/Im parts of the 8 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix960_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      4];	tmp->d4 = *(double *)&tmp64;	// cos(04*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      5];	tmp->d5 = *(double *)&tmp64;	// cos(05*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      6];	tmp->d6 = *(double *)&tmp64;	// cos(06*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      7];	tmp->d7 = *(double *)&tmp64;	// cos(07*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      4];	tmp->d4 = u64_to_f64(tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      5];	tmp->d5 = u64_to_f64(tmp64);	// cos(05*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      6];	tmp->d6 = u64_to_f64(tmp64);	// cos(06*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      7];	tmp->d7 = u64_to_f64(tmp64);	// cos(07*I*Pi/(2*RADIX))
 		++tmp;
 		tmp->d0 = 0.0;
-		tmp64 = radix960_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-4];	tmp->d4 = *(double *)&tmp64;	// sin(04*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-5];	tmp->d5 = *(double *)&tmp64;	// sin(05*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-6];	tmp->d6 = *(double *)&tmp64;	// sin(06*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-7];	tmp->d7 = *(double *)&tmp64;	// sin(07*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-4];	tmp->d4 = u64_to_f64(tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-5];	tmp->d5 = u64_to_f64(tmp64);	// sin(05*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-6];	tmp->d6 = u64_to_f64(tmp64);	// sin(06*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-7];	tmp->d7 = u64_to_f64(tmp64);	// sin(07*I*Pi/(2*RADIX))
 		++tmp;	// 0x480(base_negacyclic_root)
-		tmp64 = radix960_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(08*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(08*I*Pi/(2*RADIX))
 		++tmp;	// 0x4c0(base_negacyclic_root)
-		tmp64 = radix960_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(08*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-8];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(08*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 16;	// reset to point to start of above block
 
 	   #elif defined(USE_AVX)
@@ -818,18 +818,18 @@ int radix960_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = radix960_avx_negadwt_consts[      1];	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      2];	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[      3];	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      1];	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      2];	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      3];	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/(2*RADIX))
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = radix960_avx_negadwt_consts[RADIX-1];	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-2];	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/(2*RADIX))
-		tmp64 = radix960_avx_negadwt_consts[RADIX-3];	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-1];	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-2];	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-3];	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix960_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[      4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/(2*RADIX))
 		++tmp;
-		tmp64 = radix960_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/(2*RADIX))
+		tmp64 = radix960_avx_negadwt_consts[RADIX-4];	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/(2*RADIX))
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 
 	   #endif

--- a/src/radix992_ditN_cy_dif1.c
+++ b/src/radix992_ditN_cy_dif1.c
@@ -608,245 +608,245 @@ int radix992_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		tmp = base_negacyclic_root + RADIX*2;	// First 2*RADIX slots reserved for RADIX/4 copies of the Re/Im parts of the 4 base multipliers
 		tm2 = tmp + RADIX/2 - 1;
 										tmp->d0 = 1.0;	(tmp+1)->d0 = 0.0;
-		tmp64 = 0x3FEFFFD3151E5533ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  1*I*Pi/480) = sin(239*I*Pi/480) */
-		tmp64 = 0x3FEFFF4C54F76E1Cull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  2*I*Pi/480) = sin(238*I*Pi/480) */
-		tmp64 = 0x3FEFFE6BC105954Eull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  3*I*Pi/480) = sin(237*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEFFD315BBF4275ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(  4*I*Pi/480) = sin(236*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEFFB9D2897136Eull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  5*I*Pi/480) = sin(235*I*Pi/480) */
-		tmp64 = 0x3FEFF9AF2BFBC297ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(  6*I*Pi/480) = sin(234*I*Pi/480) */
-		tmp64 = 0x3FEFF7676B581A63ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(  7*I*Pi/480) = sin(233*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEFF4C5ED12E61Dull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(  8*I*Pi/480) = sin(232*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEFF1CAB88EDFF7ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(  9*I*Pi/480) = sin(231*I*Pi/480) */
-		tmp64 = 0x3FEFEE75D62A9C46ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 10*I*Pi/480) = sin(230*I*Pi/480) */
-		tmp64 = 0x3FEFEAC74F40720Cull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 11*I*Pi/480) = sin(229*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEFE6BF2E2660AFull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 12*I*Pi/480) = sin(228*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEFE25D7E2DF2F8ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 13*I*Pi/480) = sin(227*I*Pi/480) */
-		tmp64 = 0x3FEFDDA24BA41F4Dull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 14*I*Pi/480) = sin(226*I*Pi/480) */
-		tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 15*I*Pi/480) = sin(225*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEFD31F94F867C6ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 16*I*Pi/480) = sin(224*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEFCD582E584632ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 17*I*Pi/480) = sin(223*I*Pi/480) */
-		tmp64 = 0x3FEFC7378029F05Full;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 18*I*Pi/480) = sin(222*I*Pi/480) */
-		tmp64 = 0x3FEFC0BD9BA139AEull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 19*I*Pi/480) = sin(221*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEFB9EA92EC689Bull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 20*I*Pi/480) = sin(220*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEFB2BE793403B9ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 21*I*Pi/480) = sin(219*I*Pi/480) */
-		tmp64 = 0x3FEFAB39629A9BE3ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 22*I*Pi/480) = sin(218*I*Pi/480) */
-		tmp64 = 0x3FEFA35B643C93B9ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 23*I*Pi/480) = sin(217*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEF9B24942FE45Cull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 24*I*Pi/480) = sin(216*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEF92950983DF6Bull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 25*I*Pi/480) = sin(215*I*Pi/480) */
-		tmp64 = 0x3FEF89ACDC40EE4Bull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 26*I*Pi/480) = sin(214*I*Pi/480) */
-		tmp64 = 0x3FEF806C25684EA8ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 27*I*Pi/480) = sin(213*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEF76D2FEF3CC4Bull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 28*I*Pi/480) = sin(212*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEF6CE183D57825ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 29*I*Pi/480) = sin(211*I*Pi/480) */
-		tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 30*I*Pi/480) = sin(210*I*Pi/480) */
-		tmp64 = 0x3FEF57F6003B2F91ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 31*I*Pi/480) = sin(209*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEF4CFC327A0080ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 32*I*Pi/480) = sin(208*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEF41AA8583E57Eull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 33*I*Pi/480) = sin(207*I*Pi/480) */
-		tmp64 = 0x3FEF3601191FA459ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 34*I*Pi/480) = sin(206*I*Pi/480) */
-		tmp64 = 0x3FEF2A000E0A5970ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 35*I*Pi/480) = sin(205*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEF1DA785F71BCEull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 36*I*Pi/480) = sin(204*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEF10F7A38E9E90ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 37*I*Pi/480) = sin(203*I*Pi/480) */
-		tmp64 = 0x3FEF03F08A6ECF94ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 38*I*Pi/480) = sin(202*I*Pi/480) */
-		tmp64 = 0x3FEEF6925F2A7380ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 39*I*Pi/480) = sin(201*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEEE8DD4748BF15ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 40*I*Pi/480) = sin(200*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEEDAD16944EDD0ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 41*I*Pi/480) = sin(199*I*Pi/480) */
-		tmp64 = 0x3FEECC6EEC8DD5E9ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 42*I*Pi/480) = sin(198*I*Pi/480) */
-		tmp64 = 0x3FEEBDB5F9857999ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 43*I*Pi/480) = sin(197*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEEAEA6B98095C0ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 44*I*Pi/480) = sin(196*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 45*I*Pi/480) = sin(195*I*Pi/480) */
-		tmp64 = 0x3FEE8F85FC8F1553ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 46*I*Pi/480) = sin(194*I*Pi/480) */
-		tmp64 = 0x3FEE7F74D705762Bull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 47*I*Pi/480) = sin(193*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEE6F0E134454FFull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 48*I*Pi/480) = sin(192*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEE5E51DF571265ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 49*I*Pi/480) = sin(191*I*Pi/480) */
-		tmp64 = 0x3FEE4D406A38E9ABull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 50*I*Pi/480) = sin(190*I*Pi/480) */
-		tmp64 = 0x3FEE3BD9E3D46CEFull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 51*I*Pi/480) = sin(189*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEE2A1E7D02FE9Full;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 52*I*Pi/480) = sin(188*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEE180E678C4853ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 53*I*Pi/480) = sin(187*I*Pi/480) */
-		tmp64 = 0x3FEE05A9D625AF0Full;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 54*I*Pi/480) = sin(186*I*Pi/480) */
-		tmp64 = 0x3FEDF2F0FC71C4E5ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 55*I*Pi/480) = sin(185*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEDDFE40EFFB805ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 56*I*Pi/480) = sin(184*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEDCC83434ABF29ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 57*I*Pi/480) = sin(183*I*Pi/480) */
-		tmp64 = 0x3FEDB8CECFB98376ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 58*I*Pi/480) = sin(182*I*Pi/480) */
-		tmp64 = 0x3FEDA4C6EB9D87C2ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 59*I*Pi/480) = sin(181*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 60*I*Pi/480) = sin(180*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FED7BBDB39DF5C3ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 61*I*Pi/480) = sin(179*I*Pi/480) */
-		tmp64 = 0x3FED66BCD2EE2313ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 62*I*Pi/480) = sin(178*I*Pi/480) */
-		tmp64 = 0x3FED51696819D42Bull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 63*I*Pi/480) = sin(177*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FED3BC3AEFF7F95ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 64*I*Pi/480) = sin(176*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FED25CBE464AB60ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 65*I*Pi/480) = sin(175*I*Pi/480) */
-		tmp64 = 0x3FED0F8245F5427Full;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 66*I*Pi/480) = sin(174*I*Pi/480) */
-		tmp64 = 0x3FECF8E71242E7ABull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 67*I*Pi/480) = sin(173*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FECE1FA88C445BBull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 68*I*Pi/480) = sin(172*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FECCABCE9D45D78ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 69*I*Pi/480) = sin(171*I*Pi/480) */
-		tmp64 = 0x3FECB32E76B1D0F4ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 70*I*Pi/480) = sin(170*I*Pi/480) */
-		tmp64 = 0x3FEC9B4F717E2C63ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 71*I*Pi/480) = sin(169*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEC83201D3D2C6Dull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 72*I*Pi/480) = sin(168*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEC6AA0BDD40210ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 73*I*Pi/480) = sin(167*I*Pi/480) */
-		tmp64 = 0x3FEC51D198089406ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 74*I*Pi/480) = sin(166*I*Pi/480) */
-		tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 75*I*Pi/480) = sin(165*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEC1F4510C18B95ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 76*I*Pi/480) = sin(164*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEC05883D2E7560ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 77*I*Pi/480) = sin(163*I*Pi/480) */
-		tmp64 = 0x3FEBEB7CBF08957Dull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 78*I*Pi/480) = sin(162*I*Pi/480) */
-		tmp64 = 0x3FEBD122DF6DDE43ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 79*I*Pi/480) = sin(161*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEBB67AE8584CAAull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 80*I*Pi/480) = sin(160*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEB9B85249D18A2ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 81*I*Pi/480) = sin(159*I*Pi/480) */
-		tmp64 = 0x3FEB8041DFEBE2FBull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 82*I*Pi/480) = sin(158*I*Pi/480) */
-		tmp64 = 0x3FEB64B166CDE0EEull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 83*I*Pi/480) = sin(157*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEB48D406A50540ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 84*I*Pi/480) = sin(156*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEB2CAA0DAB2702ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 85*I*Pi/480) = sin(155*I*Pi/480) */
-		tmp64 = 0x3FEB1033CAF125F6ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 86*I*Pi/480) = sin(154*I*Pi/480) */
-		tmp64 = 0x3FEAF3718E5E0C9Cull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 87*I*Pi/480) = sin(153*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEAD663A8AE2FDCull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 88*I*Pi/480) = sin(152*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEAB90A6B724C62ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 89*I*Pi/480) = sin(151*I*Pi/480) */
-		tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 90*I*Pi/480) = sin(150*I*Pi/480) */
-		tmp64 = 0x3FEA7D7734BA0A8Eull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 91*I*Pi/480) = sin(149*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FEA5F3DE27D13F2ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 92*I*Pi/480) = sin(148*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FEA40BA87311090ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 93*I*Pi/480) = sin(147*I*Pi/480) */
-		tmp64 = 0x3FEA21ED787F2AEFull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 94*I*Pi/480) = sin(146*I*Pi/480) */
-		tmp64 = 0x3FEA02D70CDF74DBull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 95*I*Pi/480) = sin(145*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE9E3779B97F4A8ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos( 96*I*Pi/480) = sin(144*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE9C3CF7CBBB030ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos( 97*I*Pi/480) = sin(143*I*Pi/480) */
-		tmp64 = 0x3FE9A3DF0929B594ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos( 98*I*Pi/480) = sin(142*I*Pi/480) */
-		tmp64 = 0x3FE983A69A8C21B8ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos( 99*I*Pi/480) = sin(141*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE963268B572492ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(100*I*Pi/480) = sin(140*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE9425F36C80335ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(101*I*Pi/480) = sin(139*I*Pi/480) */
-		tmp64 = 0x3FE92150F8E417B1ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(102*I*Pi/480) = sin(138*I*Pi/480) */
-		tmp64 = 0x3FE8FFFC2E77CEBAull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(103*I*Pi/480) = sin(137*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE8DE613515A328ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(104*I*Pi/480) = sin(136*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE8BC806B151741ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(105*I*Pi/480) = sin(135*I*Pi/480) */
-		tmp64 = 0x3FE89A5A2F91ABE4ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(106*I*Pi/480) = sin(134*I*Pi/480) */
-		tmp64 = 0x3FE877EEE269D586ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(107*I*Pi/480) = sin(133*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE8553EE43DEF13ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(108*I*Pi/480) = sin(132*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE8324A966F2AA5ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(109*I*Pi/480) = sin(131*I*Pi/480) */
-		tmp64 = 0x3FE80F125B1E8028ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(110*I*Pi/480) = sin(130*I*Pi/480) */
-		tmp64 = 0x3FE7EB96952B99DCull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(111*I*Pi/480) = sin(129*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE7C7D7A833BEC2ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(112*I*Pi/480) = sin(128*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE7A3D5F890BAF9ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(113*I*Pi/480) = sin(127*I*Pi/480) */
-		tmp64 = 0x3FE77F91EB57C602ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(114*I*Pi/480) = sin(126*I*Pi/480) */
-		tmp64 = 0x3FE75B0BE65866FBull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(115*I*Pi/480) = sin(125*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE73644501B56CDull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(116*I*Pi/480) = sin(124*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE7113B8FE16056ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(117*I*Pi/480) = sin(123*I*Pi/480) */
-		tmp64 = 0x3FE6EBF20DA23E86ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(118*I*Pi/480) = sin(122*I*Pi/480) */
-		tmp64 = 0x3FE6C668320B7884ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(119*I*Pi/480) = sin(121*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(120*I*Pi/480) = sin(120*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE67A951513345Cull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(121*I*Pi/480) = sin(119*I*Pi/480) */
-		tmp64 = 0x3FE6544CA88F62DBull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(122*I*Pi/480) = sin(118*I*Pi/480) */
-		tmp64 = 0x3FE62DC58C6CF0DBull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(123*I*Pi/480) = sin(117*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE607002CD5031Dull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(124*I*Pi/480) = sin(116*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE5DFFCF69F89EDull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(125*I*Pi/480) = sin(115*I*Pi/480) */
-		tmp64 = 0x3FE5B8BC57520F97ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(126*I*Pi/480) = sin(114*I*Pi/480) */
-		tmp64 = 0x3FE5913EBD1E84E7ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(127*I*Pi/480) = sin(113*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE5698496E20BD8ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(128*I*Pi/480) = sin(112*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE5418E5423C050ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(129*I*Pi/480) = sin(111*I*Pi/480) */
-		tmp64 = 0x3FE5195C65137F0Cull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(130*I*Pi/480) = sin(110*I*Pi/480) */
-		tmp64 = 0x3FE4F0EF3A88AAADull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(131*I*Pi/480) = sin(109*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE4C8474600EEEEull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(132*I*Pi/480) = sin(108*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE49F64F99F0207ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(133*I*Pi/480) = sin(107*I*Pi/480) */
-		tmp64 = 0x3FE47648C8296447ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(134*I*Pi/480) = sin(106*I*Pi/480) */
-		tmp64 = 0x3FE44CF325091DD6ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(135*I*Pi/480) = sin(105*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE4236484487ABEull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(136*I*Pi/480) = sin(104*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE3F99D5A91C51Full;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(137*I*Pi/480) = sin(103*I*Pi/480) */
-		tmp64 = 0x3FE3CF9E1D2DFDB2ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(138*I*Pi/480) = sin(102*I*Pi/480) */
-		tmp64 = 0x3FE3A56742039280ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(139*I*Pi/480) = sin(101*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE37AF93F9513EAull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(140*I*Pi/480) = sin(100*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE350548CFFE7F2ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(141*I*Pi/480) = sin( 99*I*Pi/480) */
-		tmp64 = 0x3FE32579A1FAFBDAull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(142*I*Pi/480) = sin( 98*I*Pi/480) */
-		tmp64 = 0x3FE2FA68F6D5740Cull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(143*I*Pi/480) = sin( 97*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE2CF2304755A5Eull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(144*I*Pi/480) = sin( 96*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE2A3A844564AA5ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(145*I*Pi/480) = sin( 95*I*Pi/480) */
-		tmp64 = 0x3FE277F930881DAFull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(146*I*Pi/480) = sin( 94*I*Pi/480) */
-		tmp64 = 0x3FE24C1643AD9295ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(147*I*Pi/480) = sin( 93*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE21FFFF8FAF674ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(148*I*Pi/480) = sin( 92*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE1F3B6CC34CA8Bull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(149*I*Pi/480) = sin( 91*I*Pi/480) */
-		tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(150*I*Pi/480) = sin( 90*I*Pi/480) */
-		tmp64 = 0x3FE19A8DBE48A6C1ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(151*I*Pi/480) = sin( 89*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE16DAED770771Dull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(152*I*Pi/480) = sin( 88*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE1409F031D897Eull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(153*I*Pi/480) = sin( 87*I*Pi/480) */
-		tmp64 = 0x3FE1135EBFD0E8D7ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(154*I*Pi/480) = sin( 86*I*Pi/480) */
-		tmp64 = 0x3FE0E5EE8C939850ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(155*I*Pi/480) = sin( 85*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE0B84EE8F52E9Dull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(156*I*Pi/480) = sin( 84*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FE08A80550A6FE5ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(157*I*Pi/480) = sin( 83*I*Pi/480) */
-		tmp64 = 0x3FE05C83516BE635ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(158*I*Pi/480) = sin( 82*I*Pi/480) */
-		tmp64 = 0x3FE02E585F347876ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(159*I*Pi/480) = sin( 81*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FE0000000000000ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(160*I*Pi/480) = sin( 80*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FDFA2F56BD3B979ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(161*I*Pi/480) = sin( 79*I*Pi/480) */
-		tmp64 = 0x3FDF459207170FCEull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(162*I*Pi/480) = sin( 78*I*Pi/480) */
-		tmp64 = 0x3FDEE7D6D7F64AD2ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(163*I*Pi/480) = sin( 77*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FDE89C4E59427B1ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(164*I*Pi/480) = sin( 76*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(165*I*Pi/480) = sin( 75*I*Pi/480) */
-		tmp64 = 0x3FDDCCA0D855B380ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(166*I*Pi/480) = sin( 74*I*Pi/480) */
-		tmp64 = 0x3FDD6D90D07521CBull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(167*I*Pi/480) = sin( 73*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FDD0E2E2B44DE01ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(168*I*Pi/480) = sin( 72*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FDCAE79F48C726Cull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(169*I*Pi/480) = sin( 71*I*Pi/480) */
-		tmp64 = 0x3FDC4E7538F866FCull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(170*I*Pi/480) = sin( 70*I*Pi/480) */
-		tmp64 = 0x3FDBEE2106174F02ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(171*I*Pi/480) = sin( 69*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FDB8D7E6A56D476ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(172*I*Pi/480) = sin( 68*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FDB2C8E7500C0C6ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(173*I*Pi/480) = sin( 67*I*Pi/480) */
-		tmp64 = 0x3FDACB523638033Bull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(174*I*Pi/480) = sin( 66*I*Pi/480) */
-		tmp64 = 0x3FDA69CABEF5B501ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(175*I*Pi/480) = sin( 65*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FDA07F921061AD1ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(176*I*Pi/480) = sin( 64*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FD9A5DE6F05A44Bull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(177*I*Pi/480) = sin( 63*I*Pi/480) */
-		tmp64 = 0x3FD9437BBC5DE90Aull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(178*I*Pi/480) = sin( 62*I*Pi/480) */
-		tmp64 = 0x3FD8E0D21D42A377ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(179*I*Pi/480) = sin( 61*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(180*I*Pi/480) = sin( 60*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FD81AAE6E60E271ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(181*I*Pi/480) = sin( 59*I*Pi/480) */
-		tmp64 = 0x3FD7B7368AD93C61ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(182*I*Pi/480) = sin( 58*I*Pi/480) */
-		tmp64 = 0x3FD7537C13559D33ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(183*I*Pi/480) = sin( 57*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FD6EF801FCED33Cull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(184*I*Pi/480) = sin( 56*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FD68B43C8F5832Aull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(185*I*Pi/480) = sin( 55*I*Pi/480) */
-		tmp64 = 0x3FD626C8282F1408ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(186*I*Pi/480) = sin( 54*I*Pi/480) */
-		tmp64 = 0x3FD5C20E57929942ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(187*I*Pi/480) = sin( 53*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FD55D1771E5BAB9ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(188*I*Pi/480) = sin( 52*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FD4F7E492999AEEull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(189*I*Pi/480) = sin( 51*I*Pi/480) */
-		tmp64 = 0x3FD49276D5C7BB48ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(190*I*Pi/480) = sin( 50*I*Pi/480) */
-		tmp64 = 0x3FD42CCF582EDE82ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(191*I*Pi/480) = sin( 49*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FD3C6EF372FE950ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(192*I*Pi/480) = sin( 48*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FD360D790CAC12Eull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(193*I*Pi/480) = sin( 47*I*Pi/480) */
-		tmp64 = 0x3FD2FA89839B2985ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(194*I*Pi/480) = sin( 46*I*Pi/480) */
-		tmp64 = 0x3FD294062ED59F06ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(195*I*Pi/480) = sin( 45*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FD22D4EB2443163ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(196*I*Pi/480) = sin( 44*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FD1C6642E435B69ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(197*I*Pi/480) = sin( 43*I*Pi/480) */
-		tmp64 = 0x3FD15F47C3BED971ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(198*I*Pi/480) = sin( 42*I*Pi/480) */
-		tmp64 = 0x3FD0F7FA942E7E48ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(199*I*Pi/480) = sin( 41*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FD0907DC1930690ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(200*I*Pi/480) = sin( 40*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FD028D26E72EA99ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(201*I*Pi/480) = sin( 39*I*Pi/480) */
-		tmp64 = 0x3FCF81F37BAE5D8Cull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(202*I*Pi/480) = sin( 38*I*Pi/480) */
-		tmp64 = 0x3FCEB1E9A690650Eull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(203*I*Pi/480) = sin( 37*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FCDE189A594FBCCull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(204*I*Pi/480) = sin( 36*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FCD10D5C1B71B7Full;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(205*I*Pi/480) = sin( 35*I*Pi/480) */
-		tmp64 = 0x3FCC3FD044DD3D45ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(206*I*Pi/480) = sin( 34*I*Pi/480) */
-		tmp64 = 0x3FCB6E7B79D2ECC9ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(207*I*Pi/480) = sin( 33*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FCA9CD9AC4258F6ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(208*I*Pi/480) = sin( 32*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FC9CAED28ADE228ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(209*I*Pi/480) = sin( 31*I*Pi/480) */
-		tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(210*I*Pi/480) = sin( 30*I*Pi/480) */
-		tmp64 = 0x3FC8263D35950926ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(211*I*Pi/480) = sin( 29*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FC7537E63143E2Eull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(212*I*Pi/480) = sin( 28*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FC6807E1489CB33ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(213*I*Pi/480) = sin( 27*I*Pi/480) */
-		tmp64 = 0x3FC5AD3E9A500CADull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(214*I*Pi/480) = sin( 26*I*Pi/480) */
-		tmp64 = 0x3FC4D9C24572B693ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(215*I*Pi/480) = sin( 25*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FC4060B67A85375ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(216*I*Pi/480) = sin( 24*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FC3321C534BC1BBull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(217*I*Pi/480) = sin( 23*I*Pi/480) */
-		tmp64 = 0x3FC25DF75B55AF15ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(218*I*Pi/480) = sin( 22*I*Pi/480) */
-		tmp64 = 0x3FC1899ED3561233ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(219*I*Pi/480) = sin( 21*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FC0B5150F6DA2D1ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(220*I*Pi/480) = sin( 20*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FBFC0B8C88EA05Aull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(221*I*Pi/480) = sin( 19*I*Pi/480) */
-		tmp64 = 0x3FBE16EE4E236BF8ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(222*I*Pi/480) = sin( 18*I*Pi/480) */
-		tmp64 = 0x3FBC6CCF5AF11FD1ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(223*I*Pi/480) = sin( 17*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FBAC2609B3C576Cull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(224*I*Pi/480) = sin( 16*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(225*I*Pi/480) = sin( 15*I*Pi/480) */
-		tmp64 = 0x3FB76CA66BB0BC83ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(226*I*Pi/480) = sin( 14*I*Pi/480) */
-		tmp64 = 0x3FB5C164588EB8DAull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(227*I*Pi/480) = sin( 13*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FB415E532398E49ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(228*I*Pi/480) = sin( 12*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FB26A2DA8D2974Aull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(229*I*Pi/480) = sin( 11*I*Pi/480) */
-		tmp64 = 0x3FB0BE426D197A8Bull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(230*I*Pi/480) = sin( 10*I*Pi/480) */
-		tmp64 = 0x3FAE245060BE0012ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(231*I*Pi/480) = sin(  9*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3FAACBC748EFC90Eull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(232*I*Pi/480) = sin(  8*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3FA772F2F75F573Cull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(233*I*Pi/480) = sin(  7*I*Pi/480) */
-		tmp64 = 0x3FA419DCD176E0F7ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(234*I*Pi/480) = sin(  6*I*Pi/480) */
-		tmp64 = 0x3FA0C08E3D596AEEull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(235*I*Pi/480) = sin(  5*I*Pi/480) */	tmp += 2;
-		tmp64 = 0x3F9ACE214390CA91ull;	tmp->d0 = tm2->d0 = *(double *)&tmp64;	/* cos(236*I*Pi/480) = sin(  4*I*Pi/480) */	tm2 -= 2;
-		tmp64 = 0x3F941ADACC128E22ull;	tmp->d1 = tm2->d3 = *(double *)&tmp64;	/* cos(237*I*Pi/480) = sin(  3*I*Pi/480) */
-		tmp64 = 0x3F8ACEB7C72CA0A8ull;	tmp->d2 = tm2->d2 = *(double *)&tmp64;	/* cos(238*I*Pi/480) = sin(  2*I*Pi/480) */
-		tmp64 = 0x3F7ACEDD6862D0D7ull;	tmp->d3 = tm2->d1 = *(double *)&tmp64;	/* cos(239*I*Pi/480) = sin(  1*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEFFFD3151E5533ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  1*I*Pi/480) = sin(239*I*Pi/480) */
+		tmp64 = 0x3FEFFF4C54F76E1Cull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  2*I*Pi/480) = sin(238*I*Pi/480) */
+		tmp64 = 0x3FEFFE6BC105954Eull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  3*I*Pi/480) = sin(237*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEFFD315BBF4275ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(  4*I*Pi/480) = sin(236*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEFFB9D2897136Eull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  5*I*Pi/480) = sin(235*I*Pi/480) */
+		tmp64 = 0x3FEFF9AF2BFBC297ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(  6*I*Pi/480) = sin(234*I*Pi/480) */
+		tmp64 = 0x3FEFF7676B581A63ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(  7*I*Pi/480) = sin(233*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEFF4C5ED12E61Dull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(  8*I*Pi/480) = sin(232*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEFF1CAB88EDFF7ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(  9*I*Pi/480) = sin(231*I*Pi/480) */
+		tmp64 = 0x3FEFEE75D62A9C46ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 10*I*Pi/480) = sin(230*I*Pi/480) */
+		tmp64 = 0x3FEFEAC74F40720Cull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 11*I*Pi/480) = sin(229*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEFE6BF2E2660AFull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 12*I*Pi/480) = sin(228*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEFE25D7E2DF2F8ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 13*I*Pi/480) = sin(227*I*Pi/480) */
+		tmp64 = 0x3FEFDDA24BA41F4Dull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 14*I*Pi/480) = sin(226*I*Pi/480) */
+		tmp64 = 0x3FEFD88DA3D12526ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 15*I*Pi/480) = sin(225*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEFD31F94F867C6ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 16*I*Pi/480) = sin(224*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEFCD582E584632ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 17*I*Pi/480) = sin(223*I*Pi/480) */
+		tmp64 = 0x3FEFC7378029F05Full;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 18*I*Pi/480) = sin(222*I*Pi/480) */
+		tmp64 = 0x3FEFC0BD9BA139AEull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 19*I*Pi/480) = sin(221*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEFB9EA92EC689Bull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 20*I*Pi/480) = sin(220*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEFB2BE793403B9ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 21*I*Pi/480) = sin(219*I*Pi/480) */
+		tmp64 = 0x3FEFAB39629A9BE3ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 22*I*Pi/480) = sin(218*I*Pi/480) */
+		tmp64 = 0x3FEFA35B643C93B9ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 23*I*Pi/480) = sin(217*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEF9B24942FE45Cull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 24*I*Pi/480) = sin(216*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEF92950983DF6Bull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 25*I*Pi/480) = sin(215*I*Pi/480) */
+		tmp64 = 0x3FEF89ACDC40EE4Bull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 26*I*Pi/480) = sin(214*I*Pi/480) */
+		tmp64 = 0x3FEF806C25684EA8ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 27*I*Pi/480) = sin(213*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEF76D2FEF3CC4Bull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 28*I*Pi/480) = sin(212*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEF6CE183D57825ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 29*I*Pi/480) = sin(211*I*Pi/480) */
+		tmp64 = 0x3FEF6297CFF75CB0ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 30*I*Pi/480) = sin(210*I*Pi/480) */
+		tmp64 = 0x3FEF57F6003B2F91ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 31*I*Pi/480) = sin(209*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEF4CFC327A0080ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 32*I*Pi/480) = sin(208*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEF41AA8583E57Eull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 33*I*Pi/480) = sin(207*I*Pi/480) */
+		tmp64 = 0x3FEF3601191FA459ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 34*I*Pi/480) = sin(206*I*Pi/480) */
+		tmp64 = 0x3FEF2A000E0A5970ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 35*I*Pi/480) = sin(205*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEF1DA785F71BCEull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 36*I*Pi/480) = sin(204*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEF10F7A38E9E90ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 37*I*Pi/480) = sin(203*I*Pi/480) */
+		tmp64 = 0x3FEF03F08A6ECF94ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 38*I*Pi/480) = sin(202*I*Pi/480) */
+		tmp64 = 0x3FEEF6925F2A7380ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 39*I*Pi/480) = sin(201*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEEE8DD4748BF15ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 40*I*Pi/480) = sin(200*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEEDAD16944EDD0ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 41*I*Pi/480) = sin(199*I*Pi/480) */
+		tmp64 = 0x3FEECC6EEC8DD5E9ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 42*I*Pi/480) = sin(198*I*Pi/480) */
+		tmp64 = 0x3FEEBDB5F9857999ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 43*I*Pi/480) = sin(197*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEEAEA6B98095C0ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 44*I*Pi/480) = sin(196*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEE9F4156C62DDAull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 45*I*Pi/480) = sin(195*I*Pi/480) */
+		tmp64 = 0x3FEE8F85FC8F1553ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 46*I*Pi/480) = sin(194*I*Pi/480) */
+		tmp64 = 0x3FEE7F74D705762Bull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 47*I*Pi/480) = sin(193*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEE6F0E134454FFull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 48*I*Pi/480) = sin(192*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEE5E51DF571265ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 49*I*Pi/480) = sin(191*I*Pi/480) */
+		tmp64 = 0x3FEE4D406A38E9ABull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 50*I*Pi/480) = sin(190*I*Pi/480) */
+		tmp64 = 0x3FEE3BD9E3D46CEFull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 51*I*Pi/480) = sin(189*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEE2A1E7D02FE9Full;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 52*I*Pi/480) = sin(188*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEE180E678C4853ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 53*I*Pi/480) = sin(187*I*Pi/480) */
+		tmp64 = 0x3FEE05A9D625AF0Full;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 54*I*Pi/480) = sin(186*I*Pi/480) */
+		tmp64 = 0x3FEDF2F0FC71C4E5ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 55*I*Pi/480) = sin(185*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEDDFE40EFFB805ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 56*I*Pi/480) = sin(184*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEDCC83434ABF29ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 57*I*Pi/480) = sin(183*I*Pi/480) */
+		tmp64 = 0x3FEDB8CECFB98376ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 58*I*Pi/480) = sin(182*I*Pi/480) */
+		tmp64 = 0x3FEDA4C6EB9D87C2ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 59*I*Pi/480) = sin(181*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FED906BCF328D46ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 60*I*Pi/480) = sin(180*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FED7BBDB39DF5C3ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 61*I*Pi/480) = sin(179*I*Pi/480) */
+		tmp64 = 0x3FED66BCD2EE2313ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 62*I*Pi/480) = sin(178*I*Pi/480) */
+		tmp64 = 0x3FED51696819D42Bull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 63*I*Pi/480) = sin(177*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FED3BC3AEFF7F95ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 64*I*Pi/480) = sin(176*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FED25CBE464AB60ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 65*I*Pi/480) = sin(175*I*Pi/480) */
+		tmp64 = 0x3FED0F8245F5427Full;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 66*I*Pi/480) = sin(174*I*Pi/480) */
+		tmp64 = 0x3FECF8E71242E7ABull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 67*I*Pi/480) = sin(173*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FECE1FA88C445BBull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 68*I*Pi/480) = sin(172*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FECCABCE9D45D78ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 69*I*Pi/480) = sin(171*I*Pi/480) */
+		tmp64 = 0x3FECB32E76B1D0F4ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 70*I*Pi/480) = sin(170*I*Pi/480) */
+		tmp64 = 0x3FEC9B4F717E2C63ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 71*I*Pi/480) = sin(169*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEC83201D3D2C6Dull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 72*I*Pi/480) = sin(168*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEC6AA0BDD40210ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 73*I*Pi/480) = sin(167*I*Pi/480) */
+		tmp64 = 0x3FEC51D198089406ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 74*I*Pi/480) = sin(166*I*Pi/480) */
+		tmp64 = 0x3FEC38B2F180BDB1ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 75*I*Pi/480) = sin(165*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEC1F4510C18B95ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 76*I*Pi/480) = sin(164*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEC05883D2E7560ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 77*I*Pi/480) = sin(163*I*Pi/480) */
+		tmp64 = 0x3FEBEB7CBF08957Dull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 78*I*Pi/480) = sin(162*I*Pi/480) */
+		tmp64 = 0x3FEBD122DF6DDE43ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 79*I*Pi/480) = sin(161*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEBB67AE8584CAAull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 80*I*Pi/480) = sin(160*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEB9B85249D18A2ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 81*I*Pi/480) = sin(159*I*Pi/480) */
+		tmp64 = 0x3FEB8041DFEBE2FBull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 82*I*Pi/480) = sin(158*I*Pi/480) */
+		tmp64 = 0x3FEB64B166CDE0EEull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 83*I*Pi/480) = sin(157*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEB48D406A50540ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 84*I*Pi/480) = sin(156*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEB2CAA0DAB2702ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 85*I*Pi/480) = sin(155*I*Pi/480) */
+		tmp64 = 0x3FEB1033CAF125F6ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 86*I*Pi/480) = sin(154*I*Pi/480) */
+		tmp64 = 0x3FEAF3718E5E0C9Cull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 87*I*Pi/480) = sin(153*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEAD663A8AE2FDCull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 88*I*Pi/480) = sin(152*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEAB90A6B724C62ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 89*I*Pi/480) = sin(151*I*Pi/480) */
+		tmp64 = 0x3FEA9B66290EA1A3ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 90*I*Pi/480) = sin(150*I*Pi/480) */
+		tmp64 = 0x3FEA7D7734BA0A8Eull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 91*I*Pi/480) = sin(149*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FEA5F3DE27D13F2ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 92*I*Pi/480) = sin(148*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FEA40BA87311090ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 93*I*Pi/480) = sin(147*I*Pi/480) */
+		tmp64 = 0x3FEA21ED787F2AEFull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 94*I*Pi/480) = sin(146*I*Pi/480) */
+		tmp64 = 0x3FEA02D70CDF74DBull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 95*I*Pi/480) = sin(145*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE9E3779B97F4A8ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos( 96*I*Pi/480) = sin(144*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE9C3CF7CBBB030ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos( 97*I*Pi/480) = sin(143*I*Pi/480) */
+		tmp64 = 0x3FE9A3DF0929B594ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos( 98*I*Pi/480) = sin(142*I*Pi/480) */
+		tmp64 = 0x3FE983A69A8C21B8ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos( 99*I*Pi/480) = sin(141*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE963268B572492ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(100*I*Pi/480) = sin(140*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE9425F36C80335ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(101*I*Pi/480) = sin(139*I*Pi/480) */
+		tmp64 = 0x3FE92150F8E417B1ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(102*I*Pi/480) = sin(138*I*Pi/480) */
+		tmp64 = 0x3FE8FFFC2E77CEBAull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(103*I*Pi/480) = sin(137*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE8DE613515A328ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(104*I*Pi/480) = sin(136*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE8BC806B151741ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(105*I*Pi/480) = sin(135*I*Pi/480) */
+		tmp64 = 0x3FE89A5A2F91ABE4ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(106*I*Pi/480) = sin(134*I*Pi/480) */
+		tmp64 = 0x3FE877EEE269D586ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(107*I*Pi/480) = sin(133*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE8553EE43DEF13ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(108*I*Pi/480) = sin(132*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE8324A966F2AA5ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(109*I*Pi/480) = sin(131*I*Pi/480) */
+		tmp64 = 0x3FE80F125B1E8028ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(110*I*Pi/480) = sin(130*I*Pi/480) */
+		tmp64 = 0x3FE7EB96952B99DCull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(111*I*Pi/480) = sin(129*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE7C7D7A833BEC2ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(112*I*Pi/480) = sin(128*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE7A3D5F890BAF9ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(113*I*Pi/480) = sin(127*I*Pi/480) */
+		tmp64 = 0x3FE77F91EB57C602ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(114*I*Pi/480) = sin(126*I*Pi/480) */
+		tmp64 = 0x3FE75B0BE65866FBull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(115*I*Pi/480) = sin(125*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE73644501B56CDull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(116*I*Pi/480) = sin(124*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE7113B8FE16056ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(117*I*Pi/480) = sin(123*I*Pi/480) */
+		tmp64 = 0x3FE6EBF20DA23E86ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(118*I*Pi/480) = sin(122*I*Pi/480) */
+		tmp64 = 0x3FE6C668320B7884ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(119*I*Pi/480) = sin(121*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE6A09E667F3BCDull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(120*I*Pi/480) = sin(120*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE67A951513345Cull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(121*I*Pi/480) = sin(119*I*Pi/480) */
+		tmp64 = 0x3FE6544CA88F62DBull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(122*I*Pi/480) = sin(118*I*Pi/480) */
+		tmp64 = 0x3FE62DC58C6CF0DBull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(123*I*Pi/480) = sin(117*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE607002CD5031Dull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(124*I*Pi/480) = sin(116*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE5DFFCF69F89EDull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(125*I*Pi/480) = sin(115*I*Pi/480) */
+		tmp64 = 0x3FE5B8BC57520F97ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(126*I*Pi/480) = sin(114*I*Pi/480) */
+		tmp64 = 0x3FE5913EBD1E84E7ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(127*I*Pi/480) = sin(113*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE5698496E20BD8ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(128*I*Pi/480) = sin(112*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE5418E5423C050ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(129*I*Pi/480) = sin(111*I*Pi/480) */
+		tmp64 = 0x3FE5195C65137F0Cull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(130*I*Pi/480) = sin(110*I*Pi/480) */
+		tmp64 = 0x3FE4F0EF3A88AAADull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(131*I*Pi/480) = sin(109*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE4C8474600EEEEull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(132*I*Pi/480) = sin(108*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE49F64F99F0207ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(133*I*Pi/480) = sin(107*I*Pi/480) */
+		tmp64 = 0x3FE47648C8296447ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(134*I*Pi/480) = sin(106*I*Pi/480) */
+		tmp64 = 0x3FE44CF325091DD6ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(135*I*Pi/480) = sin(105*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE4236484487ABEull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(136*I*Pi/480) = sin(104*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE3F99D5A91C51Full;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(137*I*Pi/480) = sin(103*I*Pi/480) */
+		tmp64 = 0x3FE3CF9E1D2DFDB2ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(138*I*Pi/480) = sin(102*I*Pi/480) */
+		tmp64 = 0x3FE3A56742039280ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(139*I*Pi/480) = sin(101*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE37AF93F9513EAull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(140*I*Pi/480) = sin(100*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE350548CFFE7F2ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(141*I*Pi/480) = sin( 99*I*Pi/480) */
+		tmp64 = 0x3FE32579A1FAFBDAull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(142*I*Pi/480) = sin( 98*I*Pi/480) */
+		tmp64 = 0x3FE2FA68F6D5740Cull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(143*I*Pi/480) = sin( 97*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE2CF2304755A5Eull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(144*I*Pi/480) = sin( 96*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE2A3A844564AA5ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(145*I*Pi/480) = sin( 95*I*Pi/480) */
+		tmp64 = 0x3FE277F930881DAFull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(146*I*Pi/480) = sin( 94*I*Pi/480) */
+		tmp64 = 0x3FE24C1643AD9295ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(147*I*Pi/480) = sin( 93*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE21FFFF8FAF674ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(148*I*Pi/480) = sin( 92*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE1F3B6CC34CA8Bull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(149*I*Pi/480) = sin( 91*I*Pi/480) */
+		tmp64 = 0x3FE1C73B39AE68C8ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(150*I*Pi/480) = sin( 90*I*Pi/480) */
+		tmp64 = 0x3FE19A8DBE48A6C1ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(151*I*Pi/480) = sin( 89*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE16DAED770771Dull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(152*I*Pi/480) = sin( 88*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE1409F031D897Eull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(153*I*Pi/480) = sin( 87*I*Pi/480) */
+		tmp64 = 0x3FE1135EBFD0E8D7ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(154*I*Pi/480) = sin( 86*I*Pi/480) */
+		tmp64 = 0x3FE0E5EE8C939850ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(155*I*Pi/480) = sin( 85*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE0B84EE8F52E9Dull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(156*I*Pi/480) = sin( 84*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FE08A80550A6FE5ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(157*I*Pi/480) = sin( 83*I*Pi/480) */
+		tmp64 = 0x3FE05C83516BE635ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(158*I*Pi/480) = sin( 82*I*Pi/480) */
+		tmp64 = 0x3FE02E585F347876ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(159*I*Pi/480) = sin( 81*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FE0000000000000ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(160*I*Pi/480) = sin( 80*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FDFA2F56BD3B979ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(161*I*Pi/480) = sin( 79*I*Pi/480) */
+		tmp64 = 0x3FDF459207170FCEull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(162*I*Pi/480) = sin( 78*I*Pi/480) */
+		tmp64 = 0x3FDEE7D6D7F64AD2ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(163*I*Pi/480) = sin( 77*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FDE89C4E59427B1ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(164*I*Pi/480) = sin( 76*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FDE2B5D3806F63Bull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(165*I*Pi/480) = sin( 75*I*Pi/480) */
+		tmp64 = 0x3FDDCCA0D855B380ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(166*I*Pi/480) = sin( 74*I*Pi/480) */
+		tmp64 = 0x3FDD6D90D07521CBull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(167*I*Pi/480) = sin( 73*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FDD0E2E2B44DE01ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(168*I*Pi/480) = sin( 72*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FDCAE79F48C726Cull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(169*I*Pi/480) = sin( 71*I*Pi/480) */
+		tmp64 = 0x3FDC4E7538F866FCull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(170*I*Pi/480) = sin( 70*I*Pi/480) */
+		tmp64 = 0x3FDBEE2106174F02ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(171*I*Pi/480) = sin( 69*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FDB8D7E6A56D476ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(172*I*Pi/480) = sin( 68*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FDB2C8E7500C0C6ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(173*I*Pi/480) = sin( 67*I*Pi/480) */
+		tmp64 = 0x3FDACB523638033Bull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(174*I*Pi/480) = sin( 66*I*Pi/480) */
+		tmp64 = 0x3FDA69CABEF5B501ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(175*I*Pi/480) = sin( 65*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FDA07F921061AD1ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(176*I*Pi/480) = sin( 64*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FD9A5DE6F05A44Bull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(177*I*Pi/480) = sin( 63*I*Pi/480) */
+		tmp64 = 0x3FD9437BBC5DE90Aull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(178*I*Pi/480) = sin( 62*I*Pi/480) */
+		tmp64 = 0x3FD8E0D21D42A377ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(179*I*Pi/480) = sin( 61*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FD87DE2A6AEA963ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(180*I*Pi/480) = sin( 60*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FD81AAE6E60E271ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(181*I*Pi/480) = sin( 59*I*Pi/480) */
+		tmp64 = 0x3FD7B7368AD93C61ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(182*I*Pi/480) = sin( 58*I*Pi/480) */
+		tmp64 = 0x3FD7537C13559D33ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(183*I*Pi/480) = sin( 57*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FD6EF801FCED33Cull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(184*I*Pi/480) = sin( 56*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FD68B43C8F5832Aull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(185*I*Pi/480) = sin( 55*I*Pi/480) */
+		tmp64 = 0x3FD626C8282F1408ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(186*I*Pi/480) = sin( 54*I*Pi/480) */
+		tmp64 = 0x3FD5C20E57929942ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(187*I*Pi/480) = sin( 53*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FD55D1771E5BAB9ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(188*I*Pi/480) = sin( 52*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FD4F7E492999AEEull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(189*I*Pi/480) = sin( 51*I*Pi/480) */
+		tmp64 = 0x3FD49276D5C7BB48ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(190*I*Pi/480) = sin( 50*I*Pi/480) */
+		tmp64 = 0x3FD42CCF582EDE82ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(191*I*Pi/480) = sin( 49*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FD3C6EF372FE950ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(192*I*Pi/480) = sin( 48*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FD360D790CAC12Eull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(193*I*Pi/480) = sin( 47*I*Pi/480) */
+		tmp64 = 0x3FD2FA89839B2985ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(194*I*Pi/480) = sin( 46*I*Pi/480) */
+		tmp64 = 0x3FD294062ED59F06ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(195*I*Pi/480) = sin( 45*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FD22D4EB2443163ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(196*I*Pi/480) = sin( 44*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FD1C6642E435B69ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(197*I*Pi/480) = sin( 43*I*Pi/480) */
+		tmp64 = 0x3FD15F47C3BED971ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(198*I*Pi/480) = sin( 42*I*Pi/480) */
+		tmp64 = 0x3FD0F7FA942E7E48ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(199*I*Pi/480) = sin( 41*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FD0907DC1930690ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(200*I*Pi/480) = sin( 40*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FD028D26E72EA99ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(201*I*Pi/480) = sin( 39*I*Pi/480) */
+		tmp64 = 0x3FCF81F37BAE5D8Cull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(202*I*Pi/480) = sin( 38*I*Pi/480) */
+		tmp64 = 0x3FCEB1E9A690650Eull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(203*I*Pi/480) = sin( 37*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FCDE189A594FBCCull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(204*I*Pi/480) = sin( 36*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FCD10D5C1B71B7Full;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(205*I*Pi/480) = sin( 35*I*Pi/480) */
+		tmp64 = 0x3FCC3FD044DD3D45ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(206*I*Pi/480) = sin( 34*I*Pi/480) */
+		tmp64 = 0x3FCB6E7B79D2ECC9ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(207*I*Pi/480) = sin( 33*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FCA9CD9AC4258F6ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(208*I*Pi/480) = sin( 32*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FC9CAED28ADE228ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(209*I*Pi/480) = sin( 31*I*Pi/480) */
+		tmp64 = 0x3FC8F8B83C69A60Bull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(210*I*Pi/480) = sin( 30*I*Pi/480) */
+		tmp64 = 0x3FC8263D35950926ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(211*I*Pi/480) = sin( 29*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FC7537E63143E2Eull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(212*I*Pi/480) = sin( 28*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FC6807E1489CB33ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(213*I*Pi/480) = sin( 27*I*Pi/480) */
+		tmp64 = 0x3FC5AD3E9A500CADull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(214*I*Pi/480) = sin( 26*I*Pi/480) */
+		tmp64 = 0x3FC4D9C24572B693ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(215*I*Pi/480) = sin( 25*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FC4060B67A85375ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(216*I*Pi/480) = sin( 24*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FC3321C534BC1BBull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(217*I*Pi/480) = sin( 23*I*Pi/480) */
+		tmp64 = 0x3FC25DF75B55AF15ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(218*I*Pi/480) = sin( 22*I*Pi/480) */
+		tmp64 = 0x3FC1899ED3561233ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(219*I*Pi/480) = sin( 21*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FC0B5150F6DA2D1ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(220*I*Pi/480) = sin( 20*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FBFC0B8C88EA05Aull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(221*I*Pi/480) = sin( 19*I*Pi/480) */
+		tmp64 = 0x3FBE16EE4E236BF8ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(222*I*Pi/480) = sin( 18*I*Pi/480) */
+		tmp64 = 0x3FBC6CCF5AF11FD1ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(223*I*Pi/480) = sin( 17*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FBAC2609B3C576Cull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(224*I*Pi/480) = sin( 16*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FB917A6BC29B42Cull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(225*I*Pi/480) = sin( 15*I*Pi/480) */
+		tmp64 = 0x3FB76CA66BB0BC83ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(226*I*Pi/480) = sin( 14*I*Pi/480) */
+		tmp64 = 0x3FB5C164588EB8DAull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(227*I*Pi/480) = sin( 13*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FB415E532398E49ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(228*I*Pi/480) = sin( 12*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FB26A2DA8D2974Aull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(229*I*Pi/480) = sin( 11*I*Pi/480) */
+		tmp64 = 0x3FB0BE426D197A8Bull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(230*I*Pi/480) = sin( 10*I*Pi/480) */
+		tmp64 = 0x3FAE245060BE0012ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(231*I*Pi/480) = sin(  9*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3FAACBC748EFC90Eull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(232*I*Pi/480) = sin(  8*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3FA772F2F75F573Cull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(233*I*Pi/480) = sin(  7*I*Pi/480) */
+		tmp64 = 0x3FA419DCD176E0F7ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(234*I*Pi/480) = sin(  6*I*Pi/480) */
+		tmp64 = 0x3FA0C08E3D596AEEull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(235*I*Pi/480) = sin(  5*I*Pi/480) */	tmp += 2;
+		tmp64 = 0x3F9ACE214390CA91ull;	tmp->d0 = tm2->d0 = u64_to_f64(tmp64);	/* cos(236*I*Pi/480) = sin(  4*I*Pi/480) */	tm2 -= 2;
+		tmp64 = 0x3F941ADACC128E22ull;	tmp->d1 = tm2->d3 = u64_to_f64(tmp64);	/* cos(237*I*Pi/480) = sin(  3*I*Pi/480) */
+		tmp64 = 0x3F8ACEB7C72CA0A8ull;	tmp->d2 = tm2->d2 = u64_to_f64(tmp64);	/* cos(238*I*Pi/480) = sin(  2*I*Pi/480) */
+		tmp64 = 0x3F7ACEDD6862D0D7ull;	tmp->d3 = tm2->d1 = u64_to_f64(tmp64);	/* cos(239*I*Pi/480) = sin(  1*I*Pi/480) */	tmp += 2;
 
 		tmp = base_negacyclic_root + RADIX*2;	// reset to point to start of above block
 		nbytes = RADIX*SZ_VD/2;	// RADIX/4 AVX-register-sized complex data
@@ -857,18 +857,18 @@ int radix992_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		// Init exp(j*I*Pi/2/RADIX), for j = 0-3:
 		tmp = base_negacyclic_root + 8;	// First 8 slots reserved for Re/Im parts of the 4 base multipliers
 		tmp->d0 = 1.0;
-		tmp64 = 0x3FEFFFD3151E5533ull;	tmp->d1 = *(double *)&tmp64;	// cos(01*I*Pi/480)
-		tmp64 = 0x3FEFFF4C54F76E1Cull;	tmp->d2 = *(double *)&tmp64;	// cos(02*I*Pi/480)
-		tmp64 = 0x3FEFFE6BC105954Eull;	tmp->d3 = *(double *)&tmp64;	// cos(03*I*Pi/480)
+		tmp64 = 0x3FEFFFD3151E5533ull;	tmp->d1 = u64_to_f64(tmp64);	// cos(01*I*Pi/480)
+		tmp64 = 0x3FEFFF4C54F76E1Cull;	tmp->d2 = u64_to_f64(tmp64);	// cos(02*I*Pi/480)
+		tmp64 = 0x3FEFFE6BC105954Eull;	tmp->d3 = u64_to_f64(tmp64);	// cos(03*I*Pi/480)
 
 		(++tmp)->d0 = 0.0;
-		tmp64 = 0x3F941ADACC128E22ull;	tmp->d3 = *(double *)&tmp64;	// sin(03*I*Pi/480)
-		tmp64 = 0x3F8ACEB7C72CA0A8ull;	tmp->d2 = *(double *)&tmp64;	// sin(02*I*Pi/480)
-		tmp64 = 0x3F7ACEDD6862D0D7ull;	tmp->d1 = *(double *)&tmp64;	// sin(01*I*Pi/480)
+		tmp64 = 0x3F941ADACC128E22ull;	tmp->d3 = u64_to_f64(tmp64);	// sin(03*I*Pi/480)
+		tmp64 = 0x3F8ACEB7C72CA0A8ull;	tmp->d2 = u64_to_f64(tmp64);	// sin(02*I*Pi/480)
+		tmp64 = 0x3F7ACEDD6862D0D7ull;	tmp->d1 = u64_to_f64(tmp64);	// sin(01*I*Pi/480)
 		++tmp;
-		tmp64 = 0x3FEFFD315BBF4275ull;	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// cos(04*I*Pi/480)
+		tmp64 = 0x3FEFFD315BBF4275ull;	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// cos(04*I*Pi/480)
 		++tmp;
-		tmp64 = 0x3F9ACE214390CA91ull;	VEC_DBL_INIT(tmp, *(double *)&tmp64);	// sin(04*I*Pi/480)
+		tmp64 = 0x3F9ACE214390CA91ull;	VEC_DBL_INIT(tmp, u64_to_f64(tmp64));	// sin(04*I*Pi/480)
 		tmp = base_negacyclic_root + 8;	// reset to point to start of above block
 		nbytes = 4*SZ_VD;	// 2 AVX-register-sized complex data
 

--- a/src/rng_isaac.c
+++ b/src/rng_isaac.c
@@ -141,7 +141,7 @@ double	rng_isaac_rand_double()
 		fexp = (uint32)(iran64 >> 52) & 0x7ff;
 		if(fexp != 0 && fexp < 0x7f0) break;
 	}
-	return	*(double *)&iran64;
+	return u64_to_f64(iran64);
 }
 
 /* Assumes IEEE64-compliant: */
@@ -158,7 +158,7 @@ double	rng_isaac_rand_double_norm_pos()
 
 	itmp64 = rng_isaac_rand();
 	iran64 = 0x3FF0000000000000ull + (itmp64 & 0x000FFFFFFFFFFFFFull);
-	retval=(*(double *)&iran64) - 1.0;
+	retval = u64_to_f64(iran64) - 1.0;
 	/* GCC compiler bug: needed to insert the explicit range-check here, otherwise compiler 'optimized' the (*(double *)&iran64) to zero: */
 	if(retval < 0.0 || retval > 1.0)
 	{
@@ -189,7 +189,7 @@ double	rng_isaac_rand_double_norm_pm1()
 	itmp64 = rng_isaac_rand();
 	sign = pm1[itmp64 >> 63];	/* Use high bit of iran64 for sign */
 	iran64 = 0x3FF0000000000000ull + (itmp64 & 0x000FFFFFFFFFFFFFull);
-	retval=sign*((*(double *)&iran64) - 1.0);
+	retval = sign * (u64_to_f64(iran64) - 1.0);
 	/* GCC compiler bug: needed to insert the explicit range-check here, otherwise compiler 'optimized' the (*(double *)&iran64) to zero: */
 	if(retval < -1.0 || retval > 1.0)
 	{

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -1202,7 +1202,7 @@ if(~pshift != p+78) {
 			two26i  = sc_ptr + 0x1c;
 			sse2_rnd= sc_ptr + 0x1e;
 			half    = sc_ptr + 0x20;
-			dtmp = *(double*)&ihalf;
+			dtmp = u64_to_f64(ihalf);
 			for(j = 0; j < max_threads; ++j) {
 				/* These remain fixed within each per-thread local store: */
 				VEC_DBL_INIT_2((vec_dbl*)two13i  , TWO13FLINV);
@@ -1244,7 +1244,7 @@ if(~pshift != p+78) {
 			/* We init "half" = 0.5-epsilon here, because emulating FLOOR(x) via DNINT(x-half) requires
 			us to always round up if x is a whole number, and our DNINT emulation can round either way if fractional part = 0.5:
 			*/
-			dtmp = *(double*)&ihalf;
+			dtmp = u64_to_f64(ihalf);
 			*half++ = dtmp;			*half-- = dtmp;
 		#endif
 			if(init_sse2) return 0;
@@ -2040,7 +2040,7 @@ if(~pshift != p+78) {
 			two26i = sc_ptr + 0x44;
 			sse2_rnd=sc_ptr + 0x46;
 			half   = sc_ptr + 0x48;
-			dtmp = *(double*)&ihalf;
+			dtmp = u64_to_f64(ihalf);
 			for(j = 0; j < max_threads; ++j) {
 				/* These remain fixed within each per-thread local store: */
 				VEC_DBL_INIT_2((vec_dbl*)two13i  , TWO13FLINV);
@@ -2087,7 +2087,7 @@ if(~pshift != p+78) {
 			/* We init "half" = 0.5-epsilon here, because emulating FLOOR(x) via DNINT(x-half) requires
 			us to always round up if x is a whole number, and our DNINT emulation can round either way if fractional part = 0.5:
 			*/
-			dtmp = *(double*)&ihalf;
+			dtmp = u64_to_f64(ihalf);
 			*half++ = dtmp;			*half-- = dtmp;
 		#endif
 			if(init_sse2) return 0;
@@ -4032,7 +4032,7 @@ if(~pshift != p+78) {
 				/* We init "half" = 0.5-epsilon here, because emulating FLOOR(x) via DNINT(x-half) requires
 				us to always round up if x is a whole number, and our DNINT emulation can round either way if fractional part = 0.5:
 				*/
-				*half++ = *(double*)&ihalf;	*half-- = *(double*)&ihalf;
+				*half++ = u64_to_f64(ihalf);	*half-- = u64_to_f64(ihalf);
 
 				/* Need both float and integer data to share same allocated chunk of memory, so can use a single base/offset scheme to manage both */
 				sm_ptr = (uint64*)(sc_ptr + 0x50);	/* Contiguous offset w.r.to last float data above is 0x4a, but start ints at +0x50 for ease: */

--- a/src/types.h
+++ b/src/types.h
@@ -99,6 +99,36 @@ EWM: nvcc gives 'error: invalid redeclaration of type name "int64_t"' for the ty
 	typedef uint64		uint64_t;
 #endif
 */
+
+/* Type to safely cast uint64 <-> double.
+ * This is used to get rid of gcc strict aliasing violation warnings.
+ */
+typedef union {
+  uint64 u64;
+  double f64;
+} i64_f64;
+
+static inline double u64_to_f64(uint64 u)
+{
+  i64_f64 cvt;
+  cvt.u64 = u;
+  return cvt.f64;
+}
+
+static inline uint64 f64_to_u64(double u)
+{
+  i64_f64 cvt;
+  cvt.f64 = u;
+  return cvt.u64;
+}
+
+static inline int64 f64_to_i64(double u)
+{
+  i64_f64 cvt;
+  cvt.f64 = u;
+  return cvt.u64;
+}
+
 /*******************************************************************************
    Some useful utility macros:
 *******************************************************************************/

--- a/src/types.h
+++ b/src/types.h
@@ -105,6 +105,7 @@ EWM: nvcc gives 'error: invalid redeclaration of type name "int64_t"' for the ty
  */
 typedef union {
   uint64 u64;
+  int64  i64;
   double f64;
 } i64_f64;
 
@@ -126,7 +127,7 @@ static inline int64 f64_to_i64(double u)
 {
   i64_f64 cvt;
   cvt.f64 = u;
-  return cvt.u64;
+  return cvt.i64;
 }
 
 /*******************************************************************************

--- a/src/util.c
+++ b/src/util.c
@@ -3145,7 +3145,7 @@ I = 981 Needed extra sub: a = 916753724; p = 11581569; pinv = 370 [a/p = 79.1562
 				r1 = rng_isaac_rand_double_norm_pm1() * pow2_dmult;	// in [-2^50, +2^50]
 				r2 = rng_isaac_rand_double_norm_pm1() * pow2_dmult;	// in [-2^50, +2^50]
 				mul50x50_debug(r1,r2, &lo,&hi);
-				printf("mul50x50_: a,b = %" PRIu64 ", %" PRIu64 "\n",*(uint64*)&r1,*(uint64*)&r2);
+				printf("mul50x50_: a,b = %" PRIu64 ", %" PRIu64 "\n",f64_to_u64(r1),f64_to_u64(r2));
 				printf("mul50x50_: lo = %16" PRIu64 "\n",*(uint64*)alo);
 				printf("mul50x50_: hi = %16" PRIu64 "\n",*(uint64*)ahi);
 			  #endif
@@ -3285,8 +3285,8 @@ void	mul50x50_debug(double a, double b, double *lo, double *hi)
 				dlo = -dlo;
 		}
 		// Extract exp & mantissa fields of the double outputs and restore hidden bits:
-		i64 = *(uint64*)&dhi; e1 = (i64>>52)&0x7ff; m1 = (i64&mmask) + two52;
-		i64 = *(uint64*)&dlo; e0 = (i64>>52)&0x7ff; m0 = (i64&mmask) +(two52 & (-(dlo != 0.)));
+		i64 = f64_to_u64(dhi); e1 = (i64>>52)&0x7ff; m1 = (i64&mmask) + two52;
+		i64 = f64_to_u64(dlo); e0 = (i64>>52)&0x7ff; m0 = (i64&mmask) +(two52 & (-(dlo != 0.)));
 		int nsh1 = e1 - 0x433;	// Shift count of hi-double result = exp - 0x3ff - 52
 		int nsh0 = e0 - 0x433;	// Shift count of lo-double result
 		exact.d0 = m1; exact.d1 = 0;	LSHIFT128(exact,nsh1, exact);
@@ -3304,7 +3304,7 @@ void	mul50x50_debug(double a, double b, double *lo, double *hi)
 			printf("In cmp_fma_lohi_vs_exact: FMA-double and pure-int DMUL results differ!\n");
 			printf("dx = %f; dy = %f; hi,lo = %f,%f\n",dx,dy, dhi * (1 - 2*(s1 != 0)), dlo * (1 - 2*(s0 != 0)));
 			printf("ix = %" PRId64 "; iy = %" PRId64 "; ihi,lo = %" PRId64 ",%" PRIu64 "\n",ix,iy, ihi,ilo);
-			printf("Unsigned FMA result: ihi = %" PRIX64 "; ilo = %" PRIX64 "\n",*(uint64*)&dhi,*(uint64*)&dlo);
+			printf("Unsigned FMA result: ihi = %" PRIX64 "; ilo = %" PRIX64 "\n",f64_to_u64(dhi),f64_to_u64(dlo));
 			printf("nsh1,0 = %d,%d: ehi = %" PRIu64 "; elo = %" PRIu64 " [mlo = %c%" PRIu64 "]\n",nsh1,nsh0,exact.d1,exact.d0, char_sgn[s1 ^ s0],m0);
 		}
 		return retval;
@@ -5711,7 +5711,7 @@ double	finvest(double x, uint32 numbits)
 	}
 
 	/* Unpack double into a uint64: */
-	itmp = *(uint64 *)&x;
+	itmp = f64_to_u64(x);
 	/* Separate upper part of the significand from the sign/exponent fields: */
 	exp  = (itmp >> 52) & MASK_EXP;
 	mant =  itmp        & MASK_MANT;
@@ -5735,7 +5735,7 @@ double	finvest(double x, uint32 numbits)
 	mant = (uint64)byte_lookup_finvest[byteval] << 44;
 
 	itmp = (itmp & MASK_SIGN) + (exp << 52) + mant;
-	ftmp = *(double *)&itmp;
+	ftmp = u64_to_f64(itmp);
 
 	/* Do as many Newton iterations as required - number of correct
 	bits approximately doubles each iteration. The iteration we use
@@ -5780,7 +5780,7 @@ double	fisqrtest(double x, uint32 numbits)
 	}
 
 	/* Unpack double into a uint64: */
-	itmp = *(uint64 *)&x;
+	itmp = f64_to_u64(x);
 	/* Separate upper part of the significand from the sign/exponent fields: */
 	exp  = (itmp >> 52) & MASK_EXP;
 	mant =  itmp        & MASK_MANT;
@@ -5838,7 +5838,7 @@ double	fisqrtest(double x, uint32 numbits)
 	mant = (uint64)byte_lookup_fisqrtest[byteval] << 44;
 
 	itmp = (itmp & MASK_SIGN) + (exp << 52) + mant;
-	ftmp = *(double *)&itmp;
+	ftmp = u64_to_f64(itmp);
 
 	/* Do as many Newton iterations as required - number of correct
 	bits approximately doubles each iteration. The iteration we use


### PR DESCRIPTION
Part of splitting @ldesnogu's warnings-cleanup PR #34 into smaller, independently-reviewable pieces.

This PR covers the **strict-aliasing** group: the `types.h` helper plus every commit that depends on it.

**1. Foundation** — adds an `i64_f64` union and `u64_to_f64` / `f64_to_u64` / `f64_to_i64` inline helpers to `types.h`, giving a well-defined (union type-punning, valid in C99+) way to reinterpret `uint64 <-> double` instead of the `*(uint64*)&x` pointer casts that violate strict aliasing.

**2. Aliasing fixes (33 commits)** — replace the offending pointer-cast reinterprets with the new helpers across `rng_isaac.c`, `mi64.c`, `fermat_mod_square.c`, `mers_mod_square.c`, `qfloat.c`, `util.c`, `dft_macro.c`, `twopmodq80.c`, `radix8_dif_dit_pass.c`, and the `radix{16,28,32,40,48,56,60,64,128,144,160,176,208,224,240,256,352,384,768,960,992,1008,1024,4032}_ditN_cy_dif1.c` DFT files.

Notes:
- All 34 commits are @ldesnogu's, cherry-picked from #34 with original authorship preserved; no content changes.
- Purely warning/UB cleanup — no behavior change. Verified: nosimd build clean, LL self-test Res64 `71E61322CCFB396C` unchanged.