### PR TITLE
radix12: initialize j1 in scalar radix12_dif/dit_pass1 (from #34)

### DIFF
--- a/src/radix12_ditN_cy_dif1.c
+++ b/src/radix12_ditN_cy_dif1.c
@@ -1399,6 +1399,8 @@ void radix12_dif_pass1(double a[], int n)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
+	#else
+		j1 = j; // LD: double-check this additional init is what is expected (comes from radix24)
 	#endif
 		j1 = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* padded-array fetch index is here */
 		j2 = j1+RE_IM_STRIDE;
@@ -1662,6 +1664,8 @@ void radix12_dit_pass1(double a[], int n)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
+	#else
+		j1 = j; // LD: double-check this additional init is what is expected (comes from radix24)
 	#endif
 		j1 = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* padded-array fetch index is here */
 		j2 = j1+RE_IM_STRIDE;

--- a/src/radix12_ditN_cy_dif1.c
+++ b/src/radix12_ditN_cy_dif1.c
@@ -1400,7 +1400,7 @@ void radix12_dif_pass1(double a[], int n)
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
 	#else
-		j1 = j; // LD: double-check this additional init is what is expected (comes from radix24)
+		j1 = j;
 	#endif
 		j1 = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* padded-array fetch index is here */
 		j2 = j1+RE_IM_STRIDE;
@@ -1665,7 +1665,7 @@ void radix12_dit_pass1(double a[], int n)
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
 	#else
-		j1 = j; // LD: double-check this additional init is what is expected (comes from radix24)
+		j1 = j;
 	#endif
 		j1 = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* padded-array fetch index is here */
 		j2 = j1+RE_IM_STRIDE;


### PR DESCRIPTION
From @ldesnogu's #34, pulled out on its own because it's a genuine correctness fix rather than a cosmetic warning cleanup, and shouldn't get lost in the larger warnings batch.

**The bug:** in scalar (non-AVX/non-SSE2) builds, `radix12_dif_pass1` and `radix12_dit_pass1` fall through their `j1` selection block with `j1` unset, then use it in `j1 = j1 + ((j1 >> DAT_BITS) << PAD_BITS)`. gcc flags it at `-O1`/`-O3`:
```
radix12_ditN_cy_dif1.c: warning: 'j1' may be used uninitialized [-Wmaybe-uninitialized]
```

**The fix:** add the scalar `#else j1 = j;` — the same initialization every sibling `*_pass1` uses in its scalar branch (verified in radix8/16/24/32/36; radix12 was the lone outlier).

**Scope / severity:** these two `_pass1` routines are currently reachable only from the `test_fft_radix.c` harness (not part of the build) and a dispatch table with no callers; production radix-12 FFT work goes through `radix12_ditN_cy_dif1`, which is unaffected. So this is a correctness/hygiene fix for the standalone pass routines (and silences the warning), not a live-run bug.

Authored by @ldesnogu, cherry-picked from #34 with original authorship preserved. Verified: nosimd build clean, LL self-test Res64 `71E61322CCFB396C` unchanged.