### PR TITLE
Remove warnings from twopmodq factoring routines (from #34)

### DIFF
--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -83,7 +83,7 @@ uint96 test_modsqr96(uint96 x, uint96 q)
 {
 	uint32 j;
 	uint96 qinv,t,hi,lo;
-#if 1
+#if 0 // what was this supposed to test?
 	uint64 __l,__m,__a,__b;
 	uint32 __tt = x.d1, __hl32,__hh32;
 	MUL64x32(x.d0,__tt, __a, __b);
@@ -216,7 +216,7 @@ uint128 test_modsqr128_96(uint128 x, uint128 q)
 uint32 test_twopmodq64(uint32 imax)
 {
 	uint32 i;
-	uint64 p,q, pos,neg,inv, prod128[2], rem;
+	uint64 p,q, pos,neg, prod128[2], rem;
 	rng_isaac_init(TRUE);
 	for(i = 0; i < imax; i++) {
 		p = rng_isaac_rand();
@@ -224,7 +224,7 @@ uint32 test_twopmodq64(uint32 imax)
 		pos = twopmmodq64(p,q);
 		neg = twopmodq64 (p,q);
 	#warning modinv64 fails for some 64-bit inputs - needs investigation.
-	//	inv = modinv64(neg,q);
+	//	uint64 inv = modinv64(neg,q);
 		// As a workaround for the modinv64 issue, instead compute 128-bit product pos*neg and check that pos*neg == 1 (mod q):
 	  #ifdef MUL_LOHI64_SUBROUTINE
 		MUL_LOHI64(pos,neg,prod128+0 ,prod128+1 );

--- a/src/twopmodq100.c
+++ b/src/twopmodq100.c
@@ -35,10 +35,12 @@
 //p = 16264097; k[0] = k[1] = k[2] = k[3] = k[4] = k[5] = k[6] = k[7] = 204476354235ull;	// Debug
 		const char func[] = "twopmodq100_2WORD_DOUBLE_q32";
 		 int32 j = 0;	/* This needs to be signed because of the LR binary exponentiation. */
-		uint64 lead7, r = 0, tmp64;
+		uint64 lead7, r = 0;
+	#ifdef USE_AVX512_I
+		uint64 tmp64;
+	#endif
 		static uint64 psave = 0, pshift;
 		static uint32 start_index, zshift, first_entry = TRUE;
-		uint32 FERMAT = isPow2_64(p)<<1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
 		const uint8* minv8_ptr = minv8;	// Ptr to Table of precomputed byte-inverses def'd in mi64.h
 		static int max_threads = 1;	// Default local-array-init is for just a single thread ... caller can re-init for > 1 threads later, if desired.
 	#ifdef USE_AVX512_I
@@ -52,7 +54,7 @@
 	  #else
 		static	// Following set of pointers only static-izable in single-thread mode
 	  #endif
-		uint64 *fq0[32],*fq1[32], *fqinv0[32],*fqinv1[32], *fx0[32],*fx1[32];
+		uint64 *fq0[32]/* ,*fq1[32] */, *fqinv0[32]/* ,*fqinv1[32] */, *fx0[32],*fx1[32];
 		for(j = 0; j < 32; j++) {
 			ASSERT((k[j] >> 52) == 0ull, "Ks must be < 2^52!");
 		}
@@ -70,7 +72,7 @@
 	  #else
 		static	// Following set of pointers only static-izable in single-thread mode
 	  #endif
-		double *fq0[32],*fq1[32], *fqinv0[32],*fqinv1[32], *fx0[32],*fx1[32], kdbl[32];
+		double *fq0[32]/* ,*fq1[32] */, *fqinv0[32]/* ,*fqinv1[32] */, *fx0[32],*fx1[32], kdbl[32];
 		// AVX-512 Foundation lacks the needed DQ extensions, so use HLL to convert kvec entries to double:
 		for(j = 0; j < 32; j++) {
 			ASSERT((k[j] >> 52) == 0ull, "Ks must be < 2^52!");
@@ -134,19 +136,19 @@
 		  #else
 			/* Remember, these are POINTERS-TO-UINT64, so need an increment of 8 to span an AVX-512 register: */
 			fq0   [0] = sc_ptr + 0x000;
-			fq1   [0] = sc_ptr + 0x020;
+			//fq1   [0] = sc_ptr + 0x020;
 			// +0x40 - Insert another slot here for q.lo + base*q.hi approximant
 			fqinv0[0] = sc_ptr + 0x060;
-			fqinv1[0] = sc_ptr + 0x080;
+			//fqinv1[0] = sc_ptr + 0x080;
 			fx0   [0] = sc_ptr + 0x0A0;
 			fx1   [0] = sc_ptr + 0x0C0;
 			// +0xE0,100 - Insert another 2 pairs of padding slots here for high-product-words (hi.lo,hi.hi) register spills
 			// +0x120 - Insert another slot here for hi.lo + base*h.hi approximant
 			for(j = 1, itmp = sc_ptr+1; j < 32; j++, itmp++) {
 				fq0   [j] = itmp + 0x000;
-				fq1   [j] = itmp + 0x020;
+				//fq1   [j] = itmp + 0x020;
 				fqinv0[j] = itmp + 0x060;
-				fqinv1[j] = itmp + 0x080;
+				//fqinv1[j] = itmp + 0x080;
 				fx0   [j] = itmp + 0x0A0;
 				fx1   [j] = itmp + 0x0C0;
 			}
@@ -165,19 +167,19 @@
 		  #else
 			/* Remember, these are POINTERS-TO-DOUBLE, so need an increment of 8 to span an AVX-512 register: */
 			fq0   [0] = sc_ptr + 0x000;
-			fq1   [0] = sc_ptr + 0x020;
+			//fq1   [0] = sc_ptr + 0x020;
 			// +0x40 - Insert another slot here for q.lo + base*q.hi approximant
 			fqinv0[0] = sc_ptr + 0x060;
-			fqinv1[0] = sc_ptr + 0x080;
+			//fqinv1[0] = sc_ptr + 0x080;
 			fx0   [0] = sc_ptr + 0x0A0;
 			fx1   [0] = sc_ptr + 0x0C0;
 			// +0xE0,100 - Insert another 2 pairs of padding slots here for high-product-words (hi.lo,hi.hi) register spills
 			// +0x120 - Insert another slot here for hi.lo + base*h.hi approximant
 			for(j = 1, dptr = sc_ptr+1; j < 32; j++, dptr++) {
 				fq0   [j] = dptr + 0x000;
-				fq1   [j] = dptr + 0x020;
+				//fq1   [j] = dptr + 0x020;
 				fqinv0[j] = dptr + 0x060;
-				fqinv1[j] = dptr + 0x080;
+				//fqinv1[j] = dptr + 0x080;
 				fx0   [j] = dptr + 0x0A0;
 				fx1   [j] = dptr + 0x0C0;
 			}
@@ -197,16 +199,16 @@
 		// Cf. above init-block for memory layout
 		/* Remember, these are POINTERS-TO-UINT64, so need an increment of 8 to span an AVX-512 register: */
 		fq0   [0] = sc_ptr + 0x000;
-		fq1   [0] = sc_ptr + 0x020;
+		//fq1   [0] = sc_ptr + 0x020;
 		fqinv0[0] = sc_ptr + 0x060;
-		fqinv1[0] = sc_ptr + 0x080;
+		//fqinv1[0] = sc_ptr + 0x080;
 		fx0   [0] = sc_ptr + 0x0A0;
 		fx1   [0] = sc_ptr + 0x0C0;
 		for(j = 1, itmp = sc_ptr+1; j < 32; j++, itmp++) {
 			fq0   [j] = itmp + 0x000;
-			fq1   [j] = itmp + 0x020;
+			//fq1   [j] = itmp + 0x020;
 			fqinv0[j] = itmp + 0x060;
-			fqinv1[j] = itmp + 0x080;
+			//fqinv1[j] = itmp + 0x080;
 			fx0   [j] = itmp + 0x0A0;
 			fx1   [j] = itmp + 0x0C0;
 		}
@@ -215,16 +217,16 @@
 		// Cf. above init-block for memory layout
 		/* Remember, these are POINTERS-TO-DOUBLE, so need an increment of 8 to span an AVX-512 register: */
 		fq0   [0] = sc_ptr + 0x000;
-		fq1   [0] = sc_ptr + 0x020;
+		//fq1   [0] = sc_ptr + 0x020;
 		fqinv0[0] = sc_ptr + 0x060;
-		fqinv1[0] = sc_ptr + 0x080;
+		//fqinv1[0] = sc_ptr + 0x080;
 		fx0   [0] = sc_ptr + 0x0A0;
 		fx1   [0] = sc_ptr + 0x0C0;
 		for(j = 1, dptr = sc_ptr+1; j < 32; j++, dptr++) {
 			fq0   [j] = dptr + 0x000;
-			fq1   [j] = dptr + 0x020;
+			//fq1   [j] = dptr + 0x020;
 			fqinv0[j] = dptr + 0x060;
-			fqinv1[j] = dptr + 0x080;
+			//fqinv1[j] = dptr + 0x080;
 			fx0   [j] = dptr + 0x0A0;
 			fx1   [j] = dptr + 0x0C0;
 		}

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -737,8 +737,8 @@ z0 = 6272576; z12 = 898312175313603; z=z0+a*z12	<*** z0 is +1 too large ***
 
 uint64 twopmodq78_3WORD_DOUBLE(uint64 p, uint64 k)
 {
-	const char func[] = "twopmodq78_3WORD_DOUBLE";
 #if FAC_DEBUG
+	const char func[] = "twopmodq78_3WORD_DOUBLE";
 	int dbg = 0;//(p==2147483647 && k==20269004);
 #endif
 	 int32 j;	/* This needs to be signed because of the LR binary exponentiation. */
@@ -1083,7 +1083,6 @@ if(~pshift != p+78) {
 	/*** 2-trial-factor version ***/
 	uint64 twopmodq78_3WORD_DOUBLE_q2(uint64 p, uint64 k0, uint64 k1, int init_sse2, int thr_id)
 	{
-		const char func[] = "twopmodq78_3WORD_DOUBLE_q2";
 	#if FAC_DEBUG
 		int dbg = 0;//(p==2147483647 && (k0==20269004 || k1==20269004));
 	#endif
@@ -1092,7 +1091,10 @@ if(~pshift != p+78) {
 		uint96 q0, q1, qinv0, qinv1, qhalf0, qhalf1, x0, x1, lo0, lo1;
 		uint192 prod192;
 		static uint64 psave = 0, pshift;
-		static uint32 start_index, zshift, first_entry = TRUE;
+		static uint32 start_index, zshift;
+	#ifdef USE_SSE2
+		static uint32 first_entry = TRUE;
+	#endif
 		uint32 FERMAT = isPow2_64(p)<<1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
 
 	#ifdef USE_SSE2
@@ -1101,16 +1103,16 @@ if(~pshift != p+78) {
 		const uint64 ihalf = 0x3FDfffffffffffffull;	/* Bitfield storing 0.5*(1-epsilon) in IEEE64 format */
 		static int max_threads = 1;	// Default local-array-init is for just a single thread ... caller can re-init for > 1 threads later, if desired.
 		static double *sc_arr = 0x0, *sc_ptr;
-		vec_dbl *tmp;
 		double dtmp;
 	  #ifdef MULTITHREAD
+		vec_dbl *tmp;
 		static double *__r0;	// Base address for discrete per-thread local stores ...
 								// *NOTE*: more convenient to use double* rather than vec_dbl* here
 	  #else
 		static	// Following set of pointers only static-izable in single-thread mode
 	  #endif
-		double *fq0,*fq1,*fq2,*fqhi52, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2
-					, *gq0,*gq1,*gq2,*gqhi52, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2
+		double *fq0,*fq1,*fq2/* ,*fqhi52 */, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2
+					, *gq0,*gq1,*gq2/* ,*gqhi52 */, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2
 					, *half, *two26f, *two26i, *two13i, *sse2_rnd;
 	#else
 
@@ -1126,7 +1128,7 @@ if(~pshift != p+78) {
 
 	#if FAC_DEBUG
 		if(dbg) {
-			printf("%s with p = %" PRIu64 ", k0 = %" PRIu64 ", k1 = %" PRIu64 "\n",func,p,k0,k1);
+			printf("%s with p = %" PRIu64 ", k0 = %" PRIu64 ", k1 = %" PRIu64 "\n",__FUNCTION__,p,k0,k1);
 		}
 	#endif
 
@@ -1181,7 +1183,7 @@ if(~pshift != p+78) {
 			#else
 				max_threads = init_sse2;
 			#endif
-				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",func,max_threads);
+				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",__FUNCTION__,max_threads);
 			#ifndef COMPILER_TYPE_GCC
 				ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 			#endif
@@ -1222,7 +1224,7 @@ if(~pshift != p+78) {
 			fq0    = sc_ptr + 0x00;		gq0    = sc_ptr + 0x01;
 			fq1    = sc_ptr + 0x02;		gq1    = sc_ptr + 0x03;
 			fq2    = sc_ptr + 0x04;		gq2    = sc_ptr + 0x05;
-			fqhi52 = sc_ptr + 0x06;		gqhi52 = sc_ptr + 0x07;
+			//fqhi52 = sc_ptr + 0x06;		gqhi52 = sc_ptr + 0x07;
 			fqinv0 = sc_ptr + 0x08;		gqinv0 = sc_ptr + 0x09;
 			fqinv1 = sc_ptr + 0x0a;		gqinv1 = sc_ptr + 0x0b;
 			fqinv2 = sc_ptr + 0x0c;		gqinv2 = sc_ptr + 0x0d;
@@ -1258,7 +1260,7 @@ if(~pshift != p+78) {
 		fq0    = sc_ptr + 0x00;		gq0    = sc_ptr + 0x01;
 		fq1    = sc_ptr + 0x02;		gq1    = sc_ptr + 0x03;
 		fq2    = sc_ptr + 0x04;		gq2    = sc_ptr + 0x05;
-		fqhi52 = sc_ptr + 0x06;		gqhi52 = sc_ptr + 0x07;
+		//fqhi52 = sc_ptr + 0x06;		gqhi52 = sc_ptr + 0x07;
 		fqinv0 = sc_ptr + 0x08;		gqinv0 = sc_ptr + 0x09;
 		fqinv1 = sc_ptr + 0x0a;		gqinv1 = sc_ptr + 0x0b;
 		fqinv2 = sc_ptr + 0x0c;		gqinv2 = sc_ptr + 0x0d;
@@ -1921,7 +1923,6 @@ if(~pshift != p+78) {
 			, int init_sse2, int thr_id
 	)
 	{
-		const char func[] = "twopmodq78_3WORD_DOUBLE_q4";
 		 int32 j;	/* This needs to be signed because of the LR binary exponentiation. */
 		uint32 q32_0, qinv32_0, tmp32_0
 			 , q32_1, qinv32_1, tmp32_1
@@ -1934,7 +1935,10 @@ if(~pshift != p+78) {
 			 , q3, qinv3, qhalf3, x3, lo3;
 		uint192 prod192;
 		static uint64 psave = 0, pshift;
-		static uint32 start_index, zshift, first_entry = TRUE;
+		static uint32 start_index, zshift;
+	#ifdef USE_SSE2
+		static uint32 first_entry = TRUE;
+	#endif
 		uint32 FERMAT = isPow2_64(p)<<1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
 
 	#ifdef USE_SSE2
@@ -1943,18 +1947,18 @@ if(~pshift != p+78) {
 		const uint64 ihalf = 0x3FDfffffffffffffull;	/* Bitfield storing 0.5*(1-epsilon) in IEEE64 format */
 		static int max_threads = 1;	// Default local-array-init is for just a single thread ... caller can re-init for > 1 threads later, if desired.
 		static double *sc_arr = 0x0, *sc_ptr;
-		vec_dbl *tmp;
 		double dtmp;
 	  #ifdef MULTITHREAD
+		vec_dbl *tmp;
 		static double *__r0;	// Base address for discrete per-thread local stores ...
 								// *NOTE*: more convenient to use double* rather than vec_dbl* here
 	  #else
 		static	// Following set of pointers only static-izable in single-thread mode
 	  #endif
-		double *fq0,*fq1,*fq2,*fqhi52, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2, *flo0,*flo1,*flo2, *fhi0,*fhi1,*fhi2
-			, *gq0,*gq1,*gq2,*gqhi52, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2, *glo0,*glo1,*glo2, *ghi0,*ghi1,*ghi2
-			, *hq0,*hq1,*hq2,*hqhi52, *hqinv0,*hqinv1,*hqinv2, *hx0,*hx1,*hx2, *hlo0,*hlo1,*hlo2, *hhi0,*hhi1,*hhi2
-			, *iq0,*iq1,*iq2,*iqhi52, *iqinv0,*iqinv1,*iqinv2, *ix0,*ix1,*ix2, *ilo0,*ilo1,*ilo2, *ihi0,*ihi1,*ihi2
+		double *fq0,*fq1,*fq2/* ,*fqhi52 */, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2/* , *flo0,*flo1,*flo2, *fhi0,*fhi1,*fhi2 */
+			, *gq0,*gq1,*gq2/* ,*gqhi52 */, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2/* , *glo0,*glo1,*glo2, *ghi0,*ghi1,*ghi2 */
+			, *hq0,*hq1,*hq2/* ,*hqhi52 */, *hqinv0,*hqinv1,*hqinv2, *hx0,*hx1,*hx2/* , *hlo0,*hlo1,*hlo2, *hhi0,*hhi1,*hhi2 */
+			, *iq0,*iq1,*iq2/* ,*iqhi52 */, *iqinv0,*iqinv1,*iqinv2, *ix0,*ix1,*ix2/* , *ilo0,*ilo1,*ilo2, *ihi0,*ihi1,*ihi2 */
 			, *half, *two26f, *two26i, *two13i, *sse2_rnd;
 
 	#else
@@ -2019,7 +2023,7 @@ if(~pshift != p+78) {
 			#else
 				max_threads = init_sse2;
 			#endif
-				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",func,max_threads);
+				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",__FUNCTION__,max_threads);
 			#ifndef COMPILER_TYPE_GCC
 				ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 			#endif
@@ -2060,19 +2064,19 @@ if(~pshift != p+78) {
 			fq0    = sc_ptr + 0x00;		gq0    = sc_ptr + 0x01;		hq0    = sc_ptr + 0x02;		iq0    = sc_ptr + 0x03;
 			fq1    = sc_ptr + 0x04;		gq1    = sc_ptr + 0x05;		hq1    = sc_ptr + 0x06;		iq1    = sc_ptr + 0x07;
 			fq2    = sc_ptr + 0x08;		gq2    = sc_ptr + 0x09;		hq2    = sc_ptr + 0x0a;		iq2    = sc_ptr + 0x0b;
-			fqhi52 = sc_ptr + 0x0c;		gqhi52 = sc_ptr + 0x0d;		hqhi52 = sc_ptr + 0x0e;		iqhi52 = sc_ptr + 0x0f;
+			//fqhi52 = sc_ptr + 0x0c;		gqhi52 = sc_ptr + 0x0d;		hqhi52 = sc_ptr + 0x0e;		iqhi52 = sc_ptr + 0x0f;
 			fqinv0 = sc_ptr + 0x10;		gqinv0 = sc_ptr + 0x11;		hqinv0 = sc_ptr + 0x12;		iqinv0 = sc_ptr + 0x13;
 			fqinv1 = sc_ptr + 0x14;		gqinv1 = sc_ptr + 0x15;		hqinv1 = sc_ptr + 0x16;		iqinv1 = sc_ptr + 0x17;
 			fqinv2 = sc_ptr + 0x18;		gqinv2 = sc_ptr + 0x19;		hqinv2 = sc_ptr + 0x1a;		iqinv2 = sc_ptr + 0x1b;
 			fx0    = sc_ptr + 0x1c;		gx0    = sc_ptr + 0x1d;		hx0    = sc_ptr + 0x1e;		ix0    = sc_ptr + 0x1f;
 			fx1    = sc_ptr + 0x20;		gx1    = sc_ptr + 0x21;		hx1    = sc_ptr + 0x22;		ix1    = sc_ptr + 0x23;
 			fx2    = sc_ptr + 0x24;		gx2    = sc_ptr + 0x25;		hx2    = sc_ptr + 0x26;		ix2    = sc_ptr + 0x27;
-			flo0   = sc_ptr + 0x28;		glo0   = sc_ptr + 0x29;		hlo0   = sc_ptr + 0x2a;		ilo0   = sc_ptr + 0x2b;
-			flo1   = sc_ptr + 0x2c;		glo1   = sc_ptr + 0x2d;		hlo1   = sc_ptr + 0x2e;		ilo1   = sc_ptr + 0x2f;
-			flo2   = sc_ptr + 0x30;		glo2   = sc_ptr + 0x31;		hlo2   = sc_ptr + 0x32;		ilo2   = sc_ptr + 0x33;
-			fhi0   = sc_ptr + 0x34;		ghi0   = sc_ptr + 0x35;		hhi0   = sc_ptr + 0x36;		ihi0   = sc_ptr + 0x37;
-			fhi1   = sc_ptr + 0x38;		ghi1   = sc_ptr + 0x39;		hhi1   = sc_ptr + 0x3a;		ihi1   = sc_ptr + 0x3b;
-			fhi2   = sc_ptr + 0x3c;		ghi2   = sc_ptr + 0x3d;		hhi2   = sc_ptr + 0x3e;		ihi2   = sc_ptr + 0x3f;
+			//flo0   = sc_ptr + 0x28;		glo0   = sc_ptr + 0x29;		hlo0   = sc_ptr + 0x2a;		ilo0   = sc_ptr + 0x2b;
+			//flo1   = sc_ptr + 0x2c;		glo1   = sc_ptr + 0x2d;		hlo1   = sc_ptr + 0x2e;		ilo1   = sc_ptr + 0x2f;
+			//flo2   = sc_ptr + 0x30;		glo2   = sc_ptr + 0x31;		hlo2   = sc_ptr + 0x32;		ilo2   = sc_ptr + 0x33;
+			//fhi0   = sc_ptr + 0x34;		ghi0   = sc_ptr + 0x35;		hhi0   = sc_ptr + 0x36;		ihi0   = sc_ptr + 0x37;
+			//fhi1   = sc_ptr + 0x38;		ghi1   = sc_ptr + 0x39;		hhi1   = sc_ptr + 0x3a;		ihi1   = sc_ptr + 0x3b;
+			//fhi2   = sc_ptr + 0x3c;		ghi2   = sc_ptr + 0x3d;		hhi2   = sc_ptr + 0x3e;		ihi2   = sc_ptr + 0x3f;
 			two13i = sc_ptr + 0x40;
 			two26f = sc_ptr + 0x42;
 			two26i = sc_ptr + 0x44;
@@ -2101,19 +2105,19 @@ if(~pshift != p+78) {
 		fq0    = sc_ptr + 0x00;		gq0    = sc_ptr + 0x01;		hq0    = sc_ptr + 0x02;		iq0    = sc_ptr + 0x03;
 		fq1    = sc_ptr + 0x04;		gq1    = sc_ptr + 0x05;		hq1    = sc_ptr + 0x06;		iq1    = sc_ptr + 0x07;
 		fq2    = sc_ptr + 0x08;		gq2    = sc_ptr + 0x09;		hq2    = sc_ptr + 0x0a;		iq2    = sc_ptr + 0x0b;
-		fqhi52 = sc_ptr + 0x0c;		gqhi52 = sc_ptr + 0x0d;		hqhi52 = sc_ptr + 0x0e;		iqhi52 = sc_ptr + 0x0f;
+		//fqhi52 = sc_ptr + 0x0c;		gqhi52 = sc_ptr + 0x0d;		hqhi52 = sc_ptr + 0x0e;		iqhi52 = sc_ptr + 0x0f;
 		fqinv0 = sc_ptr + 0x10;		gqinv0 = sc_ptr + 0x11;		hqinv0 = sc_ptr + 0x12;		iqinv0 = sc_ptr + 0x13;
 		fqinv1 = sc_ptr + 0x14;		gqinv1 = sc_ptr + 0x15;		hqinv1 = sc_ptr + 0x16;		iqinv1 = sc_ptr + 0x17;
 		fqinv2 = sc_ptr + 0x18;		gqinv2 = sc_ptr + 0x19;		hqinv2 = sc_ptr + 0x1a;		iqinv2 = sc_ptr + 0x1b;
 		fx0    = sc_ptr + 0x1c;		gx0    = sc_ptr + 0x1d;		hx0    = sc_ptr + 0x1e;		ix0    = sc_ptr + 0x1f;
 		fx1    = sc_ptr + 0x20;		gx1    = sc_ptr + 0x21;		hx1    = sc_ptr + 0x22;		ix1    = sc_ptr + 0x23;
 		fx2    = sc_ptr + 0x24;		gx2    = sc_ptr + 0x25;		hx2    = sc_ptr + 0x26;		ix2    = sc_ptr + 0x27;
-		flo0   = sc_ptr + 0x28;		glo0   = sc_ptr + 0x29;		hlo0   = sc_ptr + 0x2a;		ilo0   = sc_ptr + 0x2b;
-		flo1   = sc_ptr + 0x2c;		glo1   = sc_ptr + 0x2d;		hlo1   = sc_ptr + 0x2e;		ilo1   = sc_ptr + 0x2f;
-		flo2   = sc_ptr + 0x30;		glo2   = sc_ptr + 0x31;		hlo2   = sc_ptr + 0x32;		ilo2   = sc_ptr + 0x33;
-		fhi0   = sc_ptr + 0x34;		ghi0   = sc_ptr + 0x35;		hhi0   = sc_ptr + 0x36;		ihi0   = sc_ptr + 0x37;
-		fhi1   = sc_ptr + 0x38;		ghi1   = sc_ptr + 0x39;		hhi1   = sc_ptr + 0x3a;		ihi1   = sc_ptr + 0x3b;
-		fhi2   = sc_ptr + 0x3c;		ghi2   = sc_ptr + 0x3d;		hhi2   = sc_ptr + 0x3e;		ihi2   = sc_ptr + 0x3f;
+		//flo0   = sc_ptr + 0x28;		glo0   = sc_ptr + 0x29;		hlo0   = sc_ptr + 0x2a;		ilo0   = sc_ptr + 0x2b;
+		//flo1   = sc_ptr + 0x2c;		glo1   = sc_ptr + 0x2d;		hlo1   = sc_ptr + 0x2e;		ilo1   = sc_ptr + 0x2f;
+		//flo2   = sc_ptr + 0x30;		glo2   = sc_ptr + 0x31;		hlo2   = sc_ptr + 0x32;		ilo2   = sc_ptr + 0x33;
+		//fhi0   = sc_ptr + 0x34;		ghi0   = sc_ptr + 0x35;		hhi0   = sc_ptr + 0x36;		ihi0   = sc_ptr + 0x37;
+		//fhi1   = sc_ptr + 0x38;		ghi1   = sc_ptr + 0x39;		hhi1   = sc_ptr + 0x3a;		ihi1   = sc_ptr + 0x3b;
+		//fhi2   = sc_ptr + 0x3c;		ghi2   = sc_ptr + 0x3d;		hhi2   = sc_ptr + 0x3e;		ihi2   = sc_ptr + 0x3f;
 		two13i = sc_ptr + 0x40;
 		two26f = sc_ptr + 0x42;
 		two26i = sc_ptr + 0x44;
@@ -3320,6 +3324,7 @@ if(~pshift != p+78) {
 		uint64 twopmodq78_3WORD_DOUBLE_q8(uint64 p, uint64 k[], int init_sse2, int thr_id)
 		{
 			ASSERT(0,"No TF support on ARMv8!");
+			return 0; // silence warning
 		}
 
 	#elif defined(X64_ASM) && defined(USE_SSE2)
@@ -3362,14 +3367,14 @@ if(~pshift != p+78) {
 		  #else
 			static	// Following set of pointers only static-izable in single-thread mode
 		  #endif
-			double *aq0,*aq1,*aq2,*aqhi52, *aqinv0,*aqinv1,*aqinv2, *ax0,*ax1,*ax2
-				, *bq0,*bq1,*bq2,*bqhi52, *bqinv0,*bqinv1,*bqinv2, *bx0,*bx1,*bx2
-				, *cq0,*cq1,*cq2,*cqhi52, *cqinv0,*cqinv1,*cqinv2, *cx0,*cx1,*cx2
-				, *dq0,*dq1,*dq2,*dqhi52, *dqinv0,*dqinv1,*dqinv2, *dx0,*dx1,*dx2
-				, *eq0,*eq1,*eq2,*eqhi52, *eqinv0,*eqinv1,*eqinv2, *ex0,*ex1,*ex2
-				, *fq0,*fq1,*fq2,*fqhi52, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2
-				, *gq0,*gq1,*gq2,*gqhi52, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2
-				, *hq0,*hq1,*hq2,*hqhi52, *hqinv0,*hqinv1,*hqinv2, *hx0,*hx1,*hx2
+			double *aq0,*aq1,*aq2/* ,*aqhi52 */, *aqinv0,*aqinv1,*aqinv2, *ax0,*ax1,*ax2
+				, *bq0,*bq1,*bq2/* ,*bqhi52 */, *bqinv0,*bqinv1,*bqinv2, *bx0,*bx1,*bx2
+				, *cq0,*cq1,*cq2/* ,*cqhi52 */, *cqinv0,*cqinv1,*cqinv2, *cx0,*cx1,*cx2
+				, *dq0,*dq1,*dq2/* ,*dqhi52 */, *dqinv0,*dqinv1,*dqinv2, *dx0,*dx1,*dx2
+				, *eq0,*eq1,*eq2/* ,*eqhi52 */, *eqinv0,*eqinv1,*eqinv2, *ex0,*ex1,*ex2
+				, *fq0,*fq1,*fq2/* ,*fqhi52 */, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2
+				, *gq0,*gq1,*gq2/* ,*gqhi52 */, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2
+				, *hq0,*hq1,*hq2/* ,*hqhi52 */, *hqinv0,*hqinv1,*hqinv2, *hx0,*hx1,*hx2
 				, *two26f, *two26i, *two13i;
 
 			if(p != psave)
@@ -3453,7 +3458,7 @@ if(~pshift != p+78) {
 				aq0    = sc_ptr + 0x00;	bq0    = sc_ptr + 0x01;	cq0    = sc_ptr + 0x02;	dq0    = sc_ptr + 0x03;	eq0    = sc_ptr + 0x04;	fq0    = sc_ptr + 0x05;	gq0    = sc_ptr + 0x06;	hq0    = sc_ptr + 0x07;
 				aq1    = sc_ptr + 0x08;	bq1    = sc_ptr + 0x09;	cq1    = sc_ptr + 0x0a;	dq1    = sc_ptr + 0x0b;	eq1    = sc_ptr + 0x0c;	fq1    = sc_ptr + 0x0d;	gq1    = sc_ptr + 0x0e;	hq1    = sc_ptr + 0x0f;
 				aq2    = sc_ptr + 0x10;	bq2    = sc_ptr + 0x11;	cq2    = sc_ptr + 0x12;	dq2    = sc_ptr + 0x13;	eq2    = sc_ptr + 0x14;	fq2    = sc_ptr + 0x15;	gq2    = sc_ptr + 0x16;	hq2    = sc_ptr + 0x17;
-				aqhi52 = sc_ptr + 0x18;	bqhi52 = sc_ptr + 0x19;	cqhi52 = sc_ptr + 0x1a;	dqhi52 = sc_ptr + 0x1b;	eqhi52 = sc_ptr + 0x1c;	fqhi52 = sc_ptr + 0x1d;	gqhi52 = sc_ptr + 0x1e;	hqhi52 = sc_ptr + 0x1f;
+				//aqhi52 = sc_ptr + 0x18;	bqhi52 = sc_ptr + 0x19;	cqhi52 = sc_ptr + 0x1a;	dqhi52 = sc_ptr + 0x1b;	eqhi52 = sc_ptr + 0x1c;	fqhi52 = sc_ptr + 0x1d;	gqhi52 = sc_ptr + 0x1e;	hqhi52 = sc_ptr + 0x1f;
 				aqinv0 = sc_ptr + 0x20;	bqinv0 = sc_ptr + 0x21;	cqinv0 = sc_ptr + 0x22;	dqinv0 = sc_ptr + 0x23;	eqinv0 = sc_ptr + 0x24;	fqinv0 = sc_ptr + 0x25;	gqinv0 = sc_ptr + 0x26;	hqinv0 = sc_ptr + 0x27;
 				aqinv1 = sc_ptr + 0x28;	bqinv1 = sc_ptr + 0x29;	cqinv1 = sc_ptr + 0x2a;	dqinv1 = sc_ptr + 0x2b;	eqinv1 = sc_ptr + 0x2c;	fqinv1 = sc_ptr + 0x2d;	gqinv1 = sc_ptr + 0x2e;	hqinv1 = sc_ptr + 0x2f;
 				aqinv2 = sc_ptr + 0x30;	bqinv2 = sc_ptr + 0x31;	cqinv2 = sc_ptr + 0x32;	dqinv2 = sc_ptr + 0x33;	eqinv2 = sc_ptr + 0x34;	fqinv2 = sc_ptr + 0x35;	gqinv2 = sc_ptr + 0x36;	hqinv2 = sc_ptr + 0x37;
@@ -3493,7 +3498,7 @@ if(~pshift != p+78) {
 			aq0    = sc_ptr + 0x00;	bq0    = sc_ptr + 0x01;	cq0    = sc_ptr + 0x02;	dq0    = sc_ptr + 0x03;	eq0    = sc_ptr + 0x04;	fq0    = sc_ptr + 0x05;	gq0    = sc_ptr + 0x06;	hq0    = sc_ptr + 0x07;
 			aq1    = sc_ptr + 0x08;	bq1    = sc_ptr + 0x09;	cq1    = sc_ptr + 0x0a;	dq1    = sc_ptr + 0x0b;	eq1    = sc_ptr + 0x0c;	fq1    = sc_ptr + 0x0d;	gq1    = sc_ptr + 0x0e;	hq1    = sc_ptr + 0x0f;
 			aq2    = sc_ptr + 0x10;	bq2    = sc_ptr + 0x11;	cq2    = sc_ptr + 0x12;	dq2    = sc_ptr + 0x13;	eq2    = sc_ptr + 0x14;	fq2    = sc_ptr + 0x15;	gq2    = sc_ptr + 0x16;	hq2    = sc_ptr + 0x17;
-			aqhi52 = sc_ptr + 0x18;	bqhi52 = sc_ptr + 0x19;	cqhi52 = sc_ptr + 0x1a;	dqhi52 = sc_ptr + 0x1b;	eqhi52 = sc_ptr + 0x1c;	fqhi52 = sc_ptr + 0x1d;	gqhi52 = sc_ptr + 0x1e;	hqhi52 = sc_ptr + 0x1f;
+			//aqhi52 = sc_ptr + 0x18;	bqhi52 = sc_ptr + 0x19;	cqhi52 = sc_ptr + 0x1a;	dqhi52 = sc_ptr + 0x1b;	eqhi52 = sc_ptr + 0x1c;	fqhi52 = sc_ptr + 0x1d;	gqhi52 = sc_ptr + 0x1e;	hqhi52 = sc_ptr + 0x1f;
 			aqinv0 = sc_ptr + 0x20;	bqinv0 = sc_ptr + 0x21;	cqinv0 = sc_ptr + 0x22;	dqinv0 = sc_ptr + 0x23;	eqinv0 = sc_ptr + 0x24;	fqinv0 = sc_ptr + 0x25;	gqinv0 = sc_ptr + 0x26;	hqinv0 = sc_ptr + 0x27;
 			aqinv1 = sc_ptr + 0x28;	bqinv1 = sc_ptr + 0x29;	cqinv1 = sc_ptr + 0x2a;	dqinv1 = sc_ptr + 0x2b;	eqinv1 = sc_ptr + 0x2c;	fqinv1 = sc_ptr + 0x2d;	gqinv1 = sc_ptr + 0x2e;	hqinv1 = sc_ptr + 0x2f;
 			aqinv2 = sc_ptr + 0x30;	bqinv2 = sc_ptr + 0x31;	cqinv2 = sc_ptr + 0x32;	dqinv2 = sc_ptr + 0x33;	eqinv2 = sc_ptr + 0x34;	fqinv2 = sc_ptr + 0x35;	gqinv2 = sc_ptr + 0x36;	hqinv2 = sc_ptr + 0x37;
@@ -3948,10 +3953,10 @@ if(~pshift != p+78) {
 			/* Force 128-bit alignment needed for SSE work via the complex type, but also need double-pointer accesses to indivdual TF data: */
 			static vec_dbl *sc_arr = 0x0;
 			static double *sc_ptr;
-			static double *fq0,*fq1,*fq2,*fqhi52, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2, *flo0,*flo1,*flo2, *fhi0,*fhi1,*fhi2;
-			static double *gq0,*gq1,*gq2,*gqhi52, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2, *glo0,*glo1,*glo2, *ghi0,*ghi1,*ghi2;
-			static double *hq0,*hq1,*hq2,*hqhi52, *hqinv0,*hqinv1,*hqinv2, *hx0,*hx1,*hx2, *hlo0,*hlo1,*hlo2, *hhi0,*hhi1,*hhi2;
-			static double *iq0,*iq1,*iq2,*iqhi52, *iqinv0,*iqinv1,*iqinv2, *ix0,*ix1,*ix2, *ilo0,*ilo1,*ilo2, *ihi0,*ihi1,*ihi2;
+			static double *fq0,*fq1,*fq2/* ,*fqhi52 */, *fqinv0,*fqinv1,*fqinv2, *fx0,*fx1,*fx2, *flo0,*flo1,*flo2, *fhi0,*fhi1,*fhi2;
+			static double *gq0,*gq1,*gq2/* ,*gqhi52 */, *gqinv0,*gqinv1,*gqinv2, *gx0,*gx1,*gx2, *glo0,*glo1,*glo2, *ghi0,*ghi1,*ghi2;
+			static double *hq0,*hq1,*hq2/* ,*hqhi52 */, *hqinv0,*hqinv1,*hqinv2, *hx0,*hx1,*hx2, *hlo0,*hlo1,*hlo2, *hhi0,*hhi1,*hhi2;
+			static double *iq0,*iq1,*iq2/* ,*iqhi52 */, *iqinv0,*iqinv1,*iqinv2, *ix0,*ix1,*ix2, *ilo0,*ilo1,*ilo2, *ihi0,*ihi1,*ihi2;
 			static double *half, *two26f, *two26i, *two13i, *sse2_rnd;
 			static uint64 ihalf = 0x3FDfffffffffffffull;	/* Bitfield storing 0.5*(1-epsilon) in IEEE64 format */
 			/* Integer stuff: */
@@ -4004,7 +4009,7 @@ if(~pshift != p+78) {
 				fq0    = sc_ptr + 0x00;		gq0    = sc_ptr + 0x01;		hq0    = sc_ptr + 0x02;		iq0    = sc_ptr + 0x03;	/* 0x000 */
 				fq1    = sc_ptr + 0x04;		gq1    = sc_ptr + 0x05;		hq1    = sc_ptr + 0x06;		iq1    = sc_ptr + 0x07;	/* 0x020 */
 				fq2    = sc_ptr + 0x08;		gq2    = sc_ptr + 0x09;		hq2    = sc_ptr + 0x0a;		iq2    = sc_ptr + 0x0b;	/* 0x040 */
-				fqhi52 = sc_ptr + 0x0c;		gqhi52 = sc_ptr + 0x0d;		hqhi52 = sc_ptr + 0x0e;		iqhi52 = sc_ptr + 0x0f;	/* 0x060 */
+				//fqhi52 = sc_ptr + 0x0c;		gqhi52 = sc_ptr + 0x0d;		hqhi52 = sc_ptr + 0x0e;		iqhi52 = sc_ptr + 0x0f;	/* 0x060 */
 				fqinv0 = sc_ptr + 0x10;		gqinv0 = sc_ptr + 0x11;		hqinv0 = sc_ptr + 0x12;		iqinv0 = sc_ptr + 0x13;	/* 0x080 */
 				fqinv1 = sc_ptr + 0x14;		gqinv1 = sc_ptr + 0x15;		hqinv1 = sc_ptr + 0x16;		iqinv1 = sc_ptr + 0x17;	/* 0x0a0 */
 				fqinv2 = sc_ptr + 0x18;		gqinv2 = sc_ptr + 0x19;		hqinv2 = sc_ptr + 0x1a;		iqinv2 = sc_ptr + 0x1b;	/* 0x0c0 */
@@ -4846,24 +4851,35 @@ if(~pshift != p+78) {
 			 int32 j = 0;	/* This needs to be signed because of the LR binary exponentiation. */
 			uint32 q32[16], qinv32[16], tmp32;
 			uint64 lead7, r = 0, tmp64;
-			uint96 q[16], qinv[16], qhalf[16], x[16], tmp96;
+			uint96 q[16], qinv[16];
+		  #ifndef USE_AVX2
+			uint96 qhalf[16], x[16];
+			uint96 tmp96;
 			uint192 prod192;
+		  #endif
 			static uint64 psave = 0, pshift;
 			static uint32 start_index, zshift, first_entry = TRUE;
+		  #ifndef USE_AVX2
 			uint32 FERMAT = isPow2_64(p)<<1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
+		  #endif
 
 			static int max_threads = 1;	// Default local-array-init is for just a single thread ... caller can re-init for > 1 threads later, if desired.
 			static double *sc_arr = 0x0, *sc_ptr;
-			double *dptr, dtmp;
-			vec_dbl *tmp;
+			double *dptr;
+		  #ifdef USE_AVX2
+			double dtmp;
+		  #endif
 		  #ifdef MULTITHREAD
 			static double *__r0;	// Base address for discrete per-thread local stores ...
 									// *NOTE*: more convenient to use double* rather than vec_dbl* here
 		  #else
 			static	// Following set of pointers only static-izable in single-thread mode
 		  #endif
-			double *fq0[16],*fq1[16],*fq2[16],*fqhi52[16], *fqinv0[16],*fqinv1[16],*fqinv2[16], *fx0[16],*fx1[16],*fx2[16],
+			double *fq0[16],*fq1[16],*fq2[16],/* *fqhi52[16], */ *fqinv0[16],*fqinv1[16],*fqinv2[16], *fx0[16],
 					*two13i, *two26f,*two26i, *two52f,*two52i;
+		  #ifndef USE_AVX2
+			double *fx1[16],*fx2[16];
+		  #endif
 
 		#if FAC_DEBUG
 			if(dbg) printf("%s with p = %" PRIu64 ", k[] = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 "\n",
@@ -4948,24 +4964,28 @@ if(~pshift != p+78) {
 				fq0   [0] = sc_ptr + 0x00;
 				fq1   [0] = sc_ptr + 0x10;
 				fq2   [0] = sc_ptr + 0x20;
-				fqhi52[0] = sc_ptr + 0x30;
+				//fqhi52[0] = sc_ptr + 0x30;
 				fqinv0[0] = sc_ptr + 0x40;
 				fqinv1[0] = sc_ptr + 0x50;
 				fqinv2[0] = sc_ptr + 0x60;
 				fx0   [0] = sc_ptr + 0x70;
+			  #ifndef USE_AVX2
 				fx1   [0] = sc_ptr + 0x80;
 				fx2   [0] = sc_ptr + 0x90;
+			  #endif
 				for(j = 1, dptr = sc_ptr+1; j < 16; j++, dptr++) {
 					fq0   [j] = dptr + 0x00;
 					fq1   [j] = dptr + 0x10;
 					fq2   [j] = dptr + 0x20;
-					fqhi52[j] = dptr + 0x30;
+					//fqhi52[j] = dptr + 0x30;
 					fqinv0[j] = dptr + 0x40;
 					fqinv1[j] = dptr + 0x50;
 					fqinv2[j] = dptr + 0x60;
 					fx0   [j] = dptr + 0x70;
+			  #ifndef USE_AVX2
 					fx1   [j] = dptr + 0x80;
 					fx2   [j] = dptr + 0x90;
+			  #endif
 				}
 			// +0xa0,b0 - Insert another 2 pairs of padding slots here for high-product-words register spills (we spill 2 of 3 words)
 			// Consts: only get 1 AVX-reg (4 doubles) per:
@@ -4994,24 +5014,28 @@ if(~pshift != p+78) {
 			fq0   [0] = sc_ptr + 0x00;
 			fq1   [0] = sc_ptr + 0x10;
 			fq2   [0] = sc_ptr + 0x20;
-			fqhi52[0] = sc_ptr + 0x30;
+			//fqhi52[0] = sc_ptr + 0x30;
 			fqinv0[0] = sc_ptr + 0x40;
 			fqinv1[0] = sc_ptr + 0x50;
 			fqinv2[0] = sc_ptr + 0x60;
 			fx0   [0] = sc_ptr + 0x70;
+		  #ifndef USE_AVX2
 			fx1   [0] = sc_ptr + 0x80;
 			fx2   [0] = sc_ptr + 0x90;
+		  #endif
 			for(j = 1, dptr = sc_ptr+1; j < 16; j++, dptr++) {
 				fq0   [j] = dptr + 0x00;
 				fq1   [j] = dptr + 0x10;
 				fq2   [j] = dptr + 0x20;
-				fqhi52[j] = dptr + 0x30;
+				//fqhi52[j] = dptr + 0x30;
 				fqinv0[j] = dptr + 0x40;
 				fqinv1[j] = dptr + 0x50;
 				fqinv2[j] = dptr + 0x60;
 				fx0   [j] = dptr + 0x70;
+		  #ifndef USE_AVX2
 				fx1   [j] = dptr + 0x80;
 				fx2   [j] = dptr + 0x90;
+		  #endif
 			}
 		// +0xa0,b0 - Insert another 2 pairs of padding slots here for high-product-words register spills (we spill 2 of 3 words)
 		// Consts: only get 1 AVX-reg (4 doubles) per:
@@ -5036,9 +5060,11 @@ if(~pshift != p+78) {
 				MUL_LOHI64(q[j].d0, k[j], q[j].d0, q[j].d1);	q[j].d0 += 1;	// Since 2*p*k even, no need to check for overflow here
 				q32[j] = (uint32)q[j].d0;
 				CVT_UINT78_3WORD_DOUBLE(q[j] ,*fq0[j],*fq1[j],*fq2[j]);	// Convert q to floating form
+			#ifndef USE_AVX2
 				tmp96.d0 = q[j].d0; tmp96.d1 = q[j].d1;	// Stash-in-scalar-uint96 to work around "expected expression" compiler error
 				RSHIFT_FAST96(tmp96, 1, tmp96);	// qhalf = (q-1)/2, since q odd.
 				qhalf[j].d0 = tmp96.d0; qhalf[j].d1 = tmp96.d1;
+			#endif
 				// Iterative mod-inverse computation:
 				/* 8 bits: */
 				qinv32[j] = minv8[(q32[j] & 0xff)>>1];
@@ -5238,7 +5264,11 @@ if(~pshift != p+78) {
 		#if FAC_DEBUG
 		  if(dbg) {
 			printf("p = %" PRIu64 ", k0 = %" PRIu64 ", start_index0 = %u, initial shift = %u\n",p,k[0],start_index,zshift);
+		  #ifdef USE_AVX2
+			printf("On modpow-loop entry: start_index = %u,\n\tfx0-2 = %20.15f, %20.15f\n",start_index, *fx0[0]);
+		  #else
 			printf("On modpow-loop entry: start_index = %u,\n\tfx0-2 = %20.15f, %20.15f, %20.15f, %20.15f\n",start_index, *fx0[0],*fx1[0],*fx2[0]);
+		  #endif
 		  }
 		#endif
 
@@ -5382,10 +5412,12 @@ if(~pshift != p+78) {
 		{//	p = 17732269; k[0] = k[1] = k[2] = k[3] = 133912345560ull;	// Debug
 			const char func[] = "twopmodq78_3WORD_DOUBLE_q32";
 			 int32 j = 0;	/* This needs to be signed because of the LR binary exponentiation. */
-			uint64 lead7, r = 0, tmp64;
+			uint64 lead7, r = 0;
+		#ifdef USE_AVX512_I
+			uin64 tmp64;
+		#endif
 			static uint64 psave = 0, pshift;
 			static uint32 start_index, zshift, first_entry = TRUE;
-			uint32 FERMAT = isPow2_64(p)<<1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
 			const uint8* minv8_ptr = minv8;	// Ptr to Table of precomputed byte-inverses def'd in mi64.h
 			static int max_threads = 1;	// Default local-array-init is for just a single thread ... caller can re-init for > 1 threads later, if desired.
 		#ifdef USE_AVX512_I
@@ -5413,7 +5445,7 @@ if(~pshift != p+78) {
 		  #else
 			static	// Following set of pointers only static-izable in single-thread mode
 		  #endif
-			double *fq0[32],*fq1[32],*fq2[32],*fqhi52[32], *fqinv0[32],*fqinv1[32],*fqinv2[32], *fx0[32],*fx1[32],*fx2[32],
+			double *fq0[32],/* *fq1[32],*fq2[32],*fqhi52[32], */ *fqinv0[32],/* *fqinv1[32],*fqinv2[32], */ *fx0[32],*fx1[32],*fx2[32],
 					*two13i, *two26f,*two26i, *two52f,*two52i,
 					kdbl[32];
 			// AVX-512 Foundation lacks the needed DQ extensions, so use HLL to convert kvec entries to double:
@@ -5488,23 +5520,23 @@ if(~pshift != p+78) {
 			  #else
 				/* Remember, these are POINTERS-TO-UINT64, so need an increment of 8 to span an AVX-512 register: */
 				fq0   [0] = sc_ptr + 0x000;
-				fq1   [0] = sc_ptr + 0x020;
-				fq2   [0] = sc_ptr + 0x040;
-				fqhi52[0] = sc_ptr + 0x060;
+				//fq1   [0] = sc_ptr + 0x020;
+				//fq2   [0] = sc_ptr + 0x040;
+				//fqhi52[0] = sc_ptr + 0x060;
 				fqinv0[0] = sc_ptr + 0x080;
-				fqinv1[0] = sc_ptr + 0x0A0;
-				fqinv2[0] = sc_ptr + 0x0C0;
+				//fqinv1[0] = sc_ptr + 0x0A0;
+				//fqinv2[0] = sc_ptr + 0x0C0;
 				fx0   [0] = sc_ptr + 0x0E0;
 				fx1   [0] = sc_ptr + 0x100;
 				fx2   [0] = sc_ptr + 0x120;
 				for(j = 1, itmp = sc_ptr+1; j < 32; j++, itmp++) {
 					fq0   [j] = itmp + 0x000;
-					fq1   [j] = itmp + 0x020;
-					fq2   [j] = itmp + 0x040;
-					fqhi52[j] = itmp + 0x060;
+					//fq1   [j] = itmp + 0x020;
+					//fq2   [j] = itmp + 0x040;
+					//fqhi52[j] = itmp + 0x060;
 					fqinv0[j] = itmp + 0x080;
-					fqinv1[j] = itmp + 0x0A0;
-					fqinv2[j] = itmp + 0x0C0;
+					//fqinv1[j] = itmp + 0x0A0;
+					//fqinv2[j] = itmp + 0x0C0;
 					fx0   [j] = itmp + 0x0E0;
 					fx1   [j] = itmp + 0x100;
 					fx2   [j] = itmp + 0x120;
@@ -5550,23 +5582,23 @@ if(~pshift != p+78) {
 			  #else
 				/* Remember, these are POINTERS-TO-DOUBLE, so need an increment of 8 to span an AVX-512 register: */
 				fq0   [0] = sc_ptr + 0x000;
-				fq1   [0] = sc_ptr + 0x020;
-				fq2   [0] = sc_ptr + 0x040;
-				fqhi52[0] = sc_ptr + 0x060;
+				//fq1   [0] = sc_ptr + 0x020;
+				//fq2   [0] = sc_ptr + 0x040;
+				//fqhi52[0] = sc_ptr + 0x060;
 				fqinv0[0] = sc_ptr + 0x080;
-				fqinv1[0] = sc_ptr + 0x0A0;
-				fqinv2[0] = sc_ptr + 0x0C0;
+				//fqinv1[0] = sc_ptr + 0x0A0;
+				//fqinv2[0] = sc_ptr + 0x0C0;
 				fx0   [0] = sc_ptr + 0x0E0;
 				fx1   [0] = sc_ptr + 0x100;
 				fx2   [0] = sc_ptr + 0x120;
 				for(j = 1, dptr = sc_ptr+1; j < 32; j++, dptr++) {
 					fq0   [j] = dptr + 0x000;
-					fq1   [j] = dptr + 0x020;
-					fq2   [j] = dptr + 0x040;
-					fqhi52[j] = dptr + 0x060;
+					//fq1   [j] = dptr + 0x020;
+					//fq2   [j] = dptr + 0x040;
+					//fqhi52[j] = dptr + 0x060;
 					fqinv0[j] = dptr + 0x080;
-					fqinv1[j] = dptr + 0x0A0;
-					fqinv2[j] = dptr + 0x0C0;
+					//fqinv1[j] = dptr + 0x0A0;
+					//fqinv2[j] = dptr + 0x0C0;
 					fx0   [j] = dptr + 0x0E0;
 					fx1   [j] = dptr + 0x100;
 					fx2   [j] = dptr + 0x120;
@@ -5600,23 +5632,23 @@ if(~pshift != p+78) {
 
 			/* Remember, these are POINTERS-TO-UINT64, so need an increment of 8 to span an AVX-512 register: */
 			fq0   [0] = sc_ptr + 0x000;
-			fq1   [0] = sc_ptr + 0x020;
-			fq2   [0] = sc_ptr + 0x040;
-			fqhi52[0] = sc_ptr + 0x060;
+			//fq1   [0] = sc_ptr + 0x020;
+			//fq2   [0] = sc_ptr + 0x040;
+			//fqhi52[0] = sc_ptr + 0x060;
 			fqinv0[0] = sc_ptr + 0x080;
-			fqinv1[0] = sc_ptr + 0x0A0;
-			fqinv2[0] = sc_ptr + 0x0C0;
+			//fqinv1[0] = sc_ptr + 0x0A0;
+			//fqinv2[0] = sc_ptr + 0x0C0;
 			fx0   [0] = sc_ptr + 0x0E0;
 			fx1   [0] = sc_ptr + 0x100;
 			fx2   [0] = sc_ptr + 0x120;
 			for(j = 1, itmp = sc_ptr+1; j < 32; j++, itmp++) {
 				fq0   [j] = itmp + 0x000;
-				fq1   [j] = itmp + 0x020;
-				fq2   [j] = itmp + 0x040;
-				fqhi52[j] = itmp + 0x060;
+				//fq1   [j] = itmp + 0x020;
+				//fq2   [j] = itmp + 0x040;
+				//fqhi52[j] = itmp + 0x060;
 				fqinv0[j] = itmp + 0x080;
-				fqinv1[j] = itmp + 0x0A0;
-				fqinv2[j] = itmp + 0x0C0;
+				//fqinv1[j] = itmp + 0x0A0;
+				//fqinv2[j] = itmp + 0x0C0;
 				fx0   [j] = itmp + 0x0E0;
 				fx1   [j] = itmp + 0x100;
 				fx2   [j] = itmp + 0x120;
@@ -5630,23 +5662,23 @@ if(~pshift != p+78) {
 
 			/* Remember, these are POINTERS-TO-DOUBLE, so need an increment of 8 to span an AVX-512 register: */
 			fq0   [0] = sc_ptr + 0x000;
-			fq1   [0] = sc_ptr + 0x020;
-			fq2   [0] = sc_ptr + 0x040;
-			fqhi52[0] = sc_ptr + 0x060;
+			//fq1   [0] = sc_ptr + 0x020;
+			//fq2   [0] = sc_ptr + 0x040;
+			//fqhi52[0] = sc_ptr + 0x060;
 			fqinv0[0] = sc_ptr + 0x080;
-			fqinv1[0] = sc_ptr + 0x0A0;
-			fqinv2[0] = sc_ptr + 0x0C0;
+			//fqinv1[0] = sc_ptr + 0x0A0;
+			//fqinv2[0] = sc_ptr + 0x0C0;
 			fx0   [0] = sc_ptr + 0x0E0;
 			fx1   [0] = sc_ptr + 0x100;
 			fx2   [0] = sc_ptr + 0x120;
 			for(j = 1, dptr = sc_ptr+1; j < 32; j++, dptr++) {
 				fq0   [j] = dptr + 0x000;
-				fq1   [j] = dptr + 0x020;
-				fq2   [j] = dptr + 0x040;
-				fqhi52[j] = dptr + 0x060;
+				//fq1   [j] = dptr + 0x020;
+				//fq2   [j] = dptr + 0x040;
+				//fqhi52[j] = dptr + 0x060;
 				fqinv0[j] = dptr + 0x080;
-				fqinv1[j] = dptr + 0x0A0;
-				fqinv2[j] = dptr + 0x0C0;
+				//fqinv1[j] = dptr + 0x0A0;
+				//fqinv2[j] = dptr + 0x0C0;
 				fx0   [j] = dptr + 0x0E0;
 				fx1   [j] = dptr + 0x100;
 				fx2   [j] = dptr + 0x120;
@@ -5880,7 +5912,7 @@ if(~pshift != p+78) {
 				"kmovw	%%esi,%%k1					\n\t	kmovw	%%esi,%%k2					\n\t	kmovw	%%esi,%%k3					\n\t	kmovw	%%esi,%%k4					\n\t"/* Init opmask k1 (Only need the low byte) */\
 		"vpgatherqq (%%rbx,%%zmm4),%%zmm5%{%%k1%}	\n\tvpgatherqq (%%rbx,%%zmm11),%%zmm12%{%%k2%}\n\tvpgatherqq (%%rbx,%%zmm18),%%zmm19%{%%k3%}\n\tvpgatherqq (%%rbx,%%zmm25),%%zmm26%{%%k4%}\n\t"/* minv8 is a byte-table ... instruction sets mask-reg = 0, so each col uses separate same-valued k-reg */\
 				"vpandq	%%zmm3,%%zmm5,%%zmm3		\n\t	vpandq	%%zmm10,%%zmm12,%%zmm10		\n\t	vpandq	%%zmm17,%%zmm19,%%zmm17		\n\t	vpandq	%%zmm24,%%zmm26,%%zmm24		\n\t"/* Iterative qinv-computation doesn't care about the garbage upper 7 bytes of each qword
-			/* Newton iteration as described in comment above this asm: q0-2 in zmm0-2, qinv0-2 in zmm3-5; currently only have low byte of qinv: */\
+			// Newton iteration as described in comment above this asm: q0-2 in zmm0-2, qinv0-2 in zmm3-5; currently only have low byte of qinv: */\
 				"movq	$2,%%rcx					\n\t"\
 				"vpbroadcastq	%%rcx,%%zmm30		\n\t"/* vector-int64 2 */\
 			/* 1. q-data are 32-bit (of which we need the low 16, but just use q32 and VPMULLD), qinv are 8-bit: */\
@@ -6129,10 +6161,12 @@ if(~pshift != p+78) {
 		{
 			const char func[] = "twopmodq78_3WORD_DOUBLE_q64";
 			 int32 j = 0;	/* This needs to be signed because of the LR binary exponentiation. */
-			uint64 lead7, r = 0, tmp64;
+			uint64 lead7, r = 0;
+		#ifdef USE_AVX512_I
+			uint64 tmp64;
+		#endif
 			static uint64 psave = 0, pshift;
 			static uint32 start_index, zshift, first_entry = TRUE;
-			uint32 FERMAT = isPow2_64(p)<<1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
 			const uint8* minv8_ptr = minv8;	// Ptr to Table of precomputed byte-inverses def'd in mi64.h
 			static int max_threads = 1;	// Default local-array-init is for just a single thread ... caller can re-init for > 1 threads later, if desired.
 		#ifdef USE_AVX512_I
@@ -6146,7 +6180,7 @@ if(~pshift != p+78) {
 		  #else
 			static	// Following set of pointers only static-izable in single-thread mode
 		  #endif
-			uint64 *fq0[64],*fq1[64],*fq2[64],*fqhi52[64], *fqinv0[64],*fqinv1[64],*fqinv2[64], *fx0[64],*fx1[64],*fx2[64],
+			uint64 *fq0[64],/* *fq1[64],*fq2[64],*fqhi52[64] */, *fqinv0[64],/* *fqinv1[64],*fqinv2[64], */ *fx0[64],*fx1[64],*fx2[64],
 					*mask_lo26,*mask_lo52;
 			for(j = 0; j < 64; j++) {
 				ASSERT((k[j] >> 52) == 0ull, "Ks must be < 2^52!");
@@ -6160,7 +6194,7 @@ if(~pshift != p+78) {
 		  #else
 			static	// Following set of pointers only static-izable in single-thread mode
 		  #endif
-			double *fq0[64],*fq1[64],*fq2[64],*fqhi52[64], *fqinv0[64],*fqinv1[64],*fqinv2[64], *fx0[64],*fx1[64],*fx2[64],
+			double *fq0[64],/* *fq1[64],*fq2[64],*fqhi52[64], */ *fqinv0[64],/* *fqinv1[64],*fqinv2[64], */ *fx0[64],*fx1[64],*fx2[64],
 					*two13i, *two26f,*two26i, *two52f,*two52i,
 					kdbl[64];
 			// AVX-512 Foundation lacks the needed DQ extensions, so use HLL to convert kvec entries to double:
@@ -6235,23 +6269,23 @@ if(~pshift != p+78) {
 			  #else
 				/* Remember, these are POINTERS-TO-UINT64, so need an increment of 8 to span an AVX-512 register: */
 				fq0   [0] = sc_ptr + 0x000;
-				fq1   [0] = sc_ptr + 0x040;
-				fq2   [0] = sc_ptr + 0x080;
-				fqhi52[0] = sc_ptr + 0x0C0;
+				//fq1   [0] = sc_ptr + 0x040;
+				//fq2   [0] = sc_ptr + 0x080;
+				//fqhi52[0] = sc_ptr + 0x0C0;
 				fqinv0[0] = sc_ptr + 0x100;
-				fqinv1[0] = sc_ptr + 0x140;
-				fqinv2[0] = sc_ptr + 0x180;
+				//fqinv1[0] = sc_ptr + 0x140;
+				//fqinv2[0] = sc_ptr + 0x180;
 				fx0   [0] = sc_ptr + 0x1C0;
 				fx1   [0] = sc_ptr + 0x200;
 				fx2   [0] = sc_ptr + 0x240;
 				for(j = 1, itmp = sc_ptr+1; j < 64; j++, itmp++) {
 					fq0   [j] = itmp + 0x000;
-					fq1   [j] = itmp + 0x040;
-					fq2   [j] = itmp + 0x080;
-					fqhi52[j] = itmp + 0x0C0;
+					//fq1   [j] = itmp + 0x040;
+					//fq2   [j] = itmp + 0x080;
+					//fqhi52[j] = itmp + 0x0C0;
 					fqinv0[j] = itmp + 0x100;
-					fqinv1[j] = itmp + 0x140;
-					fqinv2[j] = itmp + 0x180;
+					//fqinv1[j] = itmp + 0x140;
+					//fqinv2[j] = itmp + 0x180;
 					fx0   [j] = itmp + 0x1C0;
 					fx1   [j] = itmp + 0x200;
 					fx2   [j] = itmp + 0x240;
@@ -6297,23 +6331,23 @@ if(~pshift != p+78) {
 			  #else
 				/* Remember, these are POINTERS-TO-DOUBLE, so need an increment of 8 to span an AVX-512 register: */
 				fq0   [0] = sc_ptr + 0x000;
-				fq1   [0] = sc_ptr + 0x040;
-				fq2   [0] = sc_ptr + 0x080;
-				fqhi52[0] = sc_ptr + 0x0C0;
+				//fq1   [0] = sc_ptr + 0x040;
+				//fq2   [0] = sc_ptr + 0x080;
+				//fqhi52[0] = sc_ptr + 0x0C0;
 				fqinv0[0] = sc_ptr + 0x100;
-				fqinv1[0] = sc_ptr + 0x140;
-				fqinv2[0] = sc_ptr + 0x180;
+				//fqinv1[0] = sc_ptr + 0x140;
+				//fqinv2[0] = sc_ptr + 0x180;
 				fx0   [0] = sc_ptr + 0x1C0;
 				fx1   [0] = sc_ptr + 0x200;
 				fx2   [0] = sc_ptr + 0x240;
 				for(j = 1, dptr = sc_ptr+1; j < 64; j++, dptr++) {
 					fq0   [j] = dptr + 0x000;
-					fq1   [j] = dptr + 0x040;
-					fq2   [j] = dptr + 0x080;
-					fqhi52[j] = dptr + 0x0C0;
+					//fq1   [j] = dptr + 0x040;
+					//fq2   [j] = dptr + 0x080;
+					//fqhi52[j] = dptr + 0x0C0;
 					fqinv0[j] = dptr + 0x100;
-					fqinv1[j] = dptr + 0x140;
-					fqinv2[j] = dptr + 0x180;
+					//fqinv1[j] = dptr + 0x140;
+					//fqinv2[j] = dptr + 0x180;
 					fx0   [j] = dptr + 0x1C0;
 					fx1   [j] = dptr + 0x200;
 					fx2   [j] = dptr + 0x240;
@@ -6347,23 +6381,23 @@ if(~pshift != p+78) {
 
 			/* Remember, these are POINTERS-TO-UINT64, so need an increment of 8 to span an AVX-512 register: */
 			fq0   [0] = sc_ptr + 0x000;
-			fq1   [0] = sc_ptr + 0x040;
-			fq2   [0] = sc_ptr + 0x080;
-			fqhi52[0] = sc_ptr + 0x0C0;
+			//fq1   [0] = sc_ptr + 0x040;
+			//fq2   [0] = sc_ptr + 0x080;
+			//fqhi52[0] = sc_ptr + 0x0C0;
 			fqinv0[0] = sc_ptr + 0x100;
-			fqinv1[0] = sc_ptr + 0x140;
-			fqinv2[0] = sc_ptr + 0x180;
+			//fqinv1[0] = sc_ptr + 0x140;
+			//fqinv2[0] = sc_ptr + 0x180;
 			fx0   [0] = sc_ptr + 0x1C0;
 			fx1   [0] = sc_ptr + 0x200;
 			fx2   [0] = sc_ptr + 0x240;
 			for(j = 1, itmp = sc_ptr+1; j < 64; j++, itmp++) {
 				fq0   [j] = itmp + 0x000;
-				fq1   [j] = itmp + 0x040;
-				fq2   [j] = itmp + 0x080;
-				fqhi52[j] = itmp + 0x0C0;
+				//fq1   [j] = itmp + 0x040;
+				//fq2   [j] = itmp + 0x080;
+				//fqhi52[j] = itmp + 0x0C0;
 				fqinv0[j] = itmp + 0x100;
-				fqinv1[j] = itmp + 0x140;
-				fqinv2[j] = itmp + 0x180;
+				//fqinv1[j] = itmp + 0x140;
+				//fqinv2[j] = itmp + 0x180;
 				fx0   [j] = itmp + 0x1C0;
 				fx1   [j] = itmp + 0x200;
 				fx2   [j] = itmp + 0x240;
@@ -6377,23 +6411,23 @@ if(~pshift != p+78) {
 
 			/* Remember, these are POINTERS-TO-DOUBLE, so need an increment of 8 to span an AVX-512 register: */
 			fq0   [0] = sc_ptr + 0x000;
-			fq1   [0] = sc_ptr + 0x040;
-			fq2   [0] = sc_ptr + 0x080;
-			fqhi52[0] = sc_ptr + 0x0C0;
+			//fq1   [0] = sc_ptr + 0x040;
+			//fq2   [0] = sc_ptr + 0x080;
+			//fqhi52[0] = sc_ptr + 0x0C0;
 			fqinv0[0] = sc_ptr + 0x100;
-			fqinv1[0] = sc_ptr + 0x140;
-			fqinv2[0] = sc_ptr + 0x180;
+			//fqinv1[0] = sc_ptr + 0x140;
+			//fqinv2[0] = sc_ptr + 0x180;
 			fx0   [0] = sc_ptr + 0x1C0;
 			fx1   [0] = sc_ptr + 0x200;
 			fx2   [0] = sc_ptr + 0x240;
 			for(j = 1, dptr = sc_ptr+1; j < 64; j++, dptr++) {
 				fq0   [j] = dptr + 0x000;
-				fq1   [j] = dptr + 0x040;
-				fq2   [j] = dptr + 0x080;
-				fqhi52[j] = dptr + 0x0C0;
+				//fq1   [j] = dptr + 0x040;
+				//fq2   [j] = dptr + 0x080;
+				//fqhi52[j] = dptr + 0x0C0;
 				fqinv0[j] = dptr + 0x100;
-				fqinv1[j] = dptr + 0x140;
-				fqinv2[j] = dptr + 0x180;
+				//fqinv1[j] = dptr + 0x140;
+				//fqinv2[j] = dptr + 0x180;
 				fx0   [j] = dptr + 0x1C0;
 				fx1   [j] = dptr + 0x200;
 				fx2   [j] = dptr + 0x240;
@@ -6529,7 +6563,7 @@ if(~pshift != p+78) {
 				"kmovw	%%esi,%%k1					\n\t	kmovw	%%esi,%%k2					\n\t	kmovw	%%esi,%%k3					\n\t	kmovw	%%esi,%%k4					\n\t"/* Init opmask k1 (Only need the low byte) */\
 		"vpgatherqq (%%rbx,%%zmm4),%%zmm5%{%%k1%}	\n\tvpgatherqq (%%rbx,%%zmm11),%%zmm12%{%%k2%}\n\tvpgatherqq (%%rbx,%%zmm18),%%zmm19%{%%k3%}\n\tvpgatherqq (%%rbx,%%zmm25),%%zmm26%{%%k4%}\n\t"/* minv8 is a byte-table ... instruction sets mask-reg = 0, so each col uses separate same-valued k-reg */\
 				"vpandq	%%zmm3,%%zmm5,%%zmm3		\n\t	vpandq	%%zmm10,%%zmm12,%%zmm10		\n\t	vpandq	%%zmm17,%%zmm19,%%zmm17		\n\t	vpandq	%%zmm24,%%zmm26,%%zmm24		\n\t"/* Iterative qinv-computation doesn't care about the garbage upper 7 bytes of each qword
-			/* Newton iteration as described in comment above this asm: q0-2 in zmm0-2, qinv0-2 in zmm3-5; currently only have low byte of qinv: */\
+			// Newton iteration as described in comment above this asm: q0-2 in zmm0-2, qinv0-2 in zmm3-5; currently only have low byte of qinv: */\
 				"movq	$2,%%rcx					\n\t"\
 				"vpbroadcastq	%%rcx,%%zmm30		\n\t"/* vector-int64 2 */\
 			/* 1. q-data are 32-bit (of which we need the low 16, but just use q32 and VPMULLD), qinv are 8-bit: */\
@@ -6664,7 +6698,7 @@ if(~pshift != p+78) {
 				"kmovw	%%esi,%%k1					\n\t	kmovw	%%esi,%%k2					\n\t	kmovw	%%esi,%%k3					\n\t	kmovw	%%esi,%%k4					\n\t"/* Init opmask k1 (Only need the low byte) */\
 		"vpgatherqq (%%rbx,%%zmm4),%%zmm5%{%%k1%}	\n\tvpgatherqq (%%rbx,%%zmm11),%%zmm12%{%%k2%}\n\tvpgatherqq (%%rbx,%%zmm18),%%zmm19%{%%k3%}\n\tvpgatherqq (%%rbx,%%zmm25),%%zmm26%{%%k4%}\n\t"/* minv8 is a byte-table ... instruction sets mask-reg = 0, so each col uses separate same-valued k-reg */\
 				"vpandq	%%zmm3,%%zmm5,%%zmm3		\n\t	vpandq	%%zmm10,%%zmm12,%%zmm10		\n\t	vpandq	%%zmm17,%%zmm19,%%zmm17		\n\t	vpandq	%%zmm24,%%zmm26,%%zmm24		\n\t"/* Iterative qinv-computation doesn't care about the garbage upper 7 bytes of each qword
-			/* Newton iteration as described in comment above this asm: q0-2 in zmm0-2, qinv0-2 in zmm3-5; currently only have low byte of qinv: */\
+			// Newton iteration as described in comment above this asm: q0-2 in zmm0-2, qinv0-2 in zmm3-5; currently only have low byte of qinv: */\
 				"movq	$2,%%rcx					\n\t"\
 				"vpbroadcastq	%%rcx,%%zmm30		\n\t"/* vector-int64 2 */\
 			/* 1. q-data are 32-bit (of which we need the low 16, but just use q32 and VPMULLD), qinv are 8-bit: */\

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -5414,7 +5414,7 @@ if(~pshift != p+78) {
 			 int32 j = 0;	/* This needs to be signed because of the LR binary exponentiation. */
 			uint64 lead7, r = 0;
 		#ifdef USE_AVX512_I
-			uin64 tmp64;
+			uint64 tmp64;
 		#endif
 			static uint64 psave = 0, pshift;
 			static uint32 start_index, zshift, first_entry = TRUE;

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -738,7 +738,6 @@ z0 = 6272576; z12 = 898312175313603; z=z0+a*z12	<*** z0 is +1 too large ***
 uint64 twopmodq78_3WORD_DOUBLE(uint64 p, uint64 k)
 {
 #if FAC_DEBUG
-	const char func[] = "twopmodq78_3WORD_DOUBLE";
 	int dbg = 0;//(p==2147483647 && k==20269004);
 #endif
 	 int32 j;	/* This needs to be signed because of the LR binary exponentiation. */
@@ -757,7 +756,7 @@ uint64 twopmodq78_3WORD_DOUBLE(uint64 p, uint64 k)
 
 #if FAC_DEBUG
 	if(dbg) {
-		printf("%s with p = %" PRIu64 ", k = %" PRIu64 "\n",func,p,k);
+		printf("%s with p = %" PRIu64 ", k = %" PRIu64 "\n",__func__,p,k);
 	}
 #endif
 	ASSERT((p >> 63) == 0, "twopmodq78_q2 : p must be < 2^63!");
@@ -1128,7 +1127,7 @@ if(~pshift != p+78) {
 
 	#if FAC_DEBUG
 		if(dbg) {
-			printf("%s with p = %" PRIu64 ", k0 = %" PRIu64 ", k1 = %" PRIu64 "\n",__FUNCTION__,p,k0,k1);
+			printf("%s with p = %" PRIu64 ", k0 = %" PRIu64 ", k1 = %" PRIu64 "\n",__func__,p,k0,k1);
 		}
 	#endif
 
@@ -1183,7 +1182,7 @@ if(~pshift != p+78) {
 			#else
 				max_threads = init_sse2;
 			#endif
-				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",__FUNCTION__,max_threads);
+				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",__func__,max_threads);
 			#ifndef COMPILER_TYPE_GCC
 				ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 			#endif
@@ -2023,7 +2022,7 @@ if(~pshift != p+78) {
 			#else
 				max_threads = init_sse2;
 			#endif
-				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",__FUNCTION__,max_threads);
+				fprintf(stderr, "%s: Setting up for as many as %d threads...\n",__func__,max_threads);
 			#ifndef COMPILER_TYPE_GCC
 				ASSERT(NTHREADS == 1, "Multithreading currently only supported for GCC builds!");
 			#endif

--- a/src/twopmodq80.h
+++ b/src/twopmodq80.h
@@ -303,7 +303,7 @@ extern "C" {
 		"vfnmadd231pd	%%zmm3,%%zmm1,%%zmm0	\n\t vfnmadd231pd	%%zmm3,%%zmm5,%%zmm4	\n\t vfnmadd231pd	%%zmm3,%%zmm9 ,%%zmm8		\n\t vfnmadd231pd	%%zmm3,%%zmm13,%%zmm12		\n\t"/* lo0 = fma(fcy ,-TWO26FLOAT,flo); overwrites flo */\
 			"vmovaps	%%zmm0,    (%%rax)		\n\t	vmovaps	%%zmm4,0x40(%%rax)			\n\t	vmovaps	%%zmm8,0x80(%%rax)				\n\t	vmovaps	%%zmm12,0xc0(%%rax)				\n\t"/* Store lo0 */\
 		/* Digit 1: */\
-		/*	"vmovaps	%%zmm1,0x100(%%rax)		\n\t	vmovaps	%%zmm5,0x140(%%rax)			\n\t	vmovaps	%%zmm9 ,0x180(%%rax)			\n\t	vmovaps	%%zmm13,0x1c0(%%rax)			\n\t"/* Store lo1 = fcy */\
+		/*	"vmovaps	%%zmm1,0x100(%%rax)		\n\t	vmovaps	%%zmm5,0x140(%%rax)			\n\t	vmovaps	%%zmm9 ,0x180(%%rax)			\n\t	vmovaps	%%zmm13,0x1c0(%%rax)			\n\t"// Store lo1 = fcy */ \
 		/* Digit 2: */\
 			"vmulpd		 (%%rbx),%%zmm2,%%zmm0	\n\t	vmulpd		 (%%rbx),%%zmm6,%%zmm4	\n\t	vmulpd		 (%%rbx),%%zmm10,%%zmm8 	\n\t	vmulpd		 (%%rbx),%%zmm14,%%zmm12	\n\t"/* fcy =       flo2*TWO26FLINV  */\
 			"vrndscalepd $1,%%zmm0,%%zmm0		\n\t	vrndscalepd $1,%%zmm4,%%zmm4		\n\t	vrndscalepd $1,%%zmm8 ,%%zmm8 			\n\t	vrndscalepd $1,%%zmm12,%%zmm12			\n\t"/* fcy = floor(flo2*TWO26FLINV) */\
@@ -658,7 +658,7 @@ extern "C" {
 		"vfnmadd231pd	%%ymm3,%%ymm1,%%ymm0	\n\t vfnmadd231pd	%%ymm3,%%ymm5,%%ymm4	\n\t vfnmadd231pd	%%ymm3,%%ymm9 ,%%ymm8		\n\t vfnmadd231pd	%%ymm3,%%ymm13,%%ymm12		\n\t"/* lo0 = fma(fcy ,-TWO26FLOAT,flo); overwrites flo */\
 			"vmovaps	%%ymm0,    (%%rax)		\n\t	vmovaps	%%ymm4,0x20(%%rax)			\n\t	vmovaps	%%ymm8,0x40(%%rax)				\n\t	vmovaps	%%ymm12,0x60(%%rax)				\n\t"/* Store lo0 */\
 		/* Digit 1: */\
-		/*	"vmovaps	%%ymm1,0x80(%%rax)		\n\t	vmovaps	%%ymm5,0xa0(%%rax)			\n\t	vmovaps	%%ymm9 ,0xc0(%%rax)				\n\t	vmovaps	%%ymm13,0xe0(%%rax)				\n\t"/* Store lo1 = fcy */\
+		/*	"vmovaps	%%ymm1,0x80(%%rax)		\n\t	vmovaps	%%ymm5,0xa0(%%rax)			\n\t	vmovaps	%%ymm9 ,0xc0(%%rax)				\n\t	vmovaps	%%ymm13,0xe0(%%rax)				\n\t"// Store lo1 = fcy */\
 		/* Digit 2: */\
 			"vmulpd		 (%%rbx),%%ymm2,%%ymm0	\n\t	vmulpd		 (%%rbx),%%ymm6,%%ymm4	\n\t	vmulpd		 (%%rbx),%%ymm10,%%ymm8 	\n\t	vmulpd		 (%%rbx),%%ymm14,%%ymm12	\n\t"/* fcy =       flo2*TWO26FLINV  */\
 			"vroundpd $1,%%ymm0,%%ymm0			\n\t	vroundpd $1,%%ymm4,%%ymm4			\n\t	vroundpd $1,%%ymm8 ,%%ymm8 			\n\t	vroundpd $1,%%ymm12,%%ymm12				\n\t"/* fcy = floor(flo2*TWO26FLINV) */\

--- a/src/twopmodq96.c
+++ b/src/twopmodq96.c
@@ -194,7 +194,7 @@ uint96 twopmodq96(uint64 p, uint64 k)
 	uint128 y;
 #endif
 	 int32 j;	/* This needs to be signed because of the LR binary exponentiation. */
-	uint64 pshift, hi64, tmp;
+	uint64 pshift, hi64;
 	uint96 q, qhalf, qinv, x, lo, hi;
 	uint32 jshift, leadb, start_index, zshift;
 	uint32 FERMAT = isPow2_64(p)<<1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
@@ -445,7 +445,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			,*qhalf0,*qhalf1,*qhalf2,*qhalf3
 			,*x0,*x1,*x2,*x3
 			,*lo0,*lo1,*lo2,*lo3
-			,*hi0,*hi1,*hi2,*hi3
+			//,*hi0,*hi1,*hi2,*hi3
 			,*ONE96_PTR;
 	#else
 		static uint96
@@ -454,7 +454,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			,*qhalf0,*qhalf1,*qhalf2,*qhalf3
 			,*x0,*x1,*x2,*x3
 			,*lo0,*lo1,*lo2,*lo3
-			,*hi0,*hi1,*hi2,*hi3
+			//,*hi0,*hi1,*hi2,*hi3
 			,*ONE96_PTR;
 	#endif
 		 int32 j;
@@ -506,7 +506,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			x0     = (uint96*)(sm_ptr + 0x10);	x1     = (uint96*)(sm_ptr + 0x12);	x2     = (uint96*)(sm_ptr + 0x14);	x3     = (uint96*)(sm_ptr + 0x16);
 			lo0    = (uint96*)(sm_ptr + 0x18);	lo1    = (uint96*)(sm_ptr + 0x1a);	lo2    = (uint96*)(sm_ptr + 0x1c);	lo3    = (uint96*)(sm_ptr + 0x1e);
 			qhalf0 = (uint96*)(sm_ptr + 0x20);	qhalf1 = (uint96*)(sm_ptr + 0x22);	qhalf2 = (uint96*)(sm_ptr + 0x24);	qhalf3 = (uint96*)(sm_ptr + 0x26);
-			hi0    = (uint96*)(sm_ptr + 0x28);	hi1    = (uint96*)(sm_ptr + 0x2a);	hi2    = (uint96*)(sm_ptr + 0x2c);	hi3    = (uint96*)(sm_ptr + 0x2e);
+			//hi0    = (uint96*)(sm_ptr + 0x28);	hi1    = (uint96*)(sm_ptr + 0x2a);	hi2    = (uint96*)(sm_ptr + 0x2c);	hi3    = (uint96*)(sm_ptr + 0x2e);
 			ONE96_PTR = (uint96*)(sm_ptr + 0x30);
 			ptr64 = (uint64*)ONE96_PTR;	*ptr64++ = ONE96.d0;	*ptr64-- = ONE96.d1;
 		#endif
@@ -522,7 +522,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 		x0     = (uint96*)(ptr64 + 0x10);	x1     = (uint96*)(ptr64 + 0x12);	x2     = (uint96*)(ptr64 + 0x14);	x3     = (uint96*)(ptr64 + 0x16);
 		lo0    = (uint96*)(ptr64 + 0x18);	lo1    = (uint96*)(ptr64 + 0x1a);	lo2    = (uint96*)(ptr64 + 0x1c);	lo3    = (uint96*)(ptr64 + 0x1e);
 		qhalf0 = (uint96*)(ptr64 + 0x20);	qhalf1 = (uint96*)(ptr64 + 0x22);	qhalf2 = (uint96*)(ptr64 + 0x24);	qhalf3 = (uint96*)(ptr64 + 0x26);
-		hi0    = (uint96*)(ptr64 + 0x28);	hi1    = (uint96*)(ptr64 + 0x2a);	hi2    = (uint96*)(ptr64 + 0x2c);	hi3    = (uint96*)(ptr64 + 0x2e);
+		//hi0    = (uint96*)(ptr64 + 0x28);	hi1    = (uint96*)(ptr64 + 0x2a);	hi2    = (uint96*)(ptr64 + 0x2c);	hi3    = (uint96*)(ptr64 + 0x2e);
 		ONE96_PTR = (uint96*)(ptr64 + 0x30);
 	//	printf("Thr %d ONE96_PTR address = %" PRIX64 "; data.d0,d1 = %" PRIu64 ",%u\n",thr_id,(uint64)ONE96_PTR,ONE96_PTR->d0,ONE96_PTR->d1);
 		ASSERT((ONE96_PTR->d0 == ONE96.d0) && (ONE96_PTR->d1 == ONE96.d1), "Bad data at ONE96_PTR address!");


### PR DESCRIPTION
Part of splitting @ldesnogu's warnings-cleanup PR #34 into smaller, independently-reviewable pieces.

Removes compiler warnings from the `twopmodq*` factoring modmul routines: `twopmodq.c`, `twopmodq80.c` (+ nested-comment cleanup in `twopmodq80.h`), `twopmodq96.c`, `twopmodq100.c` (5 commits).

- All @ldesnogu's, cherry-picked from #34 with original authorship preserved; no content changes — mechanical warning removal only.
- Verified: nosimd build clean, LL self-test Res64 `71E61322CCFB396C` unchanged.

Note: `twopmodq96.c` here and the gcc-11 pragma in #118, and `twopmodq80/100.c` vs the recent GCC-15 changes on main, touch disjoint regions — no conflict either way. Each file's strict-aliasing counterpart is in #124.