### PR TITLE
Remove warnings from FFT driver / DFT-macro files (from #34)

### DIFF
--- a/src/br.c
+++ b/src/br.c
@@ -31,7 +31,7 @@
 void print_pow2_twiddles(const uint32 n, const uint32 p, const uint32 q)
 {
 	const uint32 n2 = n>>1, n4 = n>>2, n8 = n>>3, lgn = trailz32(n),lgp = trailz32(p), lgq = trailz32(q);
-	uint32 pow2,odd, re_im_idx, sigma,signs;
+	uint32 pow2,odd, re_im_idx, signs;
 	int i,ir,j,k,pow;
 	const char csigns[2] = {'+','-'};
 	const char re_im[2] = {'c','s'};

--- a/src/dft_macro.c
+++ b/src/dft_macro.c
@@ -3075,7 +3075,7 @@ void RADIX_128_DIF(
 	double *__B, const int *__odx, const int __re_im_stride_out	/* Outputs: Base address plus 128 (index) offsets */
 )
 {
-	int i,j,nshift, *off_ptr;
+	int i,j;
 	struct complex t[128], *tptr;
 	const struct complex *cd_ptr;
 	double *Are = __A,*Aim = __A + __re_im_stride_in, *Bre = __B,*Bim = __B + __re_im_stride_out;
@@ -3120,7 +3120,7 @@ void RADIX_128_DIT(
 	double *__B, const int *__odx, const int __re_im_stride_out	/* Outputs: Base address plus 128 (index) offsets */
 )
 {
-	int i,j,nshift, *off_ptr;
+	int i,j;
 	struct complex t[128], *tptr;
 	const struct complex *cd_ptr;
 	double *Are = __A,*Aim = __A + __re_im_stride_in, *Bre = __B,*Bim = __B + __re_im_stride_out;
@@ -3509,6 +3509,8 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		ss3    = tmp + 0x5;			ds2    = tmp + 0xd;
 		cc4    = tmp + 0x6;			dc3    = tmp + 0xe;
 		ss4    = tmp + 0x7;			ds3    = tmp + 0xf;
+	#else
+		tdat = sc_ptr;
 	#endif
 
 		//...gather the needed data (63 64-bit complex, i.e. 126 64-bit reals) and do 9 radix-7 transforms:
@@ -3758,6 +3760,8 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		ss3    = tmp + 0x5;			ds2    = tmp + 0xd;
 		cc4    = tmp + 0x6;			dc3    = tmp + 0xe;
 		ss4    = tmp + 0x7;			ds3    = tmp + 0xf;
+	#else
+		tdat = sc_ptr;
 	#endif
 
 		//...gather the needed data (63 64-bit complex, i.e. 126 64-bit reals) and do 7 radix-9 transforms:
@@ -3851,9 +3855,7 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 			*nisrt2,*ncc1,*nss1,*ncc2,*nss2,*ncc3,*nss3,*ncc4,*nss4,*ncc5,*nss5,*ncc6,*nss6,*ncc7,*nss7;
 	  #endif
 		// Intermediates pointers:
-		vec_dbl *tmp, *v0,*v1,*v2,*v3,*v4,*v5,*v6,*v7,
-			// Each of these rhi-ptrs points to next 8 vec_cmplx= 16 vec_dbl data sets:
-			*r10 = r00+0x10,*r20 = r00+0x20,*r30 = r00+0x30,*r40 = r00+0x40,*r50 = r00+0x50,*r60 = r00+0x60,*r70 = r00+0x70;
+		vec_dbl *tmp, *v0,*v1,*v2,*v3,*v4,*v5,*v6,*v7;
 		/* Addresses into array sections */
 		double *add0, *add1, *add2, *add3, *add4, *add5, *add6, *add7;
 		// Index-offset names here reflect original unpermuted inputs, but the math also works for permuted ones:
@@ -4151,7 +4153,6 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 			add0,add1,add2,add3,add4,add5,add6,add7, isrt2
 		);
 	  #endif
-	// Remaining 7 macro cals need explicitly named BRed iptrs with stride 16, use tmp(in place of iarg r00),r40,r20,r60,r10,r50,r30,r70:
 	  #if COMPACT_OBJ
 
 		bptr = twid_offsets;	// Byte-pointer loops over slots in twid_offsets[] byte-array
@@ -4167,6 +4168,9 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		}
 
 	  #else	// COMPACT_OBJ = False:
+			// Each of these rhi-ptrs points to next 8 vec_cmplx= 16 vec_dbl data sets:
+		vec_dbl *r10 = r00+0x10,*r20 = r00+0x20,*r30 = r00+0x30,*r40 = r00+0x40,*r50 = r00+0x50,*r60 = r00+0x60,*r70 = r00+0x70;
+	// Remaining 7 macro calls need explicitly named BRed iptrs with stride 16, use tmp(in place of iarg r00),r40,r20,r60,r10,r50,r30,r70:
 		#error SSE2_RADIX8_DIF_TWIDDLE_OOP in this section need twiddles collected into w[]-array as above!
 	/* Block 4: */
 		tmp += 8;	// r08
@@ -4613,13 +4617,12 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 	{
 		// Intermediates pointers:
 		vec_dbl *tm0,*tm1,
-			*u0,*u1,*u2,*u3,*u4,*u5,*u6,*u7, *v0,*v1,*v2,*v3,*v4,*v5,*v6,*v7,
 			*w[14], **twid_ptrs = &(w[0]);	// Array of 14 SIMD twiddles-pointers for the reduced-#args version of SSE2_RADIX8_DIF_TWIDDLE_OOP
 		/* Addresses into array sections */
-		double *addr,*add0,*add1,*add2,*add3,*add4,*add5,*add6,*add7,*add8,*add9,*adda,*addb,*addc,*addd,*adde,*addf;
+		double *addr,*add0,*add1,*add2,*add3,*add4,*add5,*add6,*add7;
 		// Index-offset names here reflect original unpermuted inputs, but the math also works for permuted ones:
 		int i,j, *off_ptr;
-		int p0,p1,p2,p3,p4,p5,p6,p7,p8,p9,pa,pb,pc,pd,pe,pf;
+		int p0,p1,p2,p3,p4,p5,p6,p7;
 
 	// Gather the needed data and do 8 twiddleless length-16 subtransforms, with p-offsets in br8 order: 04261537:
 	// NOTE that unlike the RADIX_08_DIF_OOP() macro used for pass 1 of the radix-64 DFT, RADIX_16_DIF outputs are IN-ORDER rather than BR:
@@ -4753,16 +4756,13 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		vec_dbl *tm0,*tm1,*tm2,
 			*u0,*u1,*u2,*u3,*u4,*u5,*u6,*u7, *v0,*v1,*v2,*v3,*v4,*v5,*v6,*v7,
 			*w[14], **twid_ptrs = &(w[0]);	// Array of 14 SIMD twiddles-pointers for the reduced-#args version of SSE2_RADIX8_DIT_TWIDDLE_OOP
-		/* Addresses into array sections */
-		double *addr,*add0,*add1,*add2,*add3,*add4,*add5,*add6,*add7,*add8,*add9,*adda,*addb,*addc,*addd,*adde,*addf;
 		// Index-offset names here reflect original unpermuted inputs, but the math also works for permuted ones:
 		int i,j, *off_ptr;
-		int p0,p1,p2,p3,p4,p5,p6,p7,p8,p9,pa,pb,pc,pd,pe,pf;
 
 	/* Gather the needed data (128 64-bit complex, i.e. 256 64-bit reals) and do 8 twiddleless length-16 subtransforms: */
 
 	  #ifdef USE_ARM_V8_SIMD
-		uint32 OFF1,OFF2,OFF3,OFF4,OFF5,OFF6,OFF7;
+		uint32 OFF1,OFF2,OFF3,OFF4;
 		OFF1 = 0x20;
 		OFF2 = 0x40;
 		OFF3 = 0x60;
@@ -4884,10 +4884,15 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 		// Intermediates pointers:
 		vec_dbl *tm0,*tm1,*tm2;
 		/* Addresses into array sections */
-		double *addr,*add0,*add1,*add2,*add3,*add4,*add5,*add6,*add7,*add8,*add9,*adda,*addb,*addc,*addd,*adde,*addf;
+		double *addr;
+	  #ifdef USE_AVX2
+		double *add0,*add1,*add2,*add3,*add4,*add5,*add6,*add7,*add8,*add9,*adda,*addb,*addc,*addd,*adde,*addf;
+	  #endif
 		// Index-offset names here reflect original unpermuted inputs, but the math also works for permuted ones:
 		int i,j,nshift, *off_ptr;
+	  #ifdef USE_AVX2
 		int p0,p1,p2,p3,p4,p5,p6,p7,p8,p9,pa,pb,pc,pd,pe,pf;
+	  #endif
 		ASSERT(o_idx != 0x0, "Null o_idx pointer in SSE2_RADIX256_DIF!");
 	// NOTE that unlike the RADIX_08_DIF_OOP() macro used for pass 1 of the radix-64 DFT, RADIX_16_DIF outputs are IN-ORDER rather than BR:
 	  #ifdef USE_ARM_V8_SIMD
@@ -5005,15 +5010,12 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 	)
 	{
 		// Intermediates pointers:
-		vec_dbl *tm0,*tm1,*tm2,
-							*r10 = r00+0x20,*r20 = r00+0x40,*r30 = r00+0x60,*r40 = r00+0x80,*r50 = r00+0xa0,*r60 = r00+0xc0,*r70 = r00+0xe0,
-			*r80 =r00+0x100,*r90 = r80+0x20,*ra0 = r80+0x40,*rb0 = r80+0x60,*rc0 = r80+0x80,*rd0 = r80+0xa0,*re0 = r80+0xc0,*rf0 = r80+0xe0;
+		vec_dbl *tm0,*tm1,*tm2;
 		/* Addresses into array sections */
-		double *addr, *add0, *add1, *add2, *add3, *add4, *add5, *add6, *add7, *add8, *add9, *adda, *addb, *addc, *addd, *adde, *addf;
+		double *addr;
 		// Index-offset names here reflect original unpermuted inputs, but the math also works for permuted ones:
 		int i,j,nshift;
 		const int *off_ptr;
-		int p0,p1,p2,p3,p4,p5,p6,p7,p8,p9,pa,pb,pc,pd,pe,pf;
 
 	/* Gather the needed data (256 64-bit complex, i.e. 512 64-bit reals) and do 8 twiddleless length-16 subtransforms: */
 	  #ifdef USE_ARM_V8_SIMD

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -197,8 +197,9 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 #if DBG_THREADS
 	int num_chunks[MAX_THREADS];		/* Collect stats about how much work done by each thread */
 #endif
-	static int nradices_prim,nradices_radix0,radix_prim[30];/* RADIX_PRIM stores sequence of complex FFT radices used, in terms of their prime factors.	*/
-	static int *index = 0x0, *index_ptmp = 0x0;		/* Bit-reversal index array and array storing S*I mod N values for DWT weights.	*/
+	static int nradices_prim,radix_prim[30];/* RADIX_PRIM stores sequence of complex FFT radices used, in terms of their prime factors.	*/
+	static int *index = 0x0;		/* Bit-reversal index array and array storing S*I mod N values for DWT weights.	*/
+//	static int *index_ptmp = 0x0;
 
 	int bimodn,i,ii,ierr = 0,iter,j,j1,j2,k,l,m,mm,k1,k2;
 	static uint64 psave=0;
@@ -256,7 +257,7 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 	static struct ferm_thread_data_t *tdat = 0x0;
 
 	// Threadpool-based dispatch:
-	static int main_work_units = 0, pool_work_units = 0;
+	static int pool_work_units = 0;
 	static struct threadpool *tpool = 0x0;
 	static int task_is_blocking = TRUE;
 	static thread_control_t thread_control = {0,0,0};
@@ -410,84 +411,84 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		*/
 		case 5:
-			nradices_radix0 = 1;
+//			nradices_radix0 = 1;
 			radix_prim[l++] = 5; break;
 		case 6:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] = 3; radix_prim[l++] = 2; break;
 		case 7:
-			nradices_radix0 = 1;
+//			nradices_radix0 = 1;
 			radix_prim[l++] = 7; break;
 		case 8:
-			nradices_radix0 = 3;
+//			nradices_radix0 = 3;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 9:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] = 3; radix_prim[l++] = 3; break;
 		case 10:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] = 5; radix_prim[l++] = 2; break;
 		case 11:
-			nradices_radix0 = 1;
+//			nradices_radix0 = 1;
 			radix_prim[l++] = 11; break;
 		case 12:
-			nradices_radix0 = 3;
+//			nradices_radix0 = 3;
 			radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 13:
-			nradices_radix0 = 1;
+//			nradices_radix0 = 1;
 			radix_prim[l++] = 13; break;
 		case 14:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; break;
 		case 15:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] = 5; radix_prim[l++] = 3; break;
 		case 16:
-			nradices_radix0 = 4;
+//			nradices_radix0 = 4;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 18:
-			nradices_radix0 = 3;
+//			nradices_radix0 = 3;
 			radix_prim[l++] = 3; radix_prim[l++] = 3; radix_prim[l++] = 2; break;
 		case 20:
-			nradices_radix0 = 3;
+//			nradices_radix0 = 3;
 			radix_prim[l++] = 5; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 22:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] =11; radix_prim[l++] = 2; break;
 		case 24:
-			nradices_radix0 = 4;
+//			nradices_radix0 = 4;
 			radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		/*
 		case 25:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] = 5; radix_prim[l++] = 5; break;
 		*/
 		case 26:
-			nradices_radix0 = 2;
+//			nradices_radix0 = 2;
 			radix_prim[l++] =13; radix_prim[l++] = 2; break;
 		case 28:
-			nradices_radix0 = 3;
+//			nradices_radix0 = 3;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 30:
-			nradices_radix0 = 3;
+//			nradices_radix0 = 3;
 			radix_prim[l++] = 5; radix_prim[l++] = 3; radix_prim[l++] = 2; break;
 		case 32:
-			nradices_radix0 = 5;
+//			nradices_radix0 = 5;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 36:
-			nradices_radix0 = 4;
+//			nradices_radix0 = 4;
 			radix_prim[l++] = 3; radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 56:
-			nradices_radix0 = 4;
+//			nradices_radix0 = 4;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 60:
-			nradices_radix0 = 4;
+//			nradices_radix0 = 4;
 			radix_prim[l++] = 5; radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 63:
-			nradices_radix0 = 3;
+//			nradices_radix0 = 3;
 			radix_prim[l++] = 7; radix_prim[l++] = 3; radix_prim[l++] = 3; break;
 		case 64:
-			nradices_radix0 = 6;
+//			nradices_radix0 = 6;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		/*
 		case 72:
@@ -501,37 +502,37 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 			radix_prim[l++] = 5; radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		*/
 		case 128:
-			nradices_radix0 = 7;
+//			nradices_radix0 = 7;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 224:
-			nradices_radix0 = 6;
+//			nradices_radix0 = 6;
 			radix_prim[l++] = 7; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 240:
-			nradices_radix0 = 6;
+//			nradices_radix0 = 6;
 			radix_prim[l++] = 5; radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 256:
-			nradices_radix0 = 8;
+//			nradices_radix0 = 8;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 512:
-			nradices_radix0 = 9;
+//			nradices_radix0 = 9;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 960:
-			nradices_radix0 = 8;
+//			nradices_radix0 = 8;
 			radix_prim[l++] = 5; radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 992:
-			nradices_radix0 = 6;
+//			nradices_radix0 = 6;
 			radix_prim[l++] =31; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 1008:
-			nradices_radix0 = 7;
+//			nradices_radix0 = 7;
 			radix_prim[l++] = 7; radix_prim[l++] = 3; radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 1024:
-			nradices_radix0 = 10;
+//			nradices_radix0 = 10;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 4032:
-			nradices_radix0 = 9;
+//			nradices_radix0 = 9;
 			radix_prim[l++] = 7; radix_prim[l++] = 3; radix_prim[l++] = 3; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		case 4096:
-			nradices_radix0 = 12;
+//			nradices_radix0 = 12;
 			radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; radix_prim[l++] = 2; break;
 		default:
 			sprintf(cbuf  ,"ERROR: radix %d not available for Fermat-mod transform. Halting...\n",RADIX_VEC[i]);
@@ -1145,7 +1146,6 @@ int fermat_mod_square(double a[], int arr_scratch[], int n, int ilo, int ihi, ui
 
 		if(radix0 % NTHREADS != 0) fprintf(stderr,"%s: radix0 not exactly divisible by NTHREADS - This will hurt performance.\n",func);
 
-		main_work_units = 0;
 		pool_work_units = radix0;
 		ASSERT(0x0 != (tpool = threadpool_init(NTHREADS, MAX_THREADS, pool_work_units, &thread_control)), "threadpool_init failed!");
 		printf("%s: Init threadpool of %d threads\n",func,NTHREADS);
@@ -1345,8 +1345,7 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 	}
 
 //	printf("start; #tasks = %d, #free_tasks = %d\n", tpool->tasks_queue.num_tasks, tpool->free_tasks_queue.num_tasks);
-	int	ns_retval;
-	struct timespec ns_time,ns_err;	// We want a sleep interval of 0.1 mSec here...
+	struct timespec ns_time;	// We want a sleep interval of 0.1 mSec here...
 	ns_time.tv_sec  =      0;	// (time_t)seconds - Don't use this because under OS X it's of type __darwin_time_t, which is long rather than double as under most linux distros
 	ns_time.tv_nsec = 100000;	// (long)nanoseconds - Get our desired 0.1 mSec as 10^5 nSec here
 
@@ -1388,7 +1387,7 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 											// Thus, RES_FLIP would probably be a better name for this global.
 		MOD_ADD64(RES_SHIFT,RES_SHIFT,p,RES_SHIFT);
 		RES_SHIFT += ((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1);	// No mod needed on this add, since result of pvs line even and < p, which is itself even in the Fermat-mod case (p = 2^m)
-		const char flip[2] = {' ','*'};
+//		const char flip[2] = {' ','*'};
 //	printf("Iter %d: shift = [%c]%" PRIu64 "\n",iter,flip[RES_SIGN],RES_SHIFT);
 	#endif
 	}
@@ -1764,7 +1763,7 @@ void fermat_process_chunk(
 
 #endif	// #ifdef MULTITHREAD
 
-	const char func[] = "fermat_process_chunk";
+//	const char func[] = "fermat_process_chunk";
 	int radix0 = RADIX_VEC[0];
 	int i,incr,istart,jstart,k,koffset,l,mm;
 	int init_sse2 = FALSE;	// Init-calls to various radix-pass routines presumed done prior to entry into this routine

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1763,7 +1763,6 @@ void fermat_process_chunk(
 
 #endif	// #ifdef MULTITHREAD
 
-//	const char func[] = "fermat_process_chunk";
 	int radix0 = RADIX_VEC[0];
 	int i,incr,istart,jstart,k,koffset,l,mm;
 	int init_sse2 = FALSE;	// Init-calls to various radix-pass routines presumed done prior to entry into this routine

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -173,11 +173,6 @@ The scratch array (2nd input argument) is only needed for data table initializat
 	double adiff, max_adiff = 0.0;	/* Use to store the max abs error between real*8 and real*16 computed values */
 	 int64 i1,i2;
 	uint64 idiff, max_idiff = 0;
-	const double mult[2] = {1.0,-1.0};
-	static double nh_inv,nq_inv;	// Needed for "which complex quadrant?" computation
-	static int nh,nq;			// #rt1 elts in each quadrant
-	int qodd;
-	double *re_im_ptr;
 	static int radix_set_save[10] = {1000,0,0,0,0,0,0,0,0,0};
 	static int radix0, nchunks; 	// Store frequently-used RADIX_VEC[0] and number-of-independently-doable work units
 #if DBG_THREADS
@@ -236,7 +231,7 @@ The scratch array (2nd input argument) is only needed for data table initializat
 	static struct mers_thread_data_t *tdat = 0x0;
 
 	// Threadpool-based dispatch:
-	static int main_work_units = 0, pool_work_units = 0;
+	static int pool_work_units = 0;
 	static struct threadpool *tpool = 0x0;
 	static int task_is_blocking = TRUE;
 	static thread_control_t thread_control = {0,0,0};
@@ -1075,6 +1070,11 @@ for(i=0; i < NRT; i++) {
 }
 */
 #if 0
+	const double mult[2] = {1.0,-1.0};
+	static double nh_inv,nq_inv;	// Needed for "which complex quadrant?" computation
+	static int nh,nq;			// #rt1 elts in each quadrant
+	int qodd;
+	double *re_im_ptr;
 	#define SYMM	2	// "foldness" of the symmetry scheme used: 2 = half-plane, 4 = quadrans, 8 = half-quads.
 	#if SYMM == 2
 		nh = n/(NRT<<2);	// #rt1 elts in each quadrant
@@ -1350,7 +1350,6 @@ for(i=0; i < NRT; i++) {
 
 		if(nchunks % NTHREADS != 0) fprintf(stderr,"%s: radix0/2 not exactly divisible by NTHREADS - This will hurt performance.\n",func);
 
-		main_work_units = 0;
 		pool_work_units = nchunks;
 		ASSERT(0x0 != (tpool = threadpool_init(NTHREADS, MAX_THREADS, pool_work_units, &thread_control)), "threadpool_init failed!");
 		printf("%s: Init threadpool of %d threads\n",func,NTHREADS);
@@ -1789,8 +1788,7 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 	}
 
 //	printf("start; #tasks = %d, #free_tasks = %d\n", tpool->tasks_queue.num_tasks, tpool->free_tasks_queue.num_tasks);
-	int	ns_retval;
-	struct timespec ns_time,ns_err;	// We want a sleep interval of 0.1 mSec here...
+	struct timespec ns_time;	// We want a sleep interval of 0.1 mSec here...
 	ns_time.tv_sec  =      0;	// (time_t)seconds - Don't use this because under OS X it's of type __darwin_time_t, which is long rather than double as under most linux distros
 	ns_time.tv_nsec = 100000;	// (long)nanoseconds - Get our desired 0.1 mSec as 10^5 nSec here
 
@@ -2178,7 +2176,7 @@ void mers_process_chunk(
 
 #endif	// #ifdef MULTITHREAD
 
-	const char func[] = "mers_process_chunk";
+//	const char func[] = "mers_process_chunk";
 	int radix0 = RADIX_VEC[0];
 	int i,incr,istart,j,jhi,jstart,k,koffset,l,mm;
 	int init_sse2 = FALSE;	// Init-calls to various radix-pass routines presumed done prior to entry into this routine

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -2176,7 +2176,6 @@ void mers_process_chunk(
 
 #endif	// #ifdef MULTITHREAD
 
-//	const char func[] = "mers_process_chunk";
 	int radix0 = RADIX_VEC[0];
 	int i,incr,istart,j,jhi,jstart,k,koffset,l,mm;
 	int init_sse2 = FALSE;	// Init-calls to various radix-pass routines presumed done prior to entry into this routine

--- a/src/sse2_macro_gcc64.h
+++ b/src/sse2_macro_gcc64.h
@@ -3764,7 +3764,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"xorq	%%r8,%%r8	\n\t	leaq	%c[i1](%%r8),%%r8	\n\t"/* movq|movslq of literal %c[i1] both segfaulted, workaround via LEA */\
 		/* The twid_ptrs[] array holds ptrs to 14 complex twiddles in-order: (c,s)[1,2,3,4,5,6,7]: */\
 		"movq	%[twid_ptrs],%%r14	\n\t"\
-	/* Block 0/1 has just one twiddle-CMUL: 												/* Blocks 2/3 use separate register subset, can be done overlapped with 0/1: */\
+	/* Block 0/1 has just one twiddle-CMUL: 												// Blocks 2/3 use separate register subset, can be done overlapped with 0/1: */\
 	"movq		%[in0],%%rax		\n\t"\
 		"leaq	(%%rax,%%r8  ),%%rbx	\n\t"\
 		"leaq	(%%rax,%%r8,2),%%rcx	\n\t											movq	0x10(%%r14),%%r10				\n\t	movq	0x20(%%r14),%%r12			\n\t"/* c2,c3 */\
@@ -9091,7 +9091,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"xorq	%%r8,%%r8	\n\t	leaq	%c[i1](%%r8),%%r8	\n\t"/* movq|movslq of literal %c[i1] both segfaulted, workaround via LEA */\
 		/* The twid_ptrs[] array holds ptrs to 14 complex twiddles in-order: (c,s)[1,2,3,4,5,6,7]: */\
 		"movq	%[twid_ptrs],%%r14	\n\t"\
-	/* Block 0/1 has just one twiddle-CMUL: 												/* Blocks 2/3 use separate register subset, can be done overlapped with 0/1: */\
+	/* Block 0/1 has just one twiddle-CMUL: 												// Blocks 2/3 use separate register subset, can be done overlapped with 0/1: */\
 	"movq		%[in0],%%rax		\n\t"\
 		"leaq	(%%rax,%%r8  ),%%rbx	\n\t"\
 		"leaq	(%%rax,%%r8,2),%%rcx	\n\t											movq	0x10(%%r14),%%r10				\n\t	movq	0x20(%%r14),%%r12			\n\t"/* c2,c3 */\
@@ -11209,7 +11209,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		"xorq	%%r8,%%r8	\n\t	leaq	%c[i1](%%r8),%%r8	\n\t"/* movq|movslq of literal %c[i1] both segfaulted, workaround via LEA */\
 		/* The twid_ptrs[] array holds ptrs to 14 complex twiddles in-order: (c,s)[1,2,3,4,5,6,7]: */\
 		"movq	%[twid_ptrs],%%r14	\n\t"\
-	/* Block 0/1 has just one twiddle-CMUL: 												/* Blocks 2/3 use separate register subset, can be done overlapped with 0/1: */\
+	/* Block 0/1 has just one twiddle-CMUL: 												// Blocks 2/3 use separate register subset, can be done overlapped with 0/1: */\
 	"movq		%[in0],%%rax		\n\t"\
 		"leaq	(%%rax,%%r8  ),%%rbx	\n\t"\
 		"leaq	(%%rax,%%r8,2),%%rcx	\n\t"\


### PR DESCRIPTION
Part of splitting @ldesnogu's warnings-cleanup PR #34 into smaller, independently-reviewable pieces.

Removes compiler warnings from the FFT machinery: `mers_mod_square.c`, `fermat_mod_square.c`, `dft_macro.c` (+ `sse2_macro_gcc64.h`), `pairFFT_mul.c`, `br.c` (5 commits).

- All @ldesnogu's, cherry-picked from #34 with original authorship preserved; no content changes — mechanical warning removal only.
- Verified: nosimd build clean, LL self-test Res64 `71E61322CCFB396C` unchanged.

Each of these files' strict-aliasing counterpart is in #124 (disjoint regions).