### PR TITLE
Remove warnings from qfloat / pm1 / factor_test (from #34)

### DIFF
--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1025,7 +1025,9 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	// "working map". Alas, since we alloc map[] at runtime, we can't actually declare hi|lo as const-ptrs. File under
 	// "stupid C tricks" - lack of a "set once at runtime but compiler/OS treat as const subsequently" declaration option:
 	static uint8 *map = 0x0,*lo = 0x0,*hi = 0x0; uint8 *map_lo,*map_hi, *rmap;
+#if !defined(PM1_STANDALONE) && (defined(PM1_DEBUG) || USE_PP1_MULTS)
 	static uint64 *vec1 = 0ull, *vec2 = 0ull;
+#endif
 	static uint32 nlimb, *b = 0x0;
 	static double *a_ptmp = 0x0, *a = 0x0;	// Storage for stage 2 in form of ptrs to m*[24,40 or 48] residue-length subarrays, depending
 	static double **buf = 0x0;	// on whether bigstep = [210,330,420 or 840]. a[] is simply a tmp-ptr used to init buf[]
@@ -1220,7 +1222,7 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	// 2 extra word-slots at high end of map used for these temps - can't declare as const pointers,0x but treat as such below:
 	lo = map + m*wsize; hi = lo + wsize;
 	rmap = hi + wsize;
-#ifndef PM1_STANDALONE
+#if !defined(PM1_STANDALONE) && (defined(PM1_DEBUG) || USE_PP1_MULTS)
 	// We know that the arrtmp vector passed in by caller is large enough to hold
 	// at least 2 nlimb-sized arrays,0x so simply point vec1 and vec2 at successive nlimb-sections of it:
 	vec1 = arrtmp; vec2 = arrtmp + nlimb;

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -425,25 +425,25 @@ uint32 pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uin
 	fprintf(stderr,"Pre-loop accumulator = %" PRIu64 " + 2^64*%" PRIu64,accum[0],accum[1]);
   }
 #endif
-// Undef to get debug output.
-//#define DEBUG_PM1_S1_PPOW_PROD
-//	fprintf(stderr,"Stage 1 exponent = %" PRIu64 ".",accum[0]);
+#ifdef PM1_DEBUG
+	fprintf(stderr,"Stage 1 exponent = %" PRIu64 ".",accum[0]);
+#endif
 	while(p < b1) {
 		mult = 1ull;
 		for(i = 0; i < loop; i++) {
 			prod = p; tmp = prod*p;
-#ifdef DEBUG_PM1_S1_PPOW_PROD
-			uint32_t j = 1;
+#ifdef PM1_DEBUG
+			uint32 j = 1;
 #endif
 			// if() uses prod*p here so as to include only the 1st power of the primes >= sqrt(b1):
 			while(tmp <= b1) {
 				prod = tmp; tmp *= p;
-#ifdef DEBUG_PM1_S1_PPOW_PROD
+#ifdef PM1_DEBUG
 				j++;
 #endif
 			}
 			mult *= prod;
-#ifdef DEBUG_PM1_S1_PPOW_PROD
+#ifdef PM1_DEBUG
 			if(j > 1)
 				fprintf(stderr,"%u^%u.",p,j);
 			else
@@ -455,10 +455,9 @@ uint32 pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uin
 		cy = mi64_mul_scalar(accum, mult, accum, len);	++*nmul;
 		accum[len] = cy; len += (cy != 0ull);
 	}
-#ifdef DEBUG_PM1_S1_PPOW_PROD
+#ifdef PM1_DEBUG
 	fprintf(stderr,"\n");
 #endif
-#undef DEBUG_PM1_S1_PPOW_PROD
 	return len;
 }
 

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1015,7 +1015,7 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	int jhi;
 #endif
 	// num_b is #buffers per unit of extended-pairing-window size M; wsize is #bytes needed per 'word' of the associated bitmap
-	uint32 bigstep_pow2,rsize, nq,np=0,ns=0,ierr,nerr,m2,m_is_odd,m_is_even,num_b,psmall,wsize, k,k0=0, nmodmul = 0,nmodmul_save = 0, p1,p2;
+	uint32 bigstep_pow2,rsize, np=0,ns=0,ierr,nerr,m2,m_is_odd,m_is_even,num_b,psmall,wsize, k,k0=0, nmodmul = 0,nmodmul_save = 0, p1,p2;
 #if USE_PP1_MULTS
 	uint32 word,bit;
 #elif defined(PM1_DEBUG)
@@ -2055,8 +2055,11 @@ MME = 0;
 	*tdiff = AME = MME = 0.0;	// Reset timer and maxROE, now also init AvgROE
 	AME_ITER_START = 0;	// For p-1 stage 2, start collecting AvgROE data immediately, no need t wait for residue to "fill in"
 #endif
-	nq = np = 0;	// nq = # of stage 2 q's processed; np = #prime-pairs
+	np = 0;			// np = #prime-pairs
 	ns = 0;			// ns = # singleton-prime q's, i.e. prime q which end up getting paired with a composite
+	// (A 'nq = # of stage 2 q's processed' counter used to live here, but it was only ever incremented in the
+	//  M-odd 0-interval loop below and not in the extended-window loop, so it never held the total it claimed.
+	//  Dropped rather than kept dead; np,ns are the counts actually reported in the summary line post-loop.)
 	/*
 	There are 2 kinds of modmul in the stage 2 accumulation loop: the first is by an element of the precomputed
 	table of the stage 1 residue raised to successive even powers; in an actual bignum-code implementation these
@@ -2087,7 +2090,6 @@ MME = 0;
 		#endif
 			map_lo = map + m2*wsize + (wsize>>1);	// ptr to midpoint of 0-interval map word
 			for(i = 0; i < num_b; i++) {
-				nq += 2;
 				p1 = bytevec_test_bit(map_lo,-i-1); p2 = bytevec_test_bit(map_lo,+i);
 			#ifdef PM1_DEBUG
 				q1 = q - b[i]; q2 = q + b[i];
@@ -2140,7 +2142,6 @@ MME = 0;
 				++nmodmul;
 			#endif
 			}
-			(void)nq; // currently unused
 		  }	// m_is_odd?
 			/* Loop over the m2 interval-pairs symmetric about the 0-interval (M odd) or midpoint of the
 			current set of M extended-pairing windows (M even) and process any resulting pairings.

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1019,6 +1019,8 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	uint32 bigstep_pow2,rsize, nq,np=0,ns=0,ierr,nerr,m2,m_is_odd,m_is_even,num_b,psmall,wsize, k,k0=0, nmodmul = 0,nmodmul_save = 0, p1,p2;
 #if USE_PP1_MULTS
 	uint32 word,bit;
+#elif defined(PM1_DEBUG)
+	uint32 bit;		// The PM1_DEBUG prime-pairing cross-checks below use bit, but not word
 #endif
 	uint64 tmp,q,q0,q1,q2, qlo = 0ull,qhi, reloc_start, pinv64 = 0ull;
 	// map_lo|hi intended as variable ptrs to various parts of map[], lo|hi as const ptrs to words beyond end of

--- a/src/qfloat.c
+++ b/src/qfloat.c
@@ -1273,6 +1273,7 @@ struct qfloat qfadd	(struct qfloat q1, struct qfloat q2)
 	else
 	{
 		ASSERT(0,"ERROR: unrecognized sign combination in QFADD");
+		q = QZRO; // silence warning
 	}
 #if QFDEBUG
 	double qres = qfdbl(q), dres = (1-2.0*sgn1)*qfdbl(q1) + (1-2.0*sgn2)*qfdbl(q2);	// Must cast sgn1,2 to double prior to 1-...
@@ -1317,6 +1318,7 @@ struct qfloat qfsub	(struct qfloat q1, struct qfloat q2)
 	else
 	{
 		ASSERT(0,"ERROR: unrecognized sign combination in QFSUB");
+		q = QZRO; // silence warning
 	}
 #if QFDEBUG
 	double qres = qfdbl(q), dres = (1-2.0*sgn1)*qfdbl(q1) - (1-2.0*sgn2)*qfdbl(q2);	// Must cast sgn1,2 to double prior to 1-...
@@ -2128,7 +2130,6 @@ then do 1 or 2 of the above N-R inverse-function iterations in qfloat mode using
 struct qfloat qfexp(struct qfloat x)
 {
 	 int32 pow2;
-	uint32 i;
 	double darg = qfdbl(x);
 	struct qfloat xabs, y, sinh;
 
@@ -2173,6 +2174,7 @@ struct qfloat qfexp(struct qfloat x)
 
 #elif 1	// Algo A:
 
+	uint32 i;
 	uint32 nterm,nterm_idx;
 	const uint8 nterm_arr[64] = {2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,3,3,4,4,4,4,4,4,5,5,5,5,6,6,6,7,7,8,8,9,9,10,10,11,12,13,15,17,19,22,25,30,30,30,30,30,30,30};
 	struct qfloat curr_term, mult;

--- a/src/qfloat.c
+++ b/src/qfloat.c
@@ -383,6 +383,7 @@ double dbl_flip_lsb(double d)
 	return *(double *)&c;
 }
 
+#ifdef X87_ASM
 /* qfloat --> long double conversion utility.
 Example: x = QLN2:
 	hi = 0x3fe62e42fefa39ef,
@@ -430,6 +431,7 @@ struct qfloat ldbl_to_q(long double x)
 	q.lo = (x87_mant<<53);
 	return q;
 }
+#endif
 
 
 /* Convert IEEE64 double to qfloat. */

--- a/src/qfloat.h
+++ b/src/qfloat.h
@@ -130,10 +130,10 @@ uint64 qfdbl_as_uint64(const struct qfloat q);
 double qfdbl		(const struct qfloat q);
 double qfdbl_wrong_way_rnd(struct qfloat q);
 double dbl_flip_lsb	(double d);
-long double qfldbl	(const struct qfloat q);
+long double qfldbl	(const struct qfloat q);	// This should only be used for x87 code.
 // double / long-double --> qfloat conversions:
 struct qfloat dbl_to_q	(double d);
-struct qfloat ldbl_to_q	(long double ld);
+struct qfloat ldbl_to_q	(long double ld);		// This should only be used for x87 code.
 // int --> qfloat conversion:
 struct qfloat i64_to_q	(int64 i64);
 struct qfloat i128_to_q	(uint128 i);


### PR DESCRIPTION
Part of splitting @ldesnogu's warnings-cleanup PR #34 into smaller, independently-reviewable pieces.

Removes compiler warnings from `qfloat.c`, `pm1.c` (two commits), and `factor_test.h` (5 commits total).

- All @ldesnogu's, cherry-picked from #34 with original authorship preserved.
- Verified: nosimd build clean, LL self-test Res64 `71E61322CCFB396C` unchanged.

**Reviewer note:** one commit here — `ac28c59` "Define qfldbl and ldbl_to_q only for x87 code" — is a *functional* change (it `#if`-gates those `qfloat` helpers to x87 builds), not a pure warning removal. Worth a look to confirm the x87 gating is correct. The other four are mechanical.