### PR TITLE
Fix ALLOC_UINT/ALIGN_UINT type and prefetch macro warnings (from #34)

### DIFF
--- a/src/align.h
+++ b/src/align.h
@@ -40,8 +40,8 @@ util.c::check_nbits_in_types()>
 #define ALLOC_INT(_p,_n)	(int           *)realloc(_p,(_n)*sizeof(int           )+256)
 #define ALIGN_INT(_p)		(int           *)(((intptr_t)(_p) | 63)+1)
 
-#define ALLOC_UINT(_p,_n)	(uint          *)realloc(_p,(_n)*sizeof(uint          )+256)
-#define ALIGN_UINT(_p)		(uint          *)(((intptr_t)(_p) | 63)+1)
+#define ALLOC_UINT(_p,_n)	(uint32        *)realloc(_p,(_n)*sizeof(uint32        )+256)
+#define ALIGN_UINT(_p)		(uint32        *)(((intptr_t)(_p) | 63)+1)
 
 #define ALLOC_INT64(_p,_n)	(int64         *)realloc(_p,(_n)*sizeof(int64         )+256)
 #define ALIGN_INT64(_p)		(int64         *)(((intptr_t)(_p) | 63)+1)

--- a/src/prefetch.h
+++ b/src/prefetch.h
@@ -82,7 +82,7 @@ to point to a simple pointer variable:
 		__asm	prefetcht0 [edx]\
 	}
   #else
-	# define prefetch_p_doubles(_pd)	/* */
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
   #endif
 
 /* AMD64/Solaris, Sun C compiler */
@@ -156,7 +156,7 @@ before the COMPILER_TYPE_GCC case because, bizarrely, ICC also #defines __GNUC__
 		__asm	prefetchw [edx]\
 	}
   #else
-	# define prefetch_p_doubles(_pd)	/* */
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
   #endif
 
 /* AMD Athlon/Duron family, Metrowerks CodeWarrior C compiler */
@@ -332,7 +332,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX	0
 
 	# define prefetch_data(_array,_k)	/* NO-OP! Use #pragma prefetch _array[_k] here??? */
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
 
   #endif
 
@@ -427,7 +427,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX	0
 
 	# define prefetch_data(_array,_k)	/* NO-OP! Use #pragma prefetch _array[_k] here??? */
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
 
 /* IBM Power: */
 #elif(defined(CPU_IS_POWER))
@@ -437,7 +437,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX	0
 
 	# define prefetch_data(_array,_k)	/* NO-OP! Use #pragma prefetch _array[_k] here??? */
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
 
 #else
 
@@ -449,7 +449,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX  0
 
 	# define prefetch_data(_array,_k)	/* */
-	# define prefetch_p_doubles(_pd)	/* */
+	# define prefetch_p_doubles(_pd)	do { (void)(_pd); } while (0)
 
 #endif
 

--- a/src/prefetch.h
+++ b/src/prefetch.h
@@ -82,7 +82,7 @@ to point to a simple pointer variable:
 		__asm	prefetcht0 [edx]\
 	}
   #else
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ (void)(_pd)
   #endif
 
 /* AMD64/Solaris, Sun C compiler */
@@ -156,7 +156,7 @@ before the COMPILER_TYPE_GCC case because, bizarrely, ICC also #defines __GNUC__
 		__asm	prefetchw [edx]\
 	}
   #else
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ (void)(_pd)
   #endif
 
 /* AMD Athlon/Duron family, Metrowerks CodeWarrior C compiler */
@@ -332,7 +332,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX	0
 
 	# define prefetch_data(_array,_k)	/* NO-OP! Use #pragma prefetch _array[_k] here??? */
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ (void)(_pd)
 
   #endif
 
@@ -427,7 +427,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX	0
 
 	# define prefetch_data(_array,_k)	/* NO-OP! Use #pragma prefetch _array[_k] here??? */
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ (void)(_pd)
 
 /* IBM Power: */
 #elif(defined(CPU_IS_POWER))
@@ -437,7 +437,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX	0
 
 	# define prefetch_data(_array,_k)	/* NO-OP! Use #pragma prefetch _array[_k] here??? */
-	# define prefetch_p_doubles(_pd)	/* NO-OP! */ do { (void)(_pd); } while (0)
+	# define prefetch_p_doubles(_pd)	/* NO-OP! */ (void)(_pd)
 
 #else
 
@@ -449,7 +449,7 @@ after the IA64/ICC case because, bizarrely, ICC also #defines __GNUC__ .
 	# define CACHE_LINE_COMPLEX  0
 
 	# define prefetch_data(_array,_k)	/* */
-	# define prefetch_p_doubles(_pd)	do { (void)(_pd); } while (0)
+	# define prefetch_p_doubles(_pd)	(void)(_pd)
 
 #endif
 


### PR DESCRIPTION
Part of splitting @ldesnogu's warnings-cleanup PR #34 into smaller, independently-reviewable pieces.

Two small macro fixes:
- **`align.h`** (`7136a86`) — `ALLOC_UINT`/`ALIGN_UINT` used the bare `uint` type, which isn't guaranteed to be defined; changed to `uint32`. A real portability fix, not just a warning.
- **`prefetch.h`** (`2ca2100`) — give `prefetch_p_doubles` an empty-macro definition that references its parameter, silencing unused-parameter warnings at call sites.

- Both @ldesnogu's, cherry-picked from #34 with original authorship preserved.
- Verified: nosimd build clean, LL self-test Res64 `71E61322CCFB396C` unchanged.