### PR TITLE
Remove warnings from Mlucas.c / mi64.c / util.c / twopmodq128-256 (from #34)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -64,7 +64,7 @@ int MLUCAS_KEEP_RUNNING = 1;
 char **global_argv;
 
 FILE *dbg_file = 0x0;
-double*ADDR0 = 0x0;	// Allows for easy debug on address-read-or-write than setting a watchpoint
+double *ADDR0 = 0x0;	// Allows for easy debug on address-read-or-write than setting a watchpoint
 
 // Define FFT-related globals (declared in Mdata.h):
 uint32 N2,NRT,NRT_BITS,NRTM1;
@@ -407,7 +407,7 @@ uint32	ernstMain
 /*...allocatable data arrays and associated params: */
 	static uint64 nbytes = 0, nalloc = 0, arrtmp_alloc = 0, s1p_alloc = 0;
 	static double *a_ptmp = 0x0, *a = 0x0, *b = 0x0, *c = 0x0, *d = 0x0, *e = 0x0;
-	// uint64 scratch array and 4 pointers used to store cast-to-(uint64*) version of above b,c,d,e-pointers
+	// uint64 scratch array and 4 pointers used to store cast-to-(uint64 *) version of above b,c,d,e-pointers
 	static uint64 *arrtmp = 0x0, *b_uint64_ptr = 0x0, *c_uint64_ptr = 0x0, *d_uint64_ptr = 0x0, *e_uint64_ptr = 0x0;
 	double final_res_offset;
 
@@ -1357,7 +1357,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		USE_SHORT_CY_CHAIN = 2;
 	else if(exp_ratio > 0.97 && USE_SHORT_CY_CHAIN < 1)
 		USE_SHORT_CY_CHAIN = 1;
-	const char*arr_sml[] = {"long","medium","short","hiacc"};
+	const char *arr_sml[] = {"long","medium","short","hiacc"};
 	fprintf(stderr,"Initial DWT-multipliers chain length = [%s] in carry step.\n",arr_sml[USE_SHORT_CY_CHAIN]);
 	// v20: If exp_ratio > 0.98, set ITERS_BETWEEN_CHECKPOINTS = 10000 irrespective of #threads or user-forced greater value;
 	if(USE_SHORT_CY_CHAIN)
@@ -1424,7 +1424,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		// v19: Add three more full-residue arrays to support 2-input FFT-modmul needed for Gerbicz check (and later, p-1 support):
 		if(use_lowmem < 2) {
 			b = a + nalloc;	c = b + nalloc;	d = c + nalloc, e = d + nalloc;
-			b_uint64_ptr = (uint64*)b; c_uint64_ptr = (uint64*)c; d_uint64_ptr = (uint64*)d; e_uint64_ptr = (uint64*)e;
+			b_uint64_ptr = (uint64 *)b; c_uint64_ptr = (uint64 *)c; d_uint64_ptr = (uint64 *)d; e_uint64_ptr = (uint64 *)e;
 		}
 
 		// For this residue (and scratch) byte-array, conservatively figure at least 4 bits per float-double residue word.
@@ -1486,8 +1486,8 @@ READ_RESTART_FILE:
 				ASSERT(use_lowmem < 2, "PRP-test mode not available in Low-memory[2] run mode!");
 			}
 			i = read_ppm1_savefiles(cstr, p, &j, fp, &itmp64,
-												(uint8*)arrtmp      , &Res64,&Res35m1,&Res36m1,	// Primality-test residue
-												(uint8*)e_uint64_ptr, &i1   ,&i2     ,&i3     );// v19: G-check residue
+												(uint8 *)arrtmp      , &Res64,&Res35m1,&Res36m1,	// Primality-test residue
+												(uint8 *)e_uint64_ptr, &i1   ,&i2     ,&i3     );// v19: G-check residue
 			fclose(fp); fp = 0x0;
 			ilo = itmp64;	// v20: E.g. distributed deep p-1 S2 may use B2 >= 2^32, so made nsquares field in savefiles r/w a uint64
 			if(!i) {
@@ -1552,7 +1552,7 @@ READ_RESTART_FILE:
 			/* Allocate floating-point residue array and convert savefile bytewise residue to floating-point form, after
 			first applying required circular shift read into the global RES_SHIFT during the above bytewise-savefile read.
 			*/
-			if(!convert_res_bytewise_FP((uint8*)arrtmp, a, n, p)) {
+			if(!convert_res_bytewise_FP((uint8 *)arrtmp, a, n, p)) {
 				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on primality-test residue read from savefile %s!\n",cstr);
 				mlucas_fprint(cbuf,0);
 				if(cstr[0] != 'q' && !(ierr == ERR_GERBICZ_CHECK)) {	// Secondary savefile only exists for regular checkpoint files
@@ -1564,7 +1564,7 @@ READ_RESTART_FILE:
 			}
 			// v19: G-check residue - we only create savefile for PRP-phase of any PRP-CF run, i.e. always expect a G-check residue:
 		  if(DO_GCHECK) {
-			if(!convert_res_bytewise_FP((uint8*)e_uint64_ptr, b, n, p)) {
+			if(!convert_res_bytewise_FP((uint8 *)e_uint64_ptr, b, n, p)) {
 				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on Gerbicz-check residue read from savefile %s!\n",cstr);
 				mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 			} else {
@@ -2020,11 +2020,11 @@ READ_RESTART_FILE:
 		// Fermat-mod residue formally needs an extra bit, though said bit should == 1
 		// only in the highly unlikely case of a prime-Fermat Pepin-test result:
 		j = (p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6;	arrtmp[j-1] = 0ull;
-		convert_res_FP_bytewise(	a, (uint8*)      arrtmp, n, p, &Res64, &Res35m1, &Res36m1);	// LL/PRP-test/[p-1 stage 1] residue
+		convert_res_FP_bytewise(	a, (uint8 *)      arrtmp, n, p, &Res64, &Res35m1, &Res36m1);	// LL/PRP-test/[p-1 stage 1] residue
 		// G-check residue...must not touch i1,i2,i3 again until ensuing write_ppm1_savefiles call!
 		if(DO_GCHECK) {
 			e_uint64_ptr[j-1] = 0ull;
-			convert_res_FP_bytewise(b, (uint8*)e_uint64_ptr, n, p, &i1,&i2,&i3);
+			convert_res_FP_bytewise(b, (uint8 *)e_uint64_ptr, n, p, &i1,&i2,&i3);
 		}
 
 		// In interactive-timing-test (e.g. self-tests) mode, do immediate-exit-sans-savefile-write on signal:
@@ -2048,7 +2048,7 @@ READ_RESTART_FILE:
 			/*...get a quick timestamp...	*/
 			calendar_time = time(NULL); local_time = localtime(&calendar_time);
 			strftime(timebuffer,SIZE,"%Y-%m-%d %H:%M:%S",local_time);
-			const char*iter_or_stage[] = {"Iter#","S1 bit"};	// Tag indicates Primality/PRP-test or p-1 S1 iteration
+			const char *iter_or_stage[] = {"Iter#","S1 bit"};	// Tag indicates Primality/PRP-test or p-1 S1 iteration
 			/*...print [date in hh:mm:ss | p | iter-count-or-stage progress | %-complete | time | per-iter time | Res64 | max ROE | residue-shift] */
 			snprintf(cbuf,sizeof(cbuf), "[%s] %s %s = %u [%5.2f%% complete] clocks =%s [%8.4f msec/iter] Res64: %016" PRIX64 ". AvgMaxErr = %10.9f. MaxErr = %10.9f. Residue shift count = %" PRIu64 ".\n"
 				, timebuffer, PSTRING, iter_or_stage[TEST_TYPE == TEST_TYPE_PM1], ihi, (float)ihi / (float)maxiter * 100,get_time_str(tdiff)
@@ -2101,7 +2101,7 @@ READ_RESTART_FILE:
 			j = (p+63)>>6;	/*** Jun 2021: cf. convert_res_FP_bytewise() for why we don't include the extra Fermat-modulus bit here ***/
 			c_uint64_ptr[j-1] = 0ull;
 			// [1] Convert b[],d[] to bytewise form, former assumed already in e[] doubles-array, latter into currently-unused c[] doubles-array:
-			convert_res_FP_bytewise(d, (uint8*)c_uint64_ptr, n, p, 0x0,0x0,0x0);
+			convert_res_FP_bytewise(d, (uint8 *)c_uint64_ptr, n, p, 0x0,0x0,0x0);
 			// Only need to compute this for initial interval - after that the needed adjustment-shift remains constant
 			if(ihi == ITERS_BETWEEN_GCHECKS && RES_SHIFT) {
 				if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
@@ -2227,7 +2227,7 @@ READ_RESTART_FILE:
 		if (ihi == maxiter && TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT) PRP_BASE = 3;
 		fp = mlucas_fopen(RESTARTFILE, "wb");
 		if(fp) {		// In the non-PRP-test case, write_ppm1_savefiles() treats the latter 4 args as null:
-			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8*)arrtmp,Res64,Res35m1,Res36m1, (uint8*)e_uint64_ptr,i1,i2,i3);
+			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 			fclose(fp); fp = 0x0;
 			/* If we're on the primary restart file, set up for secondary: */
 			if(RESTARTFILE[0] != 'q') {
@@ -2253,7 +2253,7 @@ READ_RESTART_FILE:
 				strcat(cstr, ".G");
 				fp = mlucas_fopen(cstr, "wb");
 				if(fp) {
-					write_ppm1_savefiles(cstr,p,n,fp, itmp64, (uint8*)arrtmp,Res64,Res35m1,Res36m1, (uint8*)e_uint64_ptr,i1,i2,i3);
+					write_ppm1_savefiles(cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 					fclose(fp); fp = 0x0;
 				} else {
 					snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open Gerbicz-check savefile %s for write of checkpoint data.\n",cstr);
@@ -2550,7 +2550,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		if( ilo < ihi || !filegrep(STATFILE,"GCD",cbuf,0))
 		{	// j = #limbs; clear high limb before filling arrtmp[0:j-1] with bytewise residue just to be sure:
 			j = (p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT))>>6; arrtmp[j-1] = 0ull;
-			convert_res_FP_bytewise(a,(uint8*)arrtmp,n,p,0x0,0x0,0x0);
+			convert_res_FP_bytewise(a,(uint8 *)arrtmp,n,p,0x0,0x0,0x0);
 			arrtmp[0] -= 1;	// S1 GCD needs residue-1
 			i = gcd(1,p,arrtmp,0x0,j,gcd_str);	// 1st arg = stage just completed
 			// If factor found, gcd() will have done needed status-file-writes:
@@ -2660,9 +2660,9 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				// PM1_S2_NBUF to the largest S2 buffer count <= (input PM1_S2_NBUF value) which is also compatible with psmall:
 				pm1_bigstep_size(&PM1_S2_NBUF, &pm1_bigstep, &pm1_stage2_mem_multiple, psmall);
 				fprintf(stderr,"Using %u Stage 2 memory buffers, D = %u, M = %u, psmall = %u.\n",PM1_S2_NBUF,pm1_bigstep,pm1_stage2_mem_multiple,psmall);
-				double*mult[4] = {b,c,d,e};	// Pointers to scratch storage in form of 4 residue-length subarrays
+				double *mult[4] = {b,c,d,e};	// Pointers to scratch storage in form of 4 residue-length subarrays
 				ierr = pm1_stage2(p, pm1_bigstep, pm1_stage2_mem_multiple,
-					a,mult,arrtmp,	// Pointers stage 1 residue in a[], double** scratch storage 4-vector mult[], arrtmp
+					a,mult,arrtmp,	// Pointers stage 1 residue in a[], double ** scratch storage 4-vector mult[], arrtmp
 					func_mod_square, n, scrnFlag, &tdiff, gcd_str);
 				if(ierr && (ierr % ERR_ROUNDOFF) == 0) {	// Workaround for pthreaded-run issue where a single ROE sometimes shows up as an integer multiple of ERR_ROUNDOFF
 					n = get_nextlarger_fft_length(n);	kblocks = (n >> 10);
@@ -2739,7 +2739,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		strcpy(cstr, RESTARTFILE); cstr[0] = 'q';		// cstr = q[expo]
 	}
 	for(ierr = 0; ; RESTARTFILE[0] = 'q') {	// Start with the p-savefile, inrement to q-savefile on looping
-		if(restart_file_valid(RESTARTFILE, p, (uint8*)arrtmp, (uint8*)e_uint64_ptr)) {
+		if(restart_file_valid(RESTARTFILE, p, (uint8 *)arrtmp, (uint8 *)e_uint64_ptr)) {
 			// If end of a regular (non-s2-continuation) p-1 run and primary good, rename it from [p|f][expo] ==> [p|f][expo].s1;
 			// if primary missing/corrupt, rename secondary q[expo] ==> [p|f][expo].s1:
 			if(TEST_TYPE == TEST_TYPE_PM1 && !s2_continuation) {
@@ -3292,9 +3292,9 @@ Example: N = M(109) = 2^109-1 = 745988807.870035986098720987332873; let F = 7459
 	B = 3^(F-1) == 610082383855388688949555345767473 (mod N), and we verify that (A - B) == 0 (mod C), thus C is a PRP.
 Similarly, if we let A' = 3^N == 3.A (mod N) and B' = 3^F == 3.B (mod N), that also satisfies (A' - B') == 0 (mod C).
 */
-uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
+uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
-	int n, int scrnFlag, double *tdiff, char*const gcd_str)
+	int n, int scrnFlag, double *tdiff, char *const gcd_str)
 {
 	uint64 *ai = (uint64 *)a, *bi = (uint64 *)b;	// Handy 'precast' pointers
 	uint32 i,j,k, isprime, ierr = 0, ihi, fbits,lenf;
@@ -3313,7 +3313,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[]
 		ilo = 0;	ihi = ilo+1;	// Have checked that savefile residue is for a complete PRP test, so reset iteration counter
 		BASE_MULTIPLIER_BITS[0] = 0ull;
 /*A*/	ierr = func_mod_square(a, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, TRUE, 0x0);
-		convert_res_FP_bytewise(a, (uint8*)ci, n, p, Res64, &Res35m1, &Res36m1);	// Overwrite passed-in Pepin-Res64 with Fermat-PRP one
+		convert_res_FP_bytewise(a, (uint8 *)ci, n, p, Res64, &Res35m1, &Res36m1);	// Overwrite passed-in Pepin-Res64 with Fermat-PRP one
 		snprintf(cbuf,sizeof(cbuf),"MaxErr = %10.9f\n",MME); mlucas_fprint(cbuf,1);
 	} else if (MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {	// Mersenne PRP-CF doesn't have the Res35m1 or Res36m1 values passed in,
 		res_SH(ci,n,&itmp64,&Res35m1,&Res36m1);			// so we refresh these; see https://github.com/primesearch/Mlucas/issues/27
@@ -3364,7 +3364,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[]
 		mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 	}
 	sprintf(cbuf,"Processed %u bits in binary modpow; MaxErr = %10.9f\n",ihi,MME);
-	convert_res_FP_bytewise(b, (uint8*)ci, n, p, &itmp64, &Res35m1, &Res36m1);	// Res64 reserved for Fermat-PRP result; use itmp64 here
+	convert_res_FP_bytewise(b, (uint8 *)ci, n, p, &itmp64, &Res35m1, &Res36m1);	// Res64 reserved for Fermat-PRP result; use itmp64 here
 	sprintf(cstr, "%u^(F-1) residue (B)        = %#016" PRIX64 ",%11" PRIu64 ",%11" PRIu64 "\n",PRP_BASE,itmp64,Res35m1,Res36m1);
 	strcat(cbuf,cstr);	mlucas_fprint(cbuf,1);
 	ASSERT(j = (p+63)>>6,"uint64 vector length got clobbered!");
@@ -4157,7 +4157,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 				// in which case j holds #radices and rvec2[] holds the corresponding radices on return.
 				// Note that get_fft_radices takes real-FFT length in terms of Kdoubles:
 				i = 0;
-				while(!get_fft_radices(fftlen, i++, (uint32*)&j, rvec2, 10)) {	// 0-return means radset index is in range
+				while(!get_fft_radices(fftlen, i++, (uint32 *)&j, rvec2, 10)) {	// 0-return means radset index is in range
 					if(j != numrad) continue;
 					// #radices matches, see if actual complex radices do
 					for(j = 0; j < numrad; j++) {
@@ -4364,7 +4364,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 		}
 
 		/* Make sure it's a valid radix set index for this FFT length: */
-		if((i = get_fft_radices(iarg, radset, (uint32*)&idum, 0x0, 0)) != 0) {
+		if((i = get_fft_radices(iarg, radset, (uint32 *)&idum, 0x0, 0)) != 0) {
 			if     (i == ERR_FFTLENGTH_ILLEGAL)
 				sprintf(cbuf  , "ERROR: FFT length %d K illegal!\n", iarg);
 			else if(i == ERR_RADIXSET_UNAVAILABLE)
@@ -4887,7 +4887,7 @@ which is presumed to contain the program version that was used to generate said 
 returns nonzero (which should be taken as a proxy for TRUE) if the .cfg file needs to be updated
 via a new round of timing tests, FALSE otherwise.
 */
-int	cfgNeedsUpdating(char*in_line)
+int	cfgNeedsUpdating(const char *in_line)
 {
 	/* For the foreseeable future, version numbers will be of form x.yz, with x a 2-digit integer,
 	y an int having 3 digits or less, and z an optional alphabetic suffix. We choose these such that
@@ -4902,7 +4902,7 @@ int	cfgNeedsUpdating(char*in_line)
 
 /******************/
 
-const char*returnMlucasErrCode(uint32 ierr)
+const char *returnMlucasErrCode(uint32 ierr)
 {
 	ASSERT(ierr < ERR_MAX, "Error code out of range!");
 	return err_code[ierr-1];
@@ -5043,7 +5043,7 @@ int test_types_compatible(uint32 t1, uint32 t2)
 fp = mlucas_fopen(RESTARTFILE,"rb");
 ***/
 // Reads an [nbytes]-long LL|Pepin|PRP|p-1 residue and validates the associated mod(2^64,2^35-1,2^36-1) checksums:
-int read_ppm1_residue(const uint32 nbytes, FILE*fp, uint8 arr_tmp[], uint64*Res64, uint64*Res35m1, uint64*Res36m1)
+int read_ppm1_residue(const uint32 nbytes, FILE *fp, uint8 arr_tmp[], uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1)
 {
 	const char func[] = "read_ppm1_residue";
 	uint32 i,j;
@@ -5078,11 +5078,11 @@ int read_ppm1_residue(const uint32 nbytes, FILE*fp, uint8 arr_tmp[], uint64*Res6
 	*/
 	j = 8 - (nbytes&7);	// nbytes%8 = #significant bytes in high limb; j = #bytes needing zeroing at the high end of the limb
 	for(i = nbytes; i < nbytes+j; i++) arr_tmp[i] = 0;
-	itmp64 = ((uint64*)arr_tmp)[0];
+	itmp64 = ((uint64 *)arr_tmp)[0];
 	if(*Res64 != itmp64) {
 		sprintf(cbuf, "%s: On restart: Res64 checksum error! Got %" PRIX64 ", expected %" PRIX64 "\n"  ,func,itmp64,*Res64); return 0;
 	}
-	// For big-endian CPUs, casting byte-array to uint64* gives byte-reversed limbs, so use a direct bitwise mod:
+	// For big-endian CPUs, casting byte-array to uint64 * gives byte-reversed limbs, so use a direct bitwise mod:
   #ifdef USE_BIG_ENDIAN
 	/*
 	My original approach here was wrong - here was the reasoning, illustrated using the (mod 2^35-1) of the S-H mod pair:
@@ -5124,11 +5124,11 @@ int read_ppm1_residue(const uint32 nbytes, FILE*fp, uint8 arr_tmp[], uint64*Res6
 	if(*Res36m1 != rmod36)	{ sprintf(cbuf, "%s: On restart: Res36m1 checksum error! Got %" PRIX64 ", expected %" PRIX64 "\n",func,rmod36,*Res36m1); return 0; }
   #else
 	i = (nbytes+7)>>3;	// # of 64-bit limbs
-	itmp64 = mi64_div_by_scalar64((uint64*)arr_tmp,two35m1,i,0x0);
+	itmp64 = mi64_div_by_scalar64((uint64 *)arr_tmp,two35m1,i,0x0);
 	if(*Res35m1 != itmp64) {
 		sprintf(cbuf, "%s: On restart: Res35m1 checksum error! Got %" PRIX64 ", expected %" PRIX64 "\n",func,itmp64,*Res35m1); return 0;
 	}
-	itmp64 = mi64_div_by_scalar64((uint64*)arr_tmp,two36m1,i,0x0);
+	itmp64 = mi64_div_by_scalar64((uint64 *)arr_tmp,two36m1,i,0x0);
 	if(*Res36m1 != itmp64) {
 		sprintf(cbuf, "%s: On restart: Res36m1 checksum error! Got %" PRIX64 ", expected %" PRIX64 "\n",func,itmp64,*Res36m1); return 0;
 	}
@@ -5139,13 +5139,13 @@ int read_ppm1_residue(const uint32 nbytes, FILE*fp, uint8 arr_tmp[], uint64*Res6
 // Returns 1 on successful read, 0 otherwise:
 // v19: For PRP-tests, also write a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]
 // v20: Distributed deep p-1 S2 may use B2 >= 2^32, so make ilo a uint64-ptr; add filename arg since S2 appends '.s2' to RESTARTFILE:
-int read_ppm1_savefiles(const char*fname, uint64 p, uint32*kblocks, FILE*fp, uint64*ilo,
-	uint8 arr1[], uint64*Res64, uint64*Res35m1, uint64*Res36m1,
-	uint8 arr2[], uint64*i1   , uint64*i2     , uint64*i3     )
+int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, uint64 *ilo,
+	uint8 arr1[], uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1,
+	uint8 arr2[], uint64 *i1   , uint64 *i2     , uint64 *i3     )
 {
 	const char func[] = "read_ppm1_savefiles";
 	uint32 i,j,k,len,nbytes = 0,nerr;
-	uint64 itmp64, nsquares = 0ull, *avec = (uint64*)arr1, exp[4],pow[4],rem[4];
+	uint64 itmp64, nsquares = 0ull, *avec = (uint64 *)arr1, exp[4],pow[4],rem[4];
 	uint128 ui128,vi128; uint192 ui192,vi192; uint256 ui256,vi256;	// Fixed-length 2/3/4-word ints for stashing results of multiword modexp.
 	*Res64 = 0ull;	// 0 value on return indicates failure of some kind
 	mi64_clear(pow,4); mi64_clear(rem,4);
@@ -5364,7 +5364,7 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 [2] any circular shift stored in the global RES_SHIFT has been removed in the preceding call to convert_res_FP_bytewise.
 v19: For PRP-tests, also write a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]
 */
-void write_ppm1_residue(const uint32 nbytes, FILE*fp, const uint8 arr_tmp[], const uint64 Res64, const uint64 Res35m1, const uint64 Res36m1)
+void write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], const uint64 Res64, const uint64 Res35m1, const uint64 Res36m1)
 {
 	const char func[] = "write_ppm1_residue";
 	uint32 i;
@@ -5388,7 +5388,7 @@ void write_ppm1_residue(const uint32 nbytes, FILE*fp, const uint8 arr_tmp[], con
 }
 
 // v20: E.g. distributed deep p-1 S2 may use B2 >= 2^32, so make ihi a uint64; add filename arg since S2 appends '.s2' to RESTARTFILE:
-void write_ppm1_savefiles(const char*fname, uint64 p, int n, FILE*fp, uint64 ihi,
+void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 ihi,
 	uint8 arr1[], uint64 Res64, uint64 Res35m1, uint64 Res36m1,
 	uint8 arr2[], uint64 i1   , uint64 i2     , uint64 i3     )
 {
@@ -5490,7 +5490,7 @@ int 	convert_res_bytewise_FP(const uint8 ui64_arr_in[], double a[], int n, const
 	nbytes = (p + 7)/8;
 	// Apply the circular shift:
 	uint32 is_ferm = (MODULUS_TYPE == MODULUS_TYPE_FERMAT);
-	mi64_shlc((uint64*)ui64_arr_in, (uint64*)ui64_arr_in, p, RES_SHIFT, (p+63+is_ferm)>>6, is_ferm);
+	mi64_shlc((uint64 *)ui64_arr_in, (uint64 *)ui64_arr_in, p, RES_SHIFT, (p+63+is_ferm)>>6, is_ferm);
 
 	/* Vector length a power of 2? */
 	pow2_fft = (n >> trailz32(n)) == 1;
@@ -5707,7 +5707,7 @@ In the Fermat-mod case digits assumed arranged in (j,j+n/2), i.e. right-angle tr
 modulus) from/to balanced-digit fixed-base floating-point form and uint64
 form, use the mi64_cvt_double_uint64() and mi64_cvt_uint64_double() functions in mi64.c .
 */
-void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, const uint64 p, uint64*Res64, uint64*Res35m1, uint64*Res36m1)
+void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, const uint64 p, uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1)
 {
 	const char func[] = "convert_res_FP_bytewise";
 	int bimodn,curr_bits,curr_char,cy,findex,ii,j,j1,k,pass,rbits,msw_lt0,bw,sw,bits[2],pow2_fft;
@@ -5715,7 +5715,7 @@ void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, cons
 	double atmp;
 	int64 itmp;
 	const uint64 two35m1 = (uint64)0x00000007FFFFFFFFull, two36m1 = (uint64)0x0000000FFFFFFFFFull;	/* 2^35,36-1 */
-	uint64*u64_ptr = (uint64*)ui64_arr_out;
+	uint64 *u64_ptr = (uint64 *)ui64_arr_out;
 
 	ASSERT(MODULUS_TYPE,"MODULUS_TYPE not set!");
 	ASSERT(MODULUS_TYPE <= MODULUS_TYPE_MAX,"MODULUS_TYPE out of range!");
@@ -5970,15 +5970,15 @@ void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, cons
 		}
 	}
 	/* Checksums: */
-	if(Res64  ) *Res64 = ((uint64*)ui64_arr_out)[0];
-	if(Res35m1) *Res35m1 = mi64_div_by_scalar64((uint64*)ui64_arr_out,two35m1,j,0x0);
-	if(Res36m1) *Res36m1 = mi64_div_by_scalar64((uint64*)ui64_arr_out,two36m1,j,0x0);
+	if(Res64  ) *Res64 = ((uint64 *)ui64_arr_out)[0];
+	if(Res35m1) *Res35m1 = mi64_div_by_scalar64((uint64 *)ui64_arr_out,two35m1,j,0x0);
+	if(Res36m1) *Res36m1 = mi64_div_by_scalar64((uint64 *)ui64_arr_out,two36m1,j,0x0);
 //	fprintf(stderr,"Res35m1,Res36m1: %" PRIu64 ",%" PRIu64 "\n",*Res35m1,*Res36m1);
 }
 
 /*********************/
 // Takes len-limb residue vector a[] and returns Selfridge-Hurwitz residues via the 3 arglist pointers:
-void res_SH(uint64 a[], uint32 len, uint64*Res64, uint64*Res35m1, uint64*Res36m1)
+void res_SH(uint64 a[], uint32 len, uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1)
 {
 	const uint64 two35m1 = (uint64)0x7FFFFFFFFull, two36m1 = (uint64)0xFFFFFFFFFull;	/* 2^35-1,36-1 */
 	*Res64  = a[0];
@@ -6031,7 +6031,7 @@ uint32 get_default_factoring_depth(uint64 p)
 
 /*********************/
 
-int	is_hex_string(char*s, int len)
+int	is_hex_string(const char *s, int len)
 {
 	int i;
 	ASSERT(s != 0x0, "Null ptr to is_hex_string()");
@@ -6065,9 +6065,9 @@ Side effect:
 	For legal assignment lines of the specified form, sets the value of the global MODULUS_TYPE,
 	to MODULUS_TYPE_MERSENNE for c = -1 and MODULUS_TYPE_FERMAT for c = +1;
 */
-char*check_kbnc(char*in_str, uint64*p) {
+char *check_kbnc(char *in_str, uint64 *p) {
 	const char func[] = "check_kbnc";
-	char*char_addr = in_str, *cptr = 0x0;
+	char *char_addr = in_str, *cptr = 0x0;
 	int i = 0;
 	while(1) {
 		if((char_addr = strstr(char_addr, "=")) == 0x0) {
@@ -6156,15 +6156,15 @@ No factor found:
 Need to differentiate between PRP-CF results and the preceding PRP; set the otherwise-unused s2_partial flag to indicate PRP-CF.
 */
 void generate_JSON_report(
-	const uint32 isprime, const uint64 p, const uint32 n, const uint64 Res64, const char* Res2048, const char*timebuffer,
-	const uint32 B1, const uint64 B2, const char*factor, const uint32 s2_partial,	// Quartet of p-1 fields
-	char*cstr)	// cstr, takes the formatted output line; the preceding const-ones are inputs for that:
+	const uint32 isprime, const uint64 p, const uint32 n, const uint64 Res64, const char * Res2048, const char *timebuffer,
+	const uint32 B1, const uint64 B2, const char *factor, const uint32 s2_partial,	// Quartet of p-1 fields
+	char *cstr)	// cstr, takes the formatted output line; the preceding const-ones are inputs for that:
 {
 	int i,j,k;
 	char ttype[11] = "\0", aid[33] = "\0";	// [test-type needs 11th | aid needs 33rd] char for \0
 	const char prp_status[2] = {'C','P'};
-	const char*pm1_status[2] = {"NF","F"};
-	const char*false_or_true[2] = {"false","true"};
+	const char *pm1_status[2] = {"NF","F"};
+	const char *false_or_true[2] = {"false","true"};
 	// Attempt to read 32-hex-char Primenet assignment ID for current assignment (first line of WORKFILE):
 	ASSERT((fp = mlucas_fopen(WORKFILE, "r")) != 0x0,"Workfile not found!");
 	// v20.1.1: Parse first line whose leading non-WS char is alphabetic:
@@ -6326,11 +6326,11 @@ the factors are stored in the global KNOWN_FACTORS[], with a limit of 10 known f
 Assumes: Modulus type and binary exponent have been set prior to function call;
 Returns: The number of factors read in.
 */
-uint32 extract_known_factors(uint64 p, char*fac_start) {
+uint32 extract_known_factors(uint64 p, char *fac_start) {
 	uint32 i, findex, lenf, nchar, nfac = 0;
 	uint64 *fac = 0x0, twop[4], quo[4],rem[4];	// fac = ptr to each mi64-converted factor input string;
 	uint256 p256,q256,res256;
-	char*cptr = fac_start+1;
+	char *cptr = fac_start+1;
 	ASSERT(fac_start[0] == '\"',"Known-factors line of worktodo must consist of a comma-separated list of such enclosed in double-quotes!");
 	/* If it's a Fermat number, need to check size of 2^ESTRING: */
 	if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
@@ -6453,7 +6453,7 @@ If p == 0 (this requires vec2 != 0x0):
 	A nonzero return value indicates a nontrivial GCD.
 The decimal value of the GCD is returned in gcd_str, presumed to be dimensioned >= 1024 chars:
 */
-uint32 gcd(uint32 stage, uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb, char*const gcd_str) {
+uint32 gcd(uint32 stage, uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb, char *const gcd_str) {
 #if !INCLUDE_GMP
 	#warning INCLUDE_GMP defined == 0 at compile time ... No GCDs will be done on p-1 outputs.
 	snprintf(cbuf,sizeof(cbuf),"INCLUDE_GMP defined == 0 at compile time ... No GCD will be done.\n");
@@ -6551,7 +6551,7 @@ GMP mod-inverse; arglist as for mpz_gcd but also returns int:
 	|op2| = 1, i.e., in the somewhat degenerate zero ring). If an inverse doesn’t exist the return
 	value is zero and rop is undefined. The behaviour of this function is undefined when op2 = 0.
 */
-void modinv(uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb) {
+void modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb) {
 #if !INCLUDE_GMP
 	#warning INCLUDE_GMP defined == 0 at compile time ... No MODINV support.
 	// If user turns off p-1 support, keep the decl of modinv() to allow pm1.c to build
@@ -6613,12 +6613,12 @@ void modinv(uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb) {
 // Assumes the globals TEST_TYPE and MODULUS_TYPE have been properly set in main.
 // Requires pointers arr1 (and arr2 if a PRP-test residue) to scratch arrays with sufficient allocation
 // to hold the bytewise residue(s) stored in the file to be passed in.
-int restart_file_valid(const char*fname, const uint64 p, uint8*arr1, uint8*arr2)
+int restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *arr2)
 {
 	int retval = 0;
 	uint32 j;
 	uint64 Res64,Res35m1,Res36m1, i1,i2,i3, itmp64;
-	FILE*fptr = mlucas_fopen(fname,"r");
+	FILE *fptr = mlucas_fopen(fname,"r");
 	if(fptr) {
 		retval = read_ppm1_savefiles(fname, p, &j, fptr, &itmp64,
 										arr1, &Res64,&Res35m1,&Res36m1,	// Primality-test residue
@@ -6635,14 +6635,14 @@ int restart_file_valid(const char*fname, const uint64 p, uint8*arr1, uint8*arr2)
 // Depending on whether the associated integer arg find_before_line_number = 0 or not, the mandatory cstr arg will contain a copy of
 // either the first or last-line-before-line-number matching find_str, respectively. If no matches, 0 is returned and cstr = '\0'.
 // To find the line number and content of the last occurrence of find_str, period, set find_before_line_number = -1:
-uint32 filegrep(const char*fname, const char*find_str, char*cstr, uint32 find_before_line_number)
+uint32 filegrep(const char *fname, const char *find_str, char *cstr, uint32 find_before_line_number)
 {
 	uint32 curr_line = 0, found_line = 0;
 	ASSERT(cstr != 0x0, "filegrep(): cstr pointer argument must be non-null!");
 	cstr[0] = '\0';
 	if(strlen(find_str) == 0)	// Nothing to find
 		return 0;
-	FILE*fptr = mlucas_fopen(fname,"r");
+	FILE *fptr = mlucas_fopen(fname,"r");
 	if(fptr){
 		while(fgets(in_line, sizeof(in_line), fptr)) {
 			++curr_line;

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -562,7 +562,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		fprintf(stderr," %s file found...reading next assignment...\n",WORKFILE);
 
 	  read_next_assignment:	// Read first line of worktodo.ini file into 1K character array:
-		if(!fgets(in_line, STR_MAX_LEN, fp)) {
+		if(!fgets(in_line, sizeof(in_line), fp)) {
 			fprintf(stderr,"Hit EOF while attempting to read next line of worktodo ... quitting.\n");
 			exit(0);
 		}
@@ -823,7 +823,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 	#endif
 		else
 		{
-			snprintf(cbuf,STR_MAX_LEN*2,"WARN: Unrecognized/Unsupported option or empty assignment line. The ini file entry was %s\n",in_line);
+			snprintf(cbuf,sizeof(cbuf),"WARN: Unrecognized/Unsupported option or empty assignment line. The ini file entry was %s\n",in_line);
 			fprintf(stderr,"%s",cbuf);
 			goto read_next_assignment;
 		}
@@ -951,7 +951,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 				TF_BITS = strtoul(char_addr, &endp, 10);
 			#if INCLUDE_TF
 				if(TF_BITS > MAX_FACT_BITS) {
-					snprintf(cbuf,STR_MAX_LEN*2,"ERROR: TF_BITS of %u > max. allowed of %u. The ini file entry was %s\n", TF_BITS, MAX_FACT_BITS, in_line);
+					snprintf(cbuf,sizeof(cbuf),"ERROR: TF_BITS of %u > max. allowed of %u. The ini file entry was %s\n", TF_BITS, MAX_FACT_BITS, in_line);
 					fprintf(stderr,"%s",cbuf);
 					goto GET_NEXT_ASSIGNMENT;
 				}
@@ -1094,7 +1094,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 
 	// If production run (not self-test), echo assignment to per-exponent logfile:
 	if(!INTERACT) {
-		snprintf(cbuf,STR_MAX_LEN*2," %s entry: %s\n",WORKFILE,in_line);
+		snprintf(cbuf,sizeof(cbuf)," %s entry: %s\n",WORKFILE,in_line);
 		mlucas_fprint(cbuf,0);
 	}
 
@@ -1173,7 +1173,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 		}
 
 		TRANSFORM_TYPE = REAL_WRAPPER;
-		snprintf(PSTRING,STR_MAX_LEN, "M%s", ESTRING);
+		snprintf(PSTRING,sizeof(PSTRING), "M%s", ESTRING);
 		/* v19:
 		Unlike standard mod-M(p) Fermat-PRP test, x0^(N-1) ?== 1 (mod N) which for N = M(p) gives N-1 = 2^p-2
 		= 0b111[p-1 binary 1s]1110 and thus requires [p-2 (x := x^2*base) steps followed by 1 final squaring], the
@@ -1495,7 +1495,7 @@ READ_RESTART_FILE:
 				if(strstr(cbuf, "read_ppm1_savefiles"))
 					mlucas_fprint(cbuf,1);
 				/* And now for the official spokesmessage: */
-				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: read_ppm1_savefiles Failed on savefile %s!\n",cstr);
+				snprintf(cbuf,sizeof(cbuf), "ERROR: read_ppm1_savefiles Failed on savefile %s!\n",cstr);
 				mlucas_fprint(cbuf,1);
 
 				if(ierr == ERR_GERBICZ_CHECK) {
@@ -1546,14 +1546,14 @@ READ_RESTART_FILE:
 			*/
 			if(ierr == ERR_GERBICZ_CHECK) {
 				MOD_ADD64(RES_SHIFT,RES_SHIFT,p,RES_SHIFT);
-				snprintf(cbuf,STR_MAX_LEN*2, "Gerbicz-check-error restart: Mod-doubling residue shift to avoid repeating any possible fractional-error aliasing in retry, new shift = %" PRIu64 "\n",RES_SHIFT);
+				snprintf(cbuf,sizeof(cbuf), "Gerbicz-check-error restart: Mod-doubling residue shift to avoid repeating any possible fractional-error aliasing in retry, new shift = %" PRIu64 "\n",RES_SHIFT);
 				mlucas_fprint(cbuf,1);
 			}
 			/* Allocate floating-point residue array and convert savefile bytewise residue to floating-point form, after
 			first applying required circular shift read into the global RES_SHIFT during the above bytewise-savefile read.
 			*/
 			if(!convert_res_bytewise_FP((uint8*)arrtmp, a, n, p)) {
-				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: convert_res_bytewise_FP Failed on primality-test residue read from savefile %s!\n",cstr);
+				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on primality-test residue read from savefile %s!\n",cstr);
 				mlucas_fprint(cbuf,0);
 				if(cstr[0] != 'q' && !(ierr == ERR_GERBICZ_CHECK)) {	// Secondary savefile only exists for regular checkpoint files
 					cstr[0] = 'q';
@@ -1565,7 +1565,7 @@ READ_RESTART_FILE:
 			// v19: G-check residue - we only create savefile for PRP-phase of any PRP-CF run, i.e. always expect a G-check residue:
 		  if(DO_GCHECK) {
 			if(!convert_res_bytewise_FP((uint8*)e_uint64_ptr, b, n, p)) {
-				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: convert_res_bytewise_FP Failed on Gerbicz-check residue read from savefile %s!\n",cstr);
+				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on Gerbicz-check residue read from savefile %s!\n",cstr);
 				mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 			} else {
 				ierr = 0;
@@ -1584,11 +1584,11 @@ READ_RESTART_FILE:
 		{
 			/* If we're on the primary restart file, set up for secondary: */
 			if(ierr == ERR_GERBICZ_CHECK || s2_continuation) {	// Secondary savefile only exists for regular checkpoint files
-				snprintf(cbuf,STR_MAX_LEN*2, "INFO: Needed restart file %s not found...moving on to next assignment in %s.\n",cstr,WORKFILE);
+				snprintf(cbuf,sizeof(cbuf), "INFO: Needed restart file %s not found...moving on to next assignment in %s.\n",cstr,WORKFILE);
 				mlucas_fprint(cbuf,1);
 				goto GET_NEXT_ASSIGNMENT;
 			} else if(cstr[0] != 'q') {
-				snprintf(cbuf,STR_MAX_LEN*2, "INFO: primary restart file %s not found...looking for secondary...\n",cstr);
+				snprintf(cbuf,sizeof(cbuf), "INFO: primary restart file %s not found...looking for secondary...\n",cstr);
 				mlucas_fprint(cbuf,1);
 				cstr[0] = 'q';
 				goto READ_RESTART_FILE;
@@ -1670,13 +1670,13 @@ READ_RESTART_FILE:
 	}
 
 	if(restart) {
-		if (MODULUS_TYPE == MODULUS_TYPE_FERMAT) snprintf(cbuf,STR_MAX_LEN*2, "Restarting %s at iteration = %u, residue shift count = %" PRIu64 ".\nRes64,Res35m1,Res36m1: %016" PRIX64 ",%" PRIu64 ",%" PRIu64 "\n",PSTRING,ilo,RES_SHIFT,Res64,Res35m1,Res36m1);
-		else snprintf(cbuf,STR_MAX_LEN*2, "Restarting %s at iteration = %u. Res64: %016" PRIX64 ", residue shift count = %" PRIu64 "\n",PSTRING,ilo,Res64,RES_SHIFT);
+		if (MODULUS_TYPE == MODULUS_TYPE_FERMAT) snprintf(cbuf,sizeof(cbuf), "Restarting %s at iteration = %u, residue shift count = %" PRIu64 ".\nRes64,Res35m1,Res36m1: %016" PRIX64 ",%" PRIu64 ",%" PRIu64 "\n",PSTRING,ilo,RES_SHIFT,Res64,Res35m1,Res36m1);
+		else snprintf(cbuf,sizeof(cbuf), "Restarting %s at iteration = %u. Res64: %016" PRIX64 ", residue shift count = %" PRIu64 "\n",PSTRING,ilo,Res64,RES_SHIFT);
 		mlucas_fprint(cbuf,0);
 	}
 
 	/*...Restart and FFT info.	*/
-	snprintf(cbuf,STR_MAX_LEN*2,"%s: using FFT length %uK = %u 8-byte floats, initial residue shift count = %" PRIu64 "\n",PSTRING,kblocks,n,RES_SHIFT);
+	snprintf(cbuf,sizeof(cbuf),"%s: using FFT length %uK = %u 8-byte floats, initial residue shift count = %" PRIu64 "\n",PSTRING,kblocks,n,RES_SHIFT);
 	sprintf(cstr,"This gives an average %20.15f bits per digit\n",1.0*p/n);	strcat(cbuf,cstr);
 	if(TEST_TYPE == TEST_TYPE_PRP) {
 		sprintf(cstr,"The test will be done in form of a %u-PRP test.\n",PRP_BASE);	strcat(cbuf,cstr);
@@ -1776,7 +1776,7 @@ READ_RESTART_FILE:
 
 	if(TEST_TYPE == TEST_TYPE_PM1 && ilo >= maxiter) {
 		ASSERT(ilo == maxiter && ilo == PM1_S1_PROD_BITS,"For completed S1 expect ilo == maxiter == PM1_S1_PROD_BITS!");
-		snprintf(cbuf,STR_MAX_LEN*2, "%s: p-1 stage 1 to b1 = %u already done -- proceeding to stage 2.\n",PSTRING,B1);
+		snprintf(cbuf,sizeof(cbuf), "%s: p-1 stage 1 to b1 = %u already done -- proceeding to stage 2.\n",PSTRING,B1);
 		fprintf(stderr,"%s",cbuf);
 		ilo = ihi;		// Need this to differentiate between just-completed S1 and S1 residue read from restart file,
 		goto PM1_STAGE2;// in terms of whether we need to do a GCD before proceeding to S2
@@ -1807,7 +1807,7 @@ READ_RESTART_FILE:
 			itmp64 = ~(-1ull << j); BASE_MULTIPLIER_BITS[i-1] &= itmp64;// ...and zero any excess bits at the high end.
 			for(i = 0, itmp64 = 0ull; i < s1p_alloc; i++) { itmp64 += PM1_S1_PRODUCT[i]; }
 			if(itmp64 != PM1_S1_PROD_RES64) {
-				snprintf(cbuf,STR_MAX_LEN*2,"PM1_S1_PRODUCT (mod 2^64_ checksum mismatch! (Current[%" PRIu64 "] != Reference[%" PRIu64 "]). Aborting due to suspected data corruption.\n",itmp64,PM1_S1_PROD_RES64);
+				snprintf(cbuf,sizeof(cbuf),"PM1_S1_PRODUCT (mod 2^64_ checksum mismatch! (Current[%" PRIu64 "] != Reference[%" PRIu64 "]). Aborting due to suspected data corruption.\n",itmp64,PM1_S1_PROD_RES64);
 				mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 			}
 		}
@@ -1878,7 +1878,7 @@ READ_RESTART_FILE:
 						fprintf(stderr,"Caught interrupt in fFFT(c) step.\n");
 						break;
 					} else {
-						snprintf(cbuf,STR_MAX_LEN*2,"Unhandled Error of type[%u] = %s in fFFT(c) step - please send e-mail to ewmayer@aol.com with copy of the p*.stat file attached. Proceeding to next assignment...\n",ierr,returnMlucasErrCode(ierr));
+						snprintf(cbuf,sizeof(cbuf),"Unhandled Error of type[%u] = %s in fFFT(c) step - please send e-mail to ewmayer@aol.com with copy of the p*.stat file attached. Proceeding to next assignment...\n",ierr,returnMlucasErrCode(ierr));
 						mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 					//	goto GET_NEXT_ASSIGNMENT;
 					}
@@ -1908,7 +1908,7 @@ READ_RESTART_FILE:
 						fprintf(stderr,"Caught interrupt in FFT(b)*FFT(c) step.\n");
 						break;
 					} else {
-						snprintf(cbuf,STR_MAX_LEN*2,"Unhandled Error of type[%u] = %s in FFT(b)*FFT(c) step - please send e-mail to ewmayer@aol.com with copy of the p*.stat file attached. Proceeding to next assignment...\n",ierr,returnMlucasErrCode(ierr));
+						snprintf(cbuf,sizeof(cbuf),"Unhandled Error of type[%u] = %s in FFT(b)*FFT(c) step - please send e-mail to ewmayer@aol.com with copy of the p*.stat file attached. Proceeding to next assignment...\n",ierr,returnMlucasErrCode(ierr));
 						mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 					//	goto GET_NEXT_ASSIGNMENT;
 					}
@@ -2050,7 +2050,7 @@ READ_RESTART_FILE:
 			strftime(timebuffer,SIZE,"%Y-%m-%d %H:%M:%S",local_time);
 			const char*iter_or_stage[] = {"Iter#","S1 bit"};	// Tag indicates Primality/PRP-test or p-1 S1 iteration
 			/*...print [date in hh:mm:ss | p | iter-count-or-stage progress | %-complete | time | per-iter time | Res64 | max ROE | residue-shift] */
-			snprintf(cbuf,STR_MAX_LEN*2, "[%s] %s %s = %u [%5.2f%% complete] clocks =%s [%8.4f msec/iter] Res64: %016" PRIX64 ". AvgMaxErr = %10.9f. MaxErr = %10.9f. Residue shift count = %" PRIu64 ".\n"
+			snprintf(cbuf,sizeof(cbuf), "[%s] %s %s = %u [%5.2f%% complete] clocks =%s [%8.4f msec/iter] Res64: %016" PRIX64 ". AvgMaxErr = %10.9f. MaxErr = %10.9f. Residue shift count = %" PRIu64 ".\n"
 				, timebuffer, PSTRING, iter_or_stage[TEST_TYPE == TEST_TYPE_PM1], ihi, (float)ihi / (float)maxiter * 100,get_time_str(tdiff)
 				, 1000*get_time(tdiff)/(ihi - ilo), Res64, AME, MME, RES_SHIFT);
 			mlucas_fprint(cbuf,scrnFlag);
@@ -2090,7 +2090,7 @@ READ_RESTART_FILE:
 					fprintf(stderr,"Caught interrupt in Gerbicz-checkproduct mod-squaring update ... skipping G-check and savefile-update and performing immediate-exit.\n");
 					exit(1);
 				} else {
-					snprintf(cbuf,STR_MAX_LEN*2,"Unhandled Error of type[%u] = %s in Gerbicz-checkproduct mod-squaring update - please send e-mail to ewmayer@aol.com with copy of the p*.stat file attached. Proceeding to next assignment...\n",ierr,returnMlucasErrCode(ierr));
+					snprintf(cbuf,sizeof(cbuf),"Unhandled Error of type[%u] = %s in Gerbicz-checkproduct mod-squaring update - please send e-mail to ewmayer@aol.com with copy of the p*.stat file attached. Proceeding to next assignment...\n",ierr,returnMlucasErrCode(ierr));
 					mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 				//	goto GET_NEXT_ASSIGNMENT;
 				}
@@ -2215,7 +2215,7 @@ READ_RESTART_FILE:
 			strcpy(cstr, RESTARTFILE);
 			strcat(cstr, cbuf);
 			if(rename(RESTARTFILE, cstr)) {
-				snprintf(cbuf,STR_MAX_LEN*2,"ERROR: unable to rename %s restart file ==> %s ... skipping every-10M-iteration restart file archiving\n",WORKFILE,cstr);
+				snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename %s restart file ==> %s ... skipping every-10M-iteration restart file archiving\n",WORKFILE,cstr);
 				fprintf(stderr,"%s",cbuf);
 			}
 		}	// ilo a multiple of 10 million?
@@ -2236,7 +2236,7 @@ READ_RESTART_FILE:
 				RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
 			}
 		} else {
-			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: unable to open restart file %s for write of checkpoint data.\n",RESTARTFILE);
+			snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open restart file %s for write of checkpoint data.\n",RESTARTFILE);
 			mlucas_fprint(cbuf,1);
 			/*
 			Don't want to assert here - asllow processing to continue, in case this is a transient failure-to-open.
@@ -2256,7 +2256,7 @@ READ_RESTART_FILE:
 					write_ppm1_savefiles(cstr,p,n,fp, itmp64, (uint8*)arrtmp,Res64,Res35m1,Res36m1, (uint8*)e_uint64_ptr,i1,i2,i3);
 					fclose(fp); fp = 0x0;
 				} else {
-					snprintf(cbuf,STR_MAX_LEN*2, "ERROR: unable to open Gerbicz-check savefile %s for write of checkpoint data.\n",cstr);
+					snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open Gerbicz-check savefile %s for write of checkpoint data.\n",cstr);
 					mlucas_fprint(cbuf,1);
 				}
 			}	// ihi a multiple of ITERS_BETWEEN_GCHECKS?
@@ -2492,7 +2492,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			if(isprime) {
 				if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
 					/*... this gets written both to file and to stdout, the latter irrespective of whether the run is in interactive mode...	*/
-					snprintf(cbuf,STR_MAX_LEN*2, "%s is a new FERMAT PRIME!!!\nPlease send e-mail to ewmayer@aol.com.\n",PSTRING);
+					snprintf(cbuf,sizeof(cbuf), "%s is a new FERMAT PRIME!!!\nPlease send e-mail to ewmayer@aol.com.\n",PSTRING);
 					mlucas_fprint(cbuf,1);
 				}
 				else if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
@@ -2502,11 +2502,11 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 							break;
 					}
 					if(knowns[i] != 0) {
-						snprintf(cbuf,STR_MAX_LEN*2, "%s is a known MERSENNE PRIME.\n",PSTRING);
+						snprintf(cbuf,sizeof(cbuf), "%s is a known MERSENNE PRIME.\n",PSTRING);
 						mlucas_fprint(cbuf,(INTERACT || scrnFlag));	// Latter clause == "Echo output to stderr?"
 					} else {
 						// This gets written both to file and to stderr, the latter irrespective of whether the run is in interactive mode:
-						snprintf(cbuf,STR_MAX_LEN*2, "%s is a (probable) new MERSENNE PRIME!!!\nPlease send e-mail to ewmayer@aol.com and woltman@alum.mit.edu.\n",PSTRING);
+						snprintf(cbuf,sizeof(cbuf), "%s is a (probable) new MERSENNE PRIME!!!\nPlease send e-mail to ewmayer@aol.com and woltman@alum.mit.edu.\n",PSTRING);
 						mlucas_fprint(cbuf,1);
 					}
 				}
@@ -2521,11 +2521,11 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				// Otherwise, write the 64-bit hex residue. As of v19, we write the old-style HRF-formatted result
 				// just to the exponent-specific logfile, and the server-expected JSON-formatted result to the results file:
 				// Note that Fermat primality tests are not submitted to server, so accordingly we slightly modify the output. More info: https://github.com/primesearch/Mlucas/pull/11
-				snprintf(cbuf,STR_MAX_LEN*2, "%s is not prime. Program: E%s. Final residue shift count = %" PRIu64 ".\n",PSTRING,VERSION,RES_SHIFT);
+				snprintf(cbuf,sizeof(cbuf), "%s is not prime. Program: E%s. Final residue shift count = %" PRIu64 ".\n",PSTRING,VERSION,RES_SHIFT);
 				mlucas_fprint(cbuf,1);
-				if (MODULUS_TYPE == MODULUS_TYPE_FERMAT) snprintf(cbuf,STR_MAX_LEN*2, "Selfridge-Hurwitz residues Res64,Res35m1,Res36m1 = %016" PRIX64 ",%11" PRIu64 ",%11" PRIu64 ".\n",Res64,Res35m1,Res36m1);
+				if (MODULUS_TYPE == MODULUS_TYPE_FERMAT) snprintf(cbuf,sizeof(cbuf), "Selfridge-Hurwitz residues Res64,Res35m1,Res36m1 = %016" PRIX64 ",%11" PRIu64 ",%11" PRIu64 ".\n",Res64,Res35m1,Res36m1);
 				else {
-					snprintf(cbuf,STR_MAX_LEN*2, "If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
+					snprintf(cbuf,sizeof(cbuf), "If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
 					// v19: Finish with the JSON-formatted result line:
 					fp = mlucas_fopen(OFILE,"a");
 					if(fp) {
@@ -2535,7 +2535,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				mlucas_fprint(cbuf,1);
 			}
 		} else if (MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {	// Cofactor-PRP run:
-			snprintf(cbuf,STR_MAX_LEN*2,"If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
+			snprintf(cbuf,sizeof(cbuf),"If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
 			mlucas_fprint(cbuf,1);
 			// Write JSON-formatted result line to results file:
 			fp = mlucas_fopen(OFILE,"a");
@@ -2563,7 +2563,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 					gm_time = localtime(&calendar_time);
 				strftime(timebuffer,SIZE,"%Y-%m-%d %H:%M:%S UTC",gm_time);
 				generate_JSON_report(0,p,n,0ull,NULL,timebuffer, B1,B2,gcd_str,s2_partial, cstr);	// cstr holds JSONified output
-				snprintf(cbuf,STR_MAX_LEN*2, "If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
+				snprintf(cbuf,sizeof(cbuf), "If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
 				mlucas_fprint(cbuf,0);
 				fp = mlucas_fopen(OFILE,"a");
 				if(fp) {
@@ -2609,10 +2609,10 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 						// This snip reads the relocation-prime from the high byte of the nsquares field, byte 10 of the S2 savefile:
 						i = fgetc(fp);
 						if(!test_types_compatible(i, TEST_TYPE)) {
-							snprintf(cbuf,STR_MAX_LEN*2, "%s: TEST_TYPE != fgetc(fp)\n",cstr); ASSERT(0,cbuf);
+							snprintf(cbuf,sizeof(cbuf), "%s: TEST_TYPE != fgetc(fp)\n",cstr); ASSERT(0,cbuf);
 						}
 						if((i = fgetc(fp)) != MODULUS_TYPE) {
-							snprintf(cbuf,STR_MAX_LEN*2, "ERROR: %s: MODULUS_TYPE != fgetc(fp)\n",cstr); ASSERT(0,cbuf);
+							snprintf(cbuf,sizeof(cbuf), "ERROR: %s: MODULUS_TYPE != fgetc(fp)\n",cstr); ASSERT(0,cbuf);
 						}
 						itmp64 = 0ull; 	for(j = 0; j < 8; j++) { i = fgetc(fp);	itmp64 += (uint64)i << (8*j); }
 						fclose(fp); fp = 0x0;
@@ -2695,7 +2695,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 					gm_time = localtime(&calendar_time);
 				strftime(timebuffer,SIZE,"%Y-%m-%d %H:%M:%S UTC",gm_time);
 				generate_JSON_report(0,p,n,0ull,NULL,timebuffer, B1,B2,gcd_str,s2_partial, cstr);	// cstr holds JSONified output
-				snprintf(cbuf,STR_MAX_LEN*2, "If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
+				snprintf(cbuf,sizeof(cbuf), "If using the manual results submission form at mersenne.org, paste the following JSON-formatted results line:\n%s\n",cstr);
 				mlucas_fprint(cbuf,0);
 				fp = mlucas_fopen(OFILE,"a");
 				if(fp){
@@ -2729,7 +2729,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		*/
 		strcpy(cstr, RESTARTFILE); strcat(cstr, ".s2");
 		if(remove(cstr)) {
-			snprintf(cbuf,STR_MAX_LEN*2,"INFO: Unable to remove stage 2 savefile %s.\n",cstr);
+			snprintf(cbuf,sizeof(cbuf),"INFO: Unable to remove stage 2 savefile %s.\n",cstr);
 			mlucas_fprint(cbuf,1);
 		}
 		if(!s2_continuation) {
@@ -2744,7 +2744,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			// if primary missing/corrupt, rename secondary q[expo] ==> [p|f][expo].s1:
 			if(TEST_TYPE == TEST_TYPE_PM1 && !s2_continuation) {
 				if(rename(RESTARTFILE, cstr)) {
-					snprintf(cbuf,STR_MAX_LEN*2,"ERROR: unable to rename the p-1 stage 1 savefile %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,cstr);
+					snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename the p-1 stage 1 savefile %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,cstr);
 					mlucas_fprint(cbuf,1);
 				}
 			} else if(TEST_TYPE == TEST_TYPE_PRIMALITY || TEST_TYPE == TEST_TYPE_PRP) {
@@ -2752,7 +2752,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				if(RESTARTFILE[0] == 'q') {
 					RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
 					if(rename(cstr, RESTARTFILE)) {
-						snprintf(cbuf,STR_MAX_LEN*2,"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,cstr);
+						snprintf(cbuf,sizeof(cbuf),"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,cstr);
 						mlucas_fprint(cbuf,1);
 					}
 				} else if(remove(cstr))	// ...otherwise delete the secondary
@@ -2806,7 +2806,7 @@ GET_NEXT_ASSIGNMENT:
 	GET_NEXT:
 		/* Delete or suitably modify current-assignment line (line 1) of worktodo file: */
 		i = 0;	// This counter tells how many *additional* assignments exist in worktodo
-		if(!fgets(in_line, STR_MAX_LEN, fp)) {
+		if(!fgets(in_line, sizeof(in_line), fp)) {
 			sprintf(cbuf, "ERROR: %s file not found at end of current-assignment processing\n", WORKFILE);
 			ASSERT(0,cbuf);
 		}
@@ -2819,7 +2819,7 @@ GET_NEXT_ASSIGNMENT:
 
 		// Look for m in first eligible assignment; for F[m], need to also look for 2^m in case assignment is in KBNC format:
 		if(!strstr(in_line, ESTRING) && !(MODULUS_TYPE == MODULUS_TYPE_FERMAT && strstr(in_line, BIN_EXP)) ) {
-			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: Current exponent %s not found in line 1 of %s file - quitting.\n", ESTRING, WORKFILE);
+			snprintf(cbuf,sizeof(cbuf), "ERROR: Current exponent %s not found in line 1 of %s file - quitting.\n", ESTRING, WORKFILE);
 			ASSERT(0,cbuf);
 		} else {
 			/* If we just finished the TF or p-1 preprocessing step of an LL or PRP test,
@@ -2853,7 +2853,7 @@ GET_NEXT_ASSIGNMENT:
 					} else if(STREQN_NOCASE(char_addr,"n/a",3)) {
 						strncpy(aid,char_addr, 3);
 					} else {
-						snprintf(cbuf,STR_MAX_LEN*2,"INFO: Assignment \"%s\" lacks a valid assignment ID ... proceeding anyway.\n",in_line);
+						snprintf(cbuf,sizeof(cbuf),"INFO: Assignment \"%s\" lacks a valid assignment ID ... proceeding anyway.\n",in_line);
 						mlucas_fprint(cbuf,1);
 						aid[0] = '\0';	// This guarantees that the strstr(in_line,aid) part of on the next-assignment search below succeeds.
 					}
@@ -2861,7 +2861,7 @@ GET_NEXT_ASSIGNMENT:
 					// copy it to the fq-file. We use both the AID and binary exponent here, since the former could be some made-up
 					// value (e.g. all-0s) and the latter has a nonzero chance of appearing in the AID of an unrelated next-assignment:
 					in_line[0] = '\0';	// Careful here - if next fgets(in_line) fails, are left with old in_line, must zero it first.
-					if(fgets(in_line, STR_MAX_LEN, fp)) {
+					if(fgets(in_line, sizeof(in_line), fp)) {
 						if( (strstr(in_line, "PRP") || strstr(in_line, "Test") || strstr(in_line, "DoubleCheck"))
 						 && strstr(in_line,ESTRING) && strstr(in_line,aid) )
 						{
@@ -2875,7 +2875,7 @@ GET_NEXT_ASSIGNMENT:
 			/* Otherwise lose the current line (by way of no-op) */
 		}
 		/* Copy the remaining ones; */
-		while(fgets(in_line, STR_MAX_LEN, fp))
+		while(fgets(in_line, sizeof(in_line), fp))
 		{
 			fputs(in_line, fq);	++i;
 		}
@@ -2901,7 +2901,7 @@ GET_NEXT_ASSIGNMENT:
 				sprintf(cbuf,"Unable to open WINI.TMP file for reading.\n");
 				ASSERT(0,cbuf);
 			}
-			while(fgets(in_line, STR_MAX_LEN, fq)) {
+			while(fgets(in_line, sizeof(in_line), fq)) {
 				fputs(in_line, fp);
 			}
 			fclose(fp); fp = 0x0;
@@ -3301,20 +3301,20 @@ uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[]
 	uint32 kblocks = n>>10, npad = n + ( (n >> DAT_BITS) << PAD_BITS );	// npad = length of padded data array
 	uint64 itmp64, Res35m1, Res36m1;	// Res64 from original PRP passed in via pointer; these are locally-def'd
 	cbuf[0] = '\0';
-	snprintf(cbuf,STR_MAX_LEN*2,"Suyama-PRP on cofactors of %s: using FFT length %uK = %u 8-byte floats.\n",PSTRING,kblocks,n);//	strcat(cbuf,cstr);
+	snprintf(cbuf,sizeof(cbuf),"Suyama-PRP on cofactors of %s: using FFT length %uK = %u 8-byte floats.\n",PSTRING,kblocks,n);//	strcat(cbuf,cstr);
 	// sprintf(cstr, " this gives an average %20.15f bits per digit\n",1.0*p/n);	strcat(cbuf,cstr);
 	mlucas_fprint(cbuf,1);
 	// Pepin-test output = P, vs Mersenne-PRP (type 1) residue = A; thus only need an initial mod-squaring for:
 	// the former. Compute Fermat-PRP residue [A] from Euler-PRP (= Pepin-test) residue via a single mod-squaring:
 	if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
 		ASSERT(ilo == p-1, "Fermat-mod cofactor-PRP test requires p-1 mod-squarings!");
-		snprintf(cbuf,STR_MAX_LEN*2,"Doing one mod-%s squaring of iteration-%u residue [Res64 = %016" PRIX64 "] to get Fermat-PRP residue\n",PSTRING,ilo,*Res64);
+		snprintf(cbuf,sizeof(cbuf),"Doing one mod-%s squaring of iteration-%u residue [Res64 = %016" PRIX64 "] to get Fermat-PRP residue\n",PSTRING,ilo,*Res64);
 		mlucas_fprint(cbuf,1);
 		ilo = 0;	ihi = ilo+1;	// Have checked that savefile residue is for a complete PRP test, so reset iteration counter
 		BASE_MULTIPLIER_BITS[0] = 0ull;
 /*A*/	ierr = func_mod_square(a, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, TRUE, 0x0);
 		convert_res_FP_bytewise(a, (uint8*)ci, n, p, Res64, &Res35m1, &Res36m1);	// Overwrite passed-in Pepin-Res64 with Fermat-PRP one
-		snprintf(cbuf,STR_MAX_LEN,"MaxErr = %10.9f\n",MME); mlucas_fprint(cbuf,1);
+		snprintf(cbuf,sizeof(cbuf),"MaxErr = %10.9f\n",MME); mlucas_fprint(cbuf,1);
 	} else if (MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {	// Mersenne PRP-CF doesn't have the Res35m1 or Res36m1 values passed in,
 		res_SH(ci,n,&itmp64,&Res35m1,&Res36m1);			// so we refresh these; see https://github.com/primesearch/Mlucas/issues/27
 	} else {
@@ -3323,7 +3323,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[]
 		Res36m1 = UINT64_MAX;
 	}
 	if(ierr) {
-		snprintf(cbuf,STR_MAX_LEN*2,"Error of type[%u] = %s in mod-squaring ... aborting\n",ierr,returnMlucasErrCode(ierr));
+		snprintf(cbuf,sizeof(cbuf),"Error of type[%u] = %s in mod-squaring ... aborting\n",ierr,returnMlucasErrCode(ierr));
 		mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 	}
 	sprintf(cbuf, "Fermat-PRP residue (A)     = %#016" PRIX64 ",%11" PRIu64 ",%11" PRIu64 "\n",*Res64,Res35m1,Res36m1);
@@ -3360,7 +3360,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[]
 	mi64_brev(BASE_MULTIPLIER_BITS,ihi);	// bit-reverse low [ihi] bits of BASE_MULTIPLIER_BITS:
 /*B*/	ierr = func_mod_square(b, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, TRUE, 0x0);
 	if(ierr) {
-		snprintf(cbuf,STR_MAX_LEN*2,"Error of type[%u] = %s on iteration %u of mod-squaring chain ... aborting\n",ierr,returnMlucasErrCode(ierr),ROE_ITER);
+		snprintf(cbuf,sizeof(cbuf),"Error of type[%u] = %s on iteration %u of mod-squaring chain ... aborting\n",ierr,returnMlucasErrCode(ierr),ROE_ITER);
 		mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 	}
 	sprintf(cbuf,"Processed %u bits in binary modpow; MaxErr = %10.9f\n",ihi,MME);
@@ -3406,7 +3406,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[]
 	sprintf(cbuf,"(A - B) Res64 = %#016" PRIX64 ", C Res64 = %#016" PRIX64 "\n",ai[0],ci[0]);
 	mlucas_fprint(cbuf,1);
 	mi64_div_binary(ai,ci, i,j, curr_fac,(uint32 *)&k, bi);	// On return, k has quotient length; curr_fac[] = quo, bi[] = rem
-	snprintf(cbuf,STR_MAX_LEN*2,"(A - B)/C: Quotient = %s, Remainder Res64 = %#016" PRIX64 "\n",&cstr[convert_mi64_base10_char(cstr,curr_fac,k,0)],bi[0]);
+	snprintf(cbuf,sizeof(cbuf),"(A - B)/C: Quotient = %s, Remainder Res64 = %#016" PRIX64 "\n",&cstr[convert_mi64_base10_char(cstr,curr_fac,k,0)],bi[0]);
 	mlucas_fprint(cbuf,1);
 	// For 1-word quotient q, double-check binary-div result by computing (q*denominator + r) and comparing vs numerator:
   #if 0	/*** May 2022: This overwrites ci[], which hoses the is-cofactor-a-prime-power GCD() below ***/
@@ -3415,7 +3415,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[]
 		ASSERT(1 == mi64_cmp_eq(ai,ci,i), "Q*C + R = (A - B) check fails!");
 	}
   #endif
-	snprintf(cbuf,STR_MAX_LEN*2,"Suyama Cofactor-PRP test of %s",PSTRING);
+	snprintf(cbuf,sizeof(cbuf),"Suyama Cofactor-PRP test of %s",PSTRING);
 	// Base-2 log of cofactor = lg(Fm/F) = lg(Fm) - lg(F) ~= 2^m - lg(F). 2^m stored in p, sub lg(F) in loop below:
 	double lg_cof = p,lg_fac,log10_2 = 0.30102999566398119521;	// Use lg_fac to store log2 of each factor as we recompute it
 	for(i = 0; KNOWN_FACTORS[i] != 0ull; i += 4) {
@@ -3984,7 +3984,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 	nargs = 1;
 	while(argv[nargs])
 	{
-		strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+		strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 		if(nargs > argc) {	// == no longer applies since e.g. -prp requires no numeric arg and can come last:
 			fprintf(stderr, "*** ERROR: Unterminated command-line option or malformed argument.\n");
 			print_help();
@@ -4001,7 +4001,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 		if(STREQ(stFlag, "-s"))
 		{
 			selfTest = TRUE;
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			for(;;) {
 				if(STREQ(stFlag, "a") || STREQ(stFlag, "all")) {	/* all, which really means all the non-Huge-and-larger sets */
 					start = 0; finish = numTeensy + numTiny + numSmall + numMedium + numLarge;
@@ -4047,7 +4047,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 		else if(STREQ(stFlag, "-maxalloc"))	// maxalloc arg is max %-of-available-mem to use
 		{
 			ASSERT(nbufSet == FALSE, "Only one of -maxalloc and -pm1_s2_buf flags may be used!");
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			darg = strtod(stFlag,&cptr);
 			// Must be > 0:
 			ASSERT((darg > 0), "maxalloc (%%-of-available-mem to use) argument must be > 0 ... halting.");
@@ -4060,7 +4060,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 		else if(STREQ(stFlag, "-pm1_s2_nbuf"))	// pm1_s2_nbuf arg is max %-of-available-mem to use
 		{
 			ASSERT(maxAllocSet == FALSE, "Only one of -maxalloc and -pm1_s2_buf flags may be used!");
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			darg = strtod(stFlag,&cptr);
 			// Must be > 0:
 			ASSERT((darg > 0), "pm1_s2_nbuf argument must be integer ... halting.");
@@ -4072,7 +4072,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 
 		else if(STREQ(stFlag, "-iters"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			i64arg = atol(stFlag);
 			// Must be < 2^32:
 			ASSERT(!(i64arg>>32), "#iters argument must be < 2^32 ... halting.");
@@ -4081,7 +4081,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 
 		else if(STREQ(stFlag, "-fft") || STREQ(stFlag, "-fftlen"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			// v20: default is still integer-FFT-length in Kdoubles, but add support for [float]M,
 			// where floating-point arg must be exactly representable, such that [float]*2^10 is integer:
 			i64arg = -1ull;
@@ -4116,7 +4116,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 		set is supported and if so, set radset to the corresponding table-index numeric value: */
 		else if(STREQ(stFlag, "-radset"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 
 			// Check if it's a comma-separated actual set of complex-FFT radices:
 			char_addr = stFlag;
@@ -4174,7 +4174,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 
 		else if(STREQ(stFlag, "-shift"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			i64arg = atol(stFlag);
 			// Must be < 2^32, though store in a uint64 for later bignum-upgrades:
 			ASSERT(!(i64arg>>32), "shift argument must be < 2^32 ... halting.");
@@ -4184,7 +4184,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 		// v20: Add p-1 support:
 		else if(STREQ(stFlag, "-b1"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			i64arg = atol(stFlag);
 			// Must be < 2^32:
 			ASSERT(!(i64arg>>32), "P-1 Stage 1 bound must be < 2^32 ... halting.");
@@ -4193,14 +4193,14 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			testType = TEST_TYPE_PM1;
 		}
 		else if(STREQ(stFlag, "-b2")) {
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			// Allow Stage 2 bounds to be > 2^32:
 			B2 = atol(stFlag);
 			ASSERT(testType != TEST_TYPE_PRP, "b2-argument implies P-1 factoring; that and PRP-test types not simultaneously specifiable.");
 			testType = TEST_TYPE_PM1;
 		}
 		else if(STREQ(stFlag, "-b2_start")) {
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			// Allow Stage 2 bounds to be > 2^32:
 			B2_start = atol(stFlag);
 			ASSERT(testType != TEST_TYPE_PRP, "b2_start-argument implies P-1 factoring; that and PRP-test types not simultaneously specifiable.");
@@ -4213,7 +4213,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			ASSERT(0,"Multithreading must be enabled in build to permit -nthread argument!");
 		#else
 			ASSERT(cpu == FALSE && core == FALSE,"Only one of -nthread, -cpu and -core flags permitted!");
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			i64arg = atol(stFlag);
 			// Must be < 2^32:
 			ASSERT(!(i64arg>>32), "nthread argument must be < 2^32 ... halting.");
@@ -4231,7 +4231,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			ASSERT(0,"Multithreading must be enabled in build to permit -cpu argument!");
 		#else
 			ASSERT(nthread == FALSE && core == FALSE,"Only one of -nthread, -cpu and -core flags permitted!");
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			parseAffinityString(stFlag);
 			cpu = TRUE;
 		#endif
@@ -4244,7 +4244,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			ASSERT(0,"Multithreading must be enabled in build to permit -core argument!");
 		#else
 			ASSERT(cpu == FALSE && nthread == FALSE,"Only one of -nthread, -cpu and -core flags permitted!");
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			NTHREADS = parseAffinityTriplet(stFlag,TRUE);	// 2nd-arg = TRUE: Use hwloc-generated topology, via '-core lo:hi[:threads_per_core]'
 			if(NTHREADS > MAX_THREADS) {
 				fprintf(stderr,"ERROR: NTHREADS [ = %d] must not exceed those of available logical cores = 0-%d!\n",NTHREADS,MAX_THREADS-1);
@@ -4261,7 +4261,7 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 
 		else if(STREQ(stFlag, "-m") || STREQ(stFlag, "-mersenne"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			expo = atol(stFlag);
 			userSetExponent = 1;
 			// Use 0-pad slot in MvecPtr[] to store user-set-exponent data - that can point to either MersVec
@@ -4275,11 +4275,11 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 		else if(STREQ(stFlag, "-prp"))	// This flag optionally takes a numeric base arg, and trips us into PRP-test mode
 		{
 			if(nargs < argc) {
-				strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+				strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 				if(isdigit(stFlag[0])) {
 					PRP_BASE = atol(stFlag);
 					if(PRP_BASE+1 == 0) {
-						snprintf(cbuf,STR_MAX_LEN*2, "*** ERROR: Numeric arg to -prp flag, '%s', overflows uint32 field.\n", stFlag);
+						snprintf(cbuf,sizeof(cbuf), "*** ERROR: Numeric arg to -prp flag, '%s', overflows uint32 field.\n", stFlag);
 						ASSERT(0,cbuf);
 					}
 				}
@@ -4301,14 +4301,14 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 
 		else if(STREQ(stFlag, "-base"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			i64arg = atol(stFlag);
 			PRP_BASE = (uint32)i64arg;
 		}
 
 		else if(STREQ(stFlag, "-f") || STREQ(stFlag, "-fermat"))
 		{
-			strncpy(stFlag, argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, argv[nargs++], sizeof(stFlag)-1);
 			i64arg = atol(stFlag);
 			// Must be < 2^32:
 			ASSERT(!(i64arg>>32), "Fermat-number-index argument must be < 2^32 ... halting.");
@@ -4592,7 +4592,7 @@ TIMING_TEST_LOOP:
 		/* Program version string assumed to be stored in line 1 of .cfg file -
 		if it's not, the .cfg file is by definition outdated:
 		*/
-		if(fgets(in_line, STR_MAX_LEN, fp))
+		if(fgets(in_line, sizeof(in_line), fp))
 			new_cfg = cfgNeedsUpdating(in_line);
 		else
 			new_cfg = TRUE;
@@ -4847,23 +4847,23 @@ uint64	parse_cmd_args_get_shift_value(void)
 	int i, nargs = 1;
 	while(global_argv[nargs])
 	{
-		strncpy(stFlag, global_argv[nargs++], STR_MAX_LEN-1);
+		strncpy(stFlag, global_argv[nargs++], sizeof(stFlag)-1);
 		if(STREQ(stFlag, "-shift"))
 		{
-			strncpy(stFlag, global_argv[nargs++], STR_MAX_LEN-1);
+			strncpy(stFlag, global_argv[nargs++], sizeof(stFlag)-1);
 			/* Convert the shift argument to a uint64: */
 			i64arg = 0;
-			for(i = 0; i < STR_MAX_LEN && stFlag[i] != '\0'; i++) {
+			for(i = 0; i < sizeof(stFlag) && stFlag[i] != '\0'; i++) {
 				if(isdigit(stFlag[i])) {
 					i64arg = 10*i64arg + (stFlag[i]-CHAROFFSET);
 					/* Check for overflow: */
 					if(i64arg % (uint64)10 != (uint64)(stFlag[i]-CHAROFFSET))
 					{
-						snprintf(cbuf,STR_MAX_LEN*2, "*** ERROR: -shift argument %s overflows uint64 field.\n", stFlag);
+						snprintf(cbuf,sizeof(cbuf), "*** ERROR: -shift argument %s overflows uint64 field.\n", stFlag);
 						fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
 					}
 				} else {
-					snprintf(cbuf,STR_MAX_LEN*2, "*** ERROR: Non-numeric character encountered in -shift argument %s.\n", stFlag);
+					snprintf(cbuf,sizeof(cbuf), "*** ERROR: Non-numeric character encountered in -shift argument %s.\n", stFlag);
 					fprintf(stderr,"%s", cbuf);	ASSERT(0,cbuf);
 				}
 			}
@@ -5278,7 +5278,7 @@ int read_ppm1_savefiles(const char*fname, uint64 p, uint32*kblocks, FILE*fp, uin
 			mi64_scalar_modpow_lr(PRP_BASE, exp, KNOWN_FACTORS+i, j, pow);
 			sprintf(cstr,"\tB: R == %s (mod q)\n",&cbuf[convert_mi64_base10_char(cbuf, pow, j, 0)] ); mlucas_fprint(cstr,1);
 			if (mi64_getlen(pow,4) != k || !mi64_cmp_eq(pow,rem,k)) {
-				snprintf(cbuf,STR_MAX_LEN,"Full-residue == %u^nsquares (mod q) check fails!", PRP_BASE); mlucas_fprint(cbuf,0);
+				snprintf(cbuf,sizeof(cbuf),"Full-residue == %u^nsquares (mod q) check fails!", PRP_BASE); mlucas_fprint(cbuf,0);
 				ASSERT(0, cbuf);
 			}
 		}
@@ -5372,7 +5372,7 @@ void write_ppm1_residue(const uint32 nbytes, FILE*fp, const uint8 arr_tmp[], con
 	i = fwrite(arr_tmp, sizeof(char), nbytes, fp);
 	if(i != nbytes) {
 		fclose(fp); fp = 0x0;
-		snprintf(cbuf,STR_MAX_LEN*2,"%s: Error writing residue to restart file.\n",func);
+		snprintf(cbuf,sizeof(cbuf),"%s: Error writing residue to restart file.\n",func);
 		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 	}
 	/* ...and checksums:	*/
@@ -6169,14 +6169,14 @@ void generate_JSON_report(
 	ASSERT((fp = mlucas_fopen(WORKFILE, "r")) != 0x0,"Workfile not found!");
 	// v20.1.1: Parse first line whose leading non-WS char is alphabetic:
 	char_addr = 0x0;
-	while(fgets(in_line, STR_MAX_LEN, fp) != 0x0) {
+	while(fgets(in_line, sizeof(in_line), fp) != 0x0) {
 		char_addr = in_line; while(isspace(*char_addr)) { ++char_addr; }
 		if(isalpha(*char_addr)) break;
 	}
 	fclose(fp); fp = 0x0;
 	ASSERT(strlen(char_addr) != 0 && isalpha(*char_addr),"Eligible assignment (leading non-WS char alphabetic) not found in workfile!");
 	if(!strstr(in_line, ESTRING) && !(MODULUS_TYPE == MODULUS_TYPE_FERMAT && strstr(in_line, BIN_EXP)) ) {
-		snprintf(cbuf,STR_MAX_LEN*2, "ERROR: Current exponent %s not found in %s file!\n",ESTRING,WORKFILE);
+		snprintf(cbuf,sizeof(cbuf), "ERROR: Current exponent %s not found in %s file!\n",ESTRING,WORKFILE);
 		ASSERT(0,cbuf);
 	}
 	// Is there a Primenet-server 32-hexit assignment ID in the assignment line? If so, include it in the JSON output:
@@ -6381,7 +6381,7 @@ uint32 extract_known_factors(uint64 p, char*fac_start) {
 				if(mi64_cmp_eq(KNOWN_FACTORS + 4*i, KNOWN_FACTORS + 4*(nfac-1), 4)) {
 					mi64_clear(KNOWN_FACTORS + 4*(--nfac), 4);
 					// Using cbuf as both string-arg and target string is problematic, so use 2nd string-global cstr as target:
-					snprintf(cstr,STR_MAX_LEN, "WARNING: p = %" PRIu64 ", known-factor list entry %s is a duplicate ... removing.\n",p,cbuf);
+					snprintf(cstr,sizeof(cstr), "WARNING: p = %" PRIu64 ", known-factor list entry %s is a duplicate ... removing.\n",p,cbuf);
 					fprintf(stderr,"%s",cstr);
 				}
 			}
@@ -6456,7 +6456,7 @@ The decimal value of the GCD is returned in gcd_str, presumed to be dimensioned 
 uint32 gcd(uint32 stage, uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb, char*const gcd_str) {
 #if !INCLUDE_GMP
 	#warning INCLUDE_GMP defined == 0 at compile time ... No GCDs will be done on p-1 outputs.
-	snprintf(cbuf,STR_MAX_LEN*2,"INCLUDE_GMP defined == 0 at compile time ... No GCD will be done.\n");
+	snprintf(cbuf,sizeof(cbuf),"INCLUDE_GMP defined == 0 at compile time ... No GCD will be done.\n");
 	mlucas_fprint(cbuf,1);
 	return 0;	// If user turns off p-1 support, keep the decl of gcd() to allow pm1.c to build
 #else
@@ -6512,24 +6512,24 @@ uint32 gcd(uint32 stage, uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb, char*
 	gmp_size = mpz_sizeinbase(gmp_arr1,10);
 	// Anything >= 900 digits (~90% the value of our STR_MAX_LEN dimensioning of I/O strings) treated as suspect:
 	if(gmp_size >= 900) {
-		snprintf(cbuf,STR_MAX_LEN*2, "GCD has %u digits -- possible data corruption, aborting.\n",(uint32)gmp_size);
+		snprintf(cbuf,sizeof(cbuf), "GCD has %u digits -- possible data corruption, aborting.\n",(uint32)gmp_size);
 		mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 	}
 	retval = 1;
 gcd_return:
 	if(!p) {
-		gmp_snprintf(gcd_str,STR_MAX_LEN,"%Zd",gmp_arr1);
-		gmp_snprintf(cbuf,STR_MAX_LEN*2,"GCD(A[%" PRIu64 " bits], B[%" PRIu64 " bits]) = %s\n",sz1,sz2,gcd_str);
+		gmp_snprintf(gcd_str,sizeof(gcd_str),"%Zd",gmp_arr1);
+		gmp_snprintf(cbuf,sizeof(cbuf),"GCD(A[%" PRIu64 " bits], B[%" PRIu64 " bits]) = %s\n",sz1,sz2,gcd_str);
 	} else if(retval) {
-		gmp_snprintf(gcd_str,STR_MAX_LEN,"%Zd",gmp_arr1);
-		gmp_snprintf(cbuf,STR_MAX_LEN*2,"Found %u-digit factor in Stage %u: %s\n",gmp_size,stage,gcd_str);
+		gmp_snprintf(gcd_str,sizeof(gcd_str),"%Zd",gmp_arr1);
+		gmp_snprintf(cbuf,sizeof(cbuf),"Found %u-digit factor in Stage %u: %s\n",gmp_size,stage,gcd_str);
 	} else {	// Caller can use either return value or empty gcd_str as proxy for "no factor found"
 		gcd_str[0] = '\0';
-		gmp_snprintf(cbuf,STR_MAX_LEN*2,"Stage %u: No factor found.\n",stage);
+		gmp_snprintf(cbuf,sizeof(cbuf),"Stage %u: No factor found.\n",stage);
 	}
 	mlucas_fprint(cbuf,1);
 	clock2 = getRealTime(); tdiff = clock2 - clock1;
-	snprintf(cbuf,STR_MAX_LEN*2,"Time for GCD =%s\n",get_time_str(tdiff));
+	snprintf(cbuf,sizeof(cbuf),"Time for GCD =%s\n",get_time_str(tdiff));
 	mlucas_fprint(cbuf,1);
 	// Done with the GMP arrays:
 	mpz_clear(gmp_arr1); mpz_clear(gmp_arr2); mpz_clear(gmp_d); mpz_clear(gmp_r); mpz_clear(gmp_q);
@@ -6591,7 +6591,7 @@ void modinv(uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb) {
 	// Return inverse in gmp_arr1:
 	retval = mpz_invert(gmp_arr1, gmp_arr1,gmp_arr2);
 	if(!retval) {
-		snprintf(cbuf,STR_MAX_LEN*2,"MODINV: Fatal error: inverse does not exist.\n");
+		snprintf(cbuf,sizeof(cbuf),"MODINV: Fatal error: inverse does not exist.\n");
 		mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 	}
 	// Export the result from gmp_arr1 to destination array vec2:
@@ -6644,7 +6644,7 @@ uint32 filegrep(const char*fname, const char*find_str, char*cstr, uint32 find_be
 		return 0;
 	FILE*fptr = mlucas_fopen(fname,"r");
 	if(fptr){
-		while(fgets(in_line, STR_MAX_LEN, fptr)) {
+		while(fgets(in_line, sizeof(in_line), fptr)) {
 			++curr_line;
 			if(find_before_line_number && curr_line >= find_before_line_number)
 				break;

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -6380,9 +6380,7 @@ uint32 extract_known_factors(uint64 p, char *fac_start) {
 				// Incremented nfac already, so just-added entry in slot (nfac-1):
 				if(mi64_cmp_eq(KNOWN_FACTORS + 4*i, KNOWN_FACTORS + 4*(nfac-1), 4)) {
 					mi64_clear(KNOWN_FACTORS + 4*(--nfac), 4);
-					// Using cbuf as both string-arg and target string is problematic, so use 2nd string-global cstr as target:
-					snprintf(cstr,sizeof(cstr), "WARNING: p = %" PRIu64 ", known-factor list entry %s is a duplicate ... removing.\n",p,cbuf);
-					fprintf(stderr,"%s",cstr);
+					fprintf(stderr, "WARNING: p = %" PRIu64 ", known-factor list entry %s is a duplicate ... removing.\n",p,cbuf);
 				}
 			}
 		}

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -6516,10 +6516,13 @@ uint32 gcd(uint32 stage, uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb, cha
 	retval = 1;
 gcd_return:
 	if(!p) {
-		gmp_snprintf(gcd_str,sizeof(gcd_str),"%Zd",gmp_arr1);
+		// gcd_str is a char*-typed parameter here (caller's actual array is dimensioned
+		// STR_MAX_LEN, see this function's header comment) - sizeof(gcd_str) would just be
+		// the pointer size, silently truncating the printed value, so use STR_MAX_LEN directly:
+		gmp_snprintf(gcd_str,STR_MAX_LEN,"%Zd",gmp_arr1);
 		gmp_snprintf(cbuf,sizeof(cbuf),"GCD(A[%" PRIu64 " bits], B[%" PRIu64 " bits]) = %s\n",sz1,sz2,gcd_str);
 	} else if(retval) {
-		gmp_snprintf(gcd_str,sizeof(gcd_str),"%Zd",gmp_arr1);
+		gmp_snprintf(gcd_str,STR_MAX_LEN,"%Zd",gmp_arr1);
 		gmp_snprintf(cbuf,sizeof(cbuf),"Found %u-digit factor in Stage %u: %s\n",gmp_size,stage,gcd_str);
 	} else {	// Caller can use either return value or empty gcd_str as proxy for "no factor found"
 		gcd_str[0] = '\0';

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -76,28 +76,28 @@ uint32	ernstMain
 );
 
 uint64	parse_cmd_args_get_shift_value(void);
-int		is_hex_string(char*s, int len);
-char*	check_kbnc(char*in_str, uint64*p);
+int		is_hex_string(const char *s, int len);
+char	*check_kbnc(char *in_str, uint64 *p);
 void	generate_JSON_report(
-	const uint32 isprime, const uint64 p, const uint32 n, const uint64 Res64, const char* Res2048, const char*timebuffer,
-	const uint32 B1, const uint64 B2, const char*factor, const uint32 s2_partial, char*cstr
+	const uint32 isprime, const uint64 p, const uint32 n, const uint64 Res64, const char *Res2048, const char *timebuffer,
+	const uint32 B1, const uint64 B2, const char *factor, const uint32 s2_partial, char *cstr
 );
 void	print_help(void);
-int		cfgNeedsUpdating(char*in_line);
-const char*returnMlucasErrCode(uint32 ierr);
+int		cfgNeedsUpdating(const char *in_line);
+const char *returnMlucasErrCode(uint32 ierr);
 void	printMlucasErrCode(uint32 ierr);
 uint64 	shift_word(double a[], int n, const uint64 p, const uint64 shift, const double cy_in);
-uint32	Suyama_CF_PRP(uint64 p, uint64*Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
+uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
-	int n, int scrnFlag, double *tdiff, char*const gcd_str);
+	int n, int scrnFlag, double *tdiff, char *const gcd_str);
 int		test_types_compatible(uint32 t1, uint32 t2);
-int		 read_ppm1_residue(const uint32 nbytes, FILE*fp,       uint8 arr_tmp[],       uint64*Res64,       uint64*Res35m1,       uint64*Res36m1);
-void	write_ppm1_residue(const uint32 nbytes, FILE*fp, const uint8 arr_tmp[], const uint64 Res64, const uint64 Res35m1, const uint64 Res36m1);
-int		 read_ppm1_savefiles(const char*fname, uint64 p, uint32*kblocks, FILE*fp, uint64*ilo, uint8 arr1[], uint64*Res64, uint64*Res35m1, uint64*Res36m1, uint8 arr2[], uint64*i1, uint64*i2, uint64*i3);
-void	write_ppm1_savefiles(const char*fname, uint64 p,          int n, FILE*fp, uint64 ihi, uint8 arr1[], uint64 Res64, uint64 Res35m1, uint64 Res36m1, uint8 arr2[], uint64 i1, uint64 i2, uint64 i3);
+int		 read_ppm1_residue(const uint32 nbytes, FILE *fp,       uint8 arr_tmp[],       uint64 *Res64,       uint64 *Res35m1,       uint64 *Res36m1);
+void	write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], const uint64 Res64, const uint64 Res35m1, const uint64 Res36m1);
+int		 read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, uint64 *ilo, uint8 arr1[], uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1, uint8 arr2[], uint64 *i1, uint64 *i2, uint64 *i3);
+void	write_ppm1_savefiles(const char *fname, uint64 p,          int n, FILE *fp, uint64 ihi, uint8 arr1[], uint64 Res64, uint64 Res35m1, uint64 Res36m1, uint8 arr2[], uint64 i1, uint64 i2, uint64 i3);
 int		convert_res_bytewise_FP(const uint8 ui64_arr_in[], double a[], int n, const uint64 p);
-void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, const uint64 p, uint64*Res64, uint64*Res35m1, uint64*Res36m1);
-void	res_SH(uint64 a[], uint32 len, uint64*Res64, uint64*Res35m1, uint64*Res36m1);
+void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, const uint64 p, uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1);
+void	res_SH(uint64 a[], uint32 len, uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1);
 uint32	get_default_factoring_depth(uint64 p);
 // Sets function pointers for DIF|DIT pass1 based on value of radix0:
 void dif1_dit1_func_name(
@@ -105,11 +105,11 @@ void dif1_dit1_func_name(
 	void (**func_dif_pass1)(double [], int),
 	void (**func_dit_pass1)(double [], int)
 );
-uint32	extract_known_factors(uint64 p, char*fac_start);
-uint32	gcd(uint32 stage, uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb, char*const gcd_str);
-void	modinv(uint64 p, uint64*vec1, uint64*vec2, uint32 nlimb);
-int		restart_file_valid(const char*fname, const uint64 p, uint8*arr1, uint8*arr2);
-uint32	filegrep(const char*fname, const char*find_str, char*cstr, uint32 find_before_line_number);
+uint32	extract_known_factors(uint64 p, char *fac_start);
+uint32	gcd(uint32 stage, uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb, char *const gcd_str);
+void	modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb);
+int		restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *arr2);
+uint32	filegrep(const char *fname, const char *find_str, char *cstr, uint32 find_before_line_number);
 void	write_fft_debug_data(double a[], int jlo, int jhi);
 
 /* pm1.c: */
@@ -117,15 +117,15 @@ uint32	pm1_set_bounds(const uint64 p, const uint32 n, const uint32 tf_bits, cons
 uint32	pm1_check_bounds();
 uint32	compute_pm1_s1_product(const uint64 p);
 uint32	pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uint32 *nmul, uint64 *maxmult);
-int		 read_pm1_s1_prod(const char*fname, uint64 p, uint32*nbits, uint64 arr[], uint64*sum64);
-int		write_pm1_s1_prod(const char*fname, uint64 p, uint32 nbits, uint64 arr[], uint64 sum64);
-void	pm1_bigstep_size(uint32 *nbuf, uint32*bigstep, uint32*m, const uint32 psmall);
+int		 read_pm1_s1_prod(const char *fname, uint64 p, uint32 *nbits, uint64 arr[], uint64 *sum64);
+int		write_pm1_s1_prod(const char *fname, uint64 p, uint32 nbits, uint64 arr[], uint64 sum64);
+void	pm1_bigstep_size(uint32 *nbuf, uint32 *bigstep, uint32 *m, const uint32 psmall);
 int		modpow(double a[], double b[], uint32 input_is_int, uint64 pow,
 			int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 			uint64 p, int n, int scrnFlag, double *tdiff);
-int		pm1_stage2(uint64 p, uint32 bigstep, uint32 m, double pow[], double*mult[], uint64 arr_scratch[],
+int		pm1_stage2(uint64 p, uint32 bigstep, uint32 m, double pow[], double *mult[], uint64 arr_scratch[],
 			int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
-			int n, int scrnFlag, double *tdiff, char*const gcd_str);
+			int n, int scrnFlag, double *tdiff, char *const gcd_str);
 
 /* br.c: */
 void	print_pow2_twiddles(const uint32 n, const uint32 p, const uint32 q);
@@ -369,60 +369,60 @@ void	radix32_dit_pass	(double a[], int n, struct complex rt0[], struct complex r
 
 #ifdef MULTITHREAD
 	/* Multithreaded version must be in form of 1-arg functor */
-	void *mers_process_chunk  (void*targ);
-	void *fermat_process_chunk(void*targ);
+	void *mers_process_chunk  (void *targ);
+	void *fermat_process_chunk(void *targ);
 	// These are shared by both mers and fermat-mod, although the code contains switches to invoke the corr. carry macros:
-	void *cy12_process_chunk(void*targ);
-	void *cy16_process_chunk(void*targ);
-	void *cy20_process_chunk(void*targ);
-	void *cy24_process_chunk(void*targ);
-	void *cy28_process_chunk(void*targ);
-	void *cy32_process_chunk(void*targ);
-	void *cy36_process_chunk(void*targ);
-	void *cy40_process_chunk(void*targ);
-	void *cy44_process_chunk(void*targ);
-	void *cy48_process_chunk(void*targ);
-	void *cy52_process_chunk(void*targ);
-	void *cy56_process_chunk(void*targ);
-	void *cy60_process_chunk(void*targ);
-	void *cy63_process_chunk(void*targ);
-	void *cy64_process_chunk(void*targ);
-	void *cy72_process_chunk(void*targ);
-	void *cy80_process_chunk(void*targ);
-	void *cy88_process_chunk(void*targ);
-	void *cy96_process_chunk(void*targ);
-	void *cy104_process_chunk(void*targ);
-	void *cy112_process_chunk(void*targ);
-	void *cy120_process_chunk(void*targ);
-	void *cy128_process_chunk(void*targ);
-	void *cy144_process_chunk(void*targ);
-	void *cy160_process_chunk(void*targ);
-	void *cy176_process_chunk(void*targ);
-	void *cy192_process_chunk(void*targ);
-	void *cy208_process_chunk(void*targ);
-	void *cy224_process_chunk(void*targ);
-	void *cy240_process_chunk(void*targ);
-	void *cy256_process_chunk(void*targ);
-	void *cy288_process_chunk(void*targ);
-	void *cy320_process_chunk(void*targ);
-	void *cy352_process_chunk(void*targ);
-	void *cy384_process_chunk(void*targ);
-	void *cy416_process_chunk(void*targ);
-	void *cy448_process_chunk(void*targ);
-	void *cy480_process_chunk(void*targ);
-	void *cy512_process_chunk(void*targ);
-	void *cy576_process_chunk(void*targ);
-	void *cy640_process_chunk(void*targ);
-	void *cy704_process_chunk(void*targ);
-	void *cy768_process_chunk(void*targ);
-	void *cy832_process_chunk(void*targ);
-	void *cy896_process_chunk(void*targ);
-	void *cy960_process_chunk(void*targ);
-	void *cy992_process_chunk(void*targ);
-	void *cy1008_process_chunk(void*targ);
-	void *cy1024_process_chunk(void*targ);
-	void *cy4032_process_chunk(void*targ);
-	void *cy4096_process_chunk(void*targ);
+	void *cy12_process_chunk(void *targ);
+	void *cy16_process_chunk(void *targ);
+	void *cy20_process_chunk(void *targ);
+	void *cy24_process_chunk(void *targ);
+	void *cy28_process_chunk(void *targ);
+	void *cy32_process_chunk(void *targ);
+	void *cy36_process_chunk(void *targ);
+	void *cy40_process_chunk(void *targ);
+	void *cy44_process_chunk(void *targ);
+	void *cy48_process_chunk(void *targ);
+	void *cy52_process_chunk(void *targ);
+	void *cy56_process_chunk(void *targ);
+	void *cy60_process_chunk(void *targ);
+	void *cy63_process_chunk(void *targ);
+	void *cy64_process_chunk(void *targ);
+	void *cy72_process_chunk(void *targ);
+	void *cy80_process_chunk(void *targ);
+	void *cy88_process_chunk(void *targ);
+	void *cy96_process_chunk(void *targ);
+	void *cy104_process_chunk(void *targ);
+	void *cy112_process_chunk(void *targ);
+	void *cy120_process_chunk(void *targ);
+	void *cy128_process_chunk(void *targ);
+	void *cy144_process_chunk(void *targ);
+	void *cy160_process_chunk(void *targ);
+	void *cy176_process_chunk(void *targ);
+	void *cy192_process_chunk(void *targ);
+	void *cy208_process_chunk(void *targ);
+	void *cy224_process_chunk(void *targ);
+	void *cy240_process_chunk(void *targ);
+	void *cy256_process_chunk(void *targ);
+	void *cy288_process_chunk(void *targ);
+	void *cy320_process_chunk(void *targ);
+	void *cy352_process_chunk(void *targ);
+	void *cy384_process_chunk(void *targ);
+	void *cy416_process_chunk(void *targ);
+	void *cy448_process_chunk(void *targ);
+	void *cy480_process_chunk(void *targ);
+	void *cy512_process_chunk(void *targ);
+	void *cy576_process_chunk(void *targ);
+	void *cy640_process_chunk(void *targ);
+	void *cy704_process_chunk(void *targ);
+	void *cy768_process_chunk(void *targ);
+	void *cy832_process_chunk(void *targ);
+	void *cy896_process_chunk(void *targ);
+	void *cy960_process_chunk(void *targ);
+	void *cy992_process_chunk(void *targ);
+	void *cy1008_process_chunk(void *targ);
+	void *cy1024_process_chunk(void *targ);
+	void *cy4032_process_chunk(void *targ);
+	void *cy4096_process_chunk(void *targ);
 #else
   #ifdef USE_FGT61
 	void mers_process_chunk  (double a[], int arr_scratch[], int n, struct complex rt0[], struct complex rt1[], uint128 mt0[], uint128 mt1[], int index[], int block_index[], int ii, int nradices_prim, int radix_prim[], int ws_i[], int ws_j1[], int ws_j2[], int ws_j2_start[], int ws_k[], int ws_m[], int ws_blocklen[], int ws_blocklen_sum[], uint64 fwd_fft_only);

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -6943,7 +6943,7 @@ printf("\n");
 		} else {
 			fquo = rem64*fqinv;
 			if(fquo >= 0.99999999999999 && fquo < 1.0) { // CXC: Give fquo a tiny push if we are in the 2nd pass, to ensure a 0.9999999999999 value actually gets to 1.0;
-				fprintf(stderr,"WARNING: floating point round-off error, %llu * %1.16f = %1.16f (should be an integer)\n", rem64, fqinv, fquo);
+				fprintf(stderr,"WARNING: floating point round-off error, %" PRIu64 " * %1.16f = %1.16f (should be an integer)\n", rem64, fqinv, fquo);
 				fquo += 0.00000000000001; // see https://github.com/primesearch/Mlucas/issues/18
 			}
 			itmp64 += (uint64)fquo;

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -316,7 +316,7 @@ __device__
 uint64	mi64_shl(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
 {
 	int i;
-	uint32 nwshift = (nshift >> 6), rembits = (nshift & 63), m64bits;
+	uint32 nwshift = (nshift >> 6), rembits = (nshift & 63);
 	uint64 lo64 = 0ull;
 	ASSERT(len != 0, "mi64_shl: zero-length array!");
 	// Special-casing for 0 shift count:
@@ -490,7 +490,7 @@ __device__
 uint32	mi64_shlc_bits_align(const uint64 x[], uint64 y[], uint32 nbits)
 {
 	uint64 x0,y0,ywindow64;
-	uint32 len = (nbits+63)>>6, i,match = 0, curr_word,curr_bit,main_part,high_part,hi_word_bits = nbits&63;
+	uint32 len = (nbits+63)>>6, i,match = 0, curr_word,curr_bit,main_part,high_part;
 	// W/o the extra "& (nbits&63)" this assumes nbits != 0, i.e. unsuitable for Fermats:
 	uint64 mask64 = (-1ull << (nbits&63)) & (uint64)(nbits&63);
 	ASSERT(x && y && len, "mi64_shlc_bits_align: null input pointer or zero-length array!");
@@ -543,7 +543,7 @@ __device__
 uint32	mi64_shlc_bits_limb0(const uint64 x0, const uint64 y[], uint32 nbits)
 {
 	uint64 y0,ywindow64;
-	uint32 len = (nbits+63)>>6, i, curr_word,curr_bit,main_part,high_part,hi_word_bits = nbits&63;
+	uint32 len = (nbits+63)>>6, i, curr_word,curr_bit,main_part,high_part;
 	// W/o the extra "& (nbits&63)" this assumes nbits != 0, i.e. unsuitable for Fermats:
 	uint64 mask64 = (-1ull << (nbits&63)) & (uint64)(nbits&63);
 	ASSERT(y && len, "mi64_shlc_bits_limb0: null input pointer or zero-length array!");
@@ -710,10 +710,22 @@ uint64	mi64_shl_short(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
   #elif defined(USE_AVX)	// SSE2/AVX - use SSE2 ASM for both cases - do 8 words per ASM-lop pass, must skip x[0:1]
 	const uint32 BLOCKLENM1 = 7, BASEADDRMASK = 0x0F;	uint32 minlen = 9;
   #elif defined(YES_ASM)
-	const uint32 BLOCKLENM1 = 3, BASEADDRMASK = 0x07;	uint32 minlen = 5;
+	const uint32 BLOCKLENM1 = 3/* , BASEADDRMASK = 0x07 */;	uint32 minlen = 5;
   #endif
-	int i, i0 = 0, i1 = 1, use_asm = FALSE, x_misalign = 0, y_misalign = 0;
-	uint32 m64bits = (64-nshift), leftover = 0;
+	int i, i0 = 0, i1 = 1;
+  #ifdef MI64_SHL1_DBG
+	int use_asm = FALSE, x_misalign = 0, y_misalign = 0;
+  #elif defined(YES_ASM)
+	int use_asm = FALSE;
+	#if defined(USE_AVX)
+	int x_misalign = 0;
+	#endif
+	#if !defined(USE_AVX512) && !defined(USE_AVX2) && defined(USE_AVX)
+	int y_misalign = 0;
+	#endif
+	uint32 leftover = 0;
+  #endif
+	uint32 m64bits = (64-nshift);
 	uint64 lo64 = 0ull;
 	ASSERT(len != 0 && nshift < 64, "mi64_shl: zero-length array or shift count >= 64!");
 	// Special-casing for 0 shift count:
@@ -772,7 +784,12 @@ uint64	mi64_shl_short(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
 		if( ((uintptr_t)x & 0x7) != 0 || ((uintptr_t)y & 0x7) != 0 )
 			ASSERT(0, "require 8-byte alignment of x,y!");
 		// In SIMD-ASM case, x_misalign = (0,1,2, or 3) how many words x[0] is above next-lower alignment boundary:
-		x_misalign = ((uintptr_t)x & BASEADDRMASK)>>3;	y_misalign = ((uintptr_t)y & BASEADDRMASK)>>3;
+	  #if defined(USE_AVX)
+		x_misalign = ((uintptr_t)x & BASEADDRMASK)>>3;
+	  #endif
+	  #if !defined(USE_AVX512) && !defined(USE_AVX2) && defined(USE_AVX)
+		y_misalign = ((uintptr_t)y & BASEADDRMASK)>>3;
+	  #endif
 
 		if(len >= minlen) {	// Low-end clean-up loop runs from i = i0 downward thru i = 1 ... x[0] handled separately:
 		  #ifdef USE_AVX2
@@ -1132,7 +1149,7 @@ __device__
 uint64	mi64_shrl_short_ref(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
 {
 	int i;
-	uint32 m64bits = (64-nshift), leftover = 0;
+	uint32 m64bits = (64-nshift);
 	uint64 hi64 = 0ull;
 	ASSERT(len != 0 && nshift < 64, "mi64_shl: zero-length array or shift count >= 64!");
 	// Special-casing for 0 shift count:
@@ -1166,8 +1183,19 @@ uint64	mi64_shrl_short(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
   #elif defined(YES_ASM)
 	const uint32 BLOCKLENM1 = 3, BASEADDRMASK = 0x07;	uint32 minlen = 5;
   #endif
-	int i, i0 = 0, i1 = 0, use_asm = FALSE, x_misalign, y_misalign;
-	uint32 m64bits = (64-nshift), leftover = 0;
+	int i, i0 = 0, i1 = 0;
+  #ifdef MI64_SHR1_DBG
+	int use_asm = FALSE, x_misalign, y_misalign;
+	uint32 leftover = 0;
+  #elif defined(YES_ASM)
+	int use_asm = FALSE;
+	int x_misalign;
+	#if !defined(USE_AVX512) && !defined(USE_AVX2) && defined(USE_AVX)
+	int y_misalign;
+	#endif
+	uint32 leftover = 0;
+  #endif
+	uint32 m64bits = (64-nshift);
 	uint64 hi64 = 0ull;
 	ASSERT(len != 0 && nshift < 64, "mi64_shl: zero-length array or shift count >= 64!");
 	// Special-casing for 0 shift count:
@@ -1224,7 +1252,10 @@ uint64	mi64_shrl_short(const uint64 x[], uint64 y[], uint32 nshift, uint32 len)
 		*/
 		if( ((uintptr_t)x & 0x7) != 0 || ((uintptr_t)y & 0x7) != 0 )
 			ASSERT(0, "require 8-byte alignment of x,y!");
-		x_misalign = ((uintptr_t)x & BASEADDRMASK)>>3;	y_misalign = ((uintptr_t)y & BASEADDRMASK)>>3;
+		x_misalign = ((uintptr_t)x & BASEADDRMASK)>>3;
+	  #if !defined(USE_AVX512) && !defined(USE_AVX2) && defined(USE_AVX)
+		y_misalign = ((uintptr_t)y & BASEADDRMASK)>>3;
+	  #endif
 
 		// minlen may have been incr. for alignment purposes, so use_asm not an unconditional TRUE here
 		if(len >= minlen && x_misalign != 0) {	// Low-end clean-up loop runs from i = 0 upward thru i = i0-1
@@ -3036,8 +3067,8 @@ void	mi64_sqr_vector(const uint64 x[], uint64 z[], uint32 len, uint64 u[])
 void	mi64_sqr_vector(const uint64 x[], uint64 z[], uint32 len)
 #endif
 {
-	const char func[] = "mi64_sqr_vector";
   #if MI64_SQR_DBG
+	const char func[] = "mi64_sqr_vector";
 	uint32 dbg = STREQ(&s0[convert_mi64_base10_char(s0, x, len, 0)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"
 	if(dbg)
 		printf("%s: len = %u\n",func,len);
@@ -3347,8 +3378,11 @@ Could consider some fast way of computing said carry, e.g. computing approximate
 #endif
 void	mi64_mul_vector_hi_trunc(const uint64 x[], const uint64 y[], uint64 z[], uint32 len)
 {
-	int i0,idx,i,j, lm1 = len-1;	// j must be signed for purposes of loop control
-	uint64 tprod[2], cy;
+	int i0,idx,i,j;	// j must be signed for purposes of loop control
+#if 0
+	int lm1 = len-1;
+#endif
+	uint64 tprod[2];
 	static uint64 *u = 0x0, *v = 0x0;	// Scratch arrays for storing intermediate scalar*vector products
 	static uint32 dimU = 0;
 	ASSERT(len != 0, "zero-length X-array!");
@@ -3956,7 +3990,7 @@ uint32 mi64_pprimeF(const uint64 p[], uint64 z, uint32 len)
 	/*	static uint64 *y, *n, *zvec, *apad, *prod, *tmp;	*/
 		const uint32 max_dim = 4096;
 		uint64 n[max_dim],ninv[max_dim], prod[2*max_dim], *lo = prod,*hi = 0x0, i64;
-		uint32 nbits, log2_numbits, wlen,wlen2, retval, lenq, alen, q32,qi32;
+		uint32 nbits, log2_numbits, wlen,wlen2, q32,qi32;
 		int i,j, start_index;
 	  #if MI64_PRP_DBG
 		int dbg = STREQ(&cbuf[convert_mi64_base10_char(cbuf, n, len, 0)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"
@@ -4092,7 +4126,7 @@ uint32 mi64_pprimeF(const uint64 p[], uint64 z, uint32 len)
 	*/
 	/*	static uint64 *y, *n, *zvec, *apad, *prod, *tmp;	*/
 		uint64 npad[2048], prod[2048];
-		uint32 len2 = len+len, wlen, retval, lenq, alen;
+		uint32 len2 = len+len, wlen, lenq;
 		int j, start_index;
 	  #if MI64_PRP_DBG
 		int dbg = STREQ(&cbuf[convert_mi64_base10_char(cbuf, n, len, 0)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"
@@ -4184,8 +4218,8 @@ Test harness code:
 #ifndef __CUDA_ARCH__
 void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 {
-	uint32 i;
 #if defined(USE_AVX512) && !defined(USE_IMCI512)
+	uint32 i;
 	__asm__ volatile (\
 		"movq	%[__a],%%rax				\n\t	vpxorq	%%zmm30,%%zmm30,%%zmm30	\n\t"/* 0.0 */\
 		"movq	%[__b],%%rbx				\n\t	vmovaps		(%%rax),%%zmm0 	\n\t"/* Load uint64 inputs */\
@@ -4215,8 +4249,8 @@ void mi64_vcvtuqq2pd(const uint64 a[], double b[])
 
 void mi64_vcvtpd2uqq(const double a[], uint64 b[])
 {
-	uint32 i;
 #ifdef USE_AVX512
+	uint32 i;
 	__asm__ volatile (\
 		"movq	%[__a],%%rax				\n\t"\
 		:					/* outputs: none */\
@@ -4273,11 +4307,13 @@ Test harness code:
 void mi64_modmul53_batch(const double a[], const double b[], const double m[], double r[])	/* a,b,m,r are ptrs to 32-byte-aligned 256-byte-large memchunk of 32 doubles */
 {
 	// Debug: short-length arrays to gather error-correction statistics:
-	static int32 ierr[100];	static double err[72], *eptr = err;	while((uint64)eptr & 0x3f) { ++eptr; }
-	const double two = 2.0, three = 3.0;	const double *ptwo = &two, *pthree = &three;
+	//static int32 ierr[100];
+	static double err[72], *eptr = err;	while((uint64)eptr & 0x3f) { ++eptr; }
 // ewm: wrap in AVX (not AVX2) prepro flag because my older gcc on the Haswell barfs on the MULXs in this file when built using USE_AVX2, but is OK with the FMA3 portion of AVX2
 #if defined(USE_AVX) && !defined(USE_IMCI512)
   #ifdef USE_AVX512
+	const double two = 2.0;
+	const double *ptwo = &two;
 	const uint32 ndata = 64;	uint32 i;
 	__asm__ volatile (\
 		"movq	%[__a]  ,%%rax			\n\t"\
@@ -4496,6 +4532,8 @@ void mi64_modmul53_batch(const double a[], const double b[], const double m[], d
 		++ierr[(int32)*(eptr+i)+50];
 	}*/
   #else
+	const double two = 2.0, three = 3.0;
+	const double *ptwo = &two, *pthree = &three;
 	const uint32 ndata = 16;	uint32 i;
 	__asm__ volatile (\
 		"movq	%[__a]  ,%%rax			\n\t"\
@@ -4725,10 +4763,11 @@ Test harness code:
 #ifndef __CUDA_ARCH__
 uint64 mi64_modmul64(const uint64 a, const uint64 b, const uint64 m)
 {
-	uint64 r,i64;
+	uint64 r;
 
 #if 0//def YES_ASM
 
+	uint64 i64;
 	static int first_entry = TRUE;
 	if(first_entry) {
 		unsigned short FPUCTRL;
@@ -5605,7 +5644,6 @@ int mi64_div_binary(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY
 	// pointers to local storage:
 	static uint64 *xloc = 0x0, *yloc = 0x0;
 	static uint64 *scratch = 0x0;	// "base pointer" for local storage shared by all of the above subarrays
-	uint64 *tmp_ptr;
 	static int lens = 0;	// # of 64-bit ints allocated for current scratch space
   #if MI64_DIV_DBG
 	if(dbg)
@@ -5649,6 +5687,7 @@ int mi64_div_binary(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY
 	#if 1
 		scratch = (uint64 *)realloc(scratch, lens*sizeof(uint64));	ASSERT(scratch != 0x0, "alloc fail!");
 	#else
+		uint64 *tmp_ptr;
 		tmp_ptr = (uint64 *)malloc(lens*sizeof(uint64));	ASSERT(tmp_ptr != 0x0, "alloc fail!");
 		free(scratch); scratch = tmp_ptr;
 	#endif
@@ -6045,7 +6084,7 @@ Returns: The (n)th modular power of the twos-complement radix, R^n (mod q).
 #endif
 uint64 radix_power64(const uint64 q, const uint64 qinv, uint32 n)
 {
-	const char func[] = "radix_power64";
+//	const char func[] = "radix_power64";
 #if MI64_RAD_POW64_DBG
 	int dbg = 0;	//q == 16357897499336320049ull;
 #endif
@@ -6227,7 +6266,7 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 #ifndef YES_ASM
 	uint64 tmp;
 #endif
-	uint32 i,nshift;
+	uint32 nshift;
 	uint64 qinv,cy;
 
 	ASSERT(q > 0, "mi64_is_div_by_scalar64: 0 modulus!");
@@ -6250,7 +6289,7 @@ int mi64_is_div_by_scalar64(const uint64 x[], uint64 q, uint32 len)
 #ifndef YES_ASM
 
 	cy = (uint64)0;
-	for(i = 0; i < len; ++i) {
+	for(uint32 i = 0; i < len; ++i) {
 		tmp  = x[i] - cy;
 		/* Add q if had a borrow - Since we low=half multiply tmp by qinv below and q*qinv == 1 (mod 2^64),
 		   can simply add 1 to tmp*qinv result instead of adding q to the difference here:
@@ -6465,9 +6504,9 @@ int mi64_is_div_by_scalar64_u2(const uint64 x[], uint64 q, uint32 len)
 	int dbg = q == 16357897499336320049ull;//87722769297534671ull;
 #endif
 #ifndef YES_ASM
-	uint64 tmp0,tmp1,bw0,bw1;
+	uint64 tmp0,tmp1;
 #endif
-	uint32 i,len2 = (len>>1),nshift;
+	uint32 len2 = (len>>1),nshift;
 	uint64 qinv,cy0,cy1,rpow;
 
 	ASSERT(q > 0, "mi64_is_div_by_scalar64: 0 modulus!");
@@ -6490,7 +6529,7 @@ ASSERT(!nshift, "2-way folded ISDIV requires odd q!");
 
 #ifndef YES_ASM
 	cy0 = cy1 = (uint64)0;
-	for(i = 0; i < len2; ++i) {
+	for(uint32 i = 0; i < len2; ++i) {
 		tmp0  = x[i] - cy0;				tmp1 = x[i+len2] - cy1;
 		cy0 = (cy0 > x[i]);				cy1 = (cy1 > x[i+len2]);
 		tmp0 = tmp0*qinv + cy0;			tmp1 = tmp1*qinv + cy1;
@@ -6586,7 +6625,7 @@ int mi64_is_div_by_scalar64_u4(const uint64 x[], uint64 q, uint32 len)
 #if MI64_ISDIV_U4_DBG
 	int dbg = 0;
 #endif
-	uint32 i,len4 = (len>>2),nshift;
+	uint32 len4 = (len>>2),nshift;
 	uint64 qinv,cy0,cy1,cy2,cy3,rpow;
 
 	ASSERT(q > 0, "mi64_is_div_by_scalar64: 0 modulus!");
@@ -6761,8 +6800,8 @@ Returns x % q in function result, and quotient x / q in y-vector, if one is prov
 #endif
 uint64 mi64_div_by_scalar64(const uint64 x[], uint64 q, uint32 len, uint64 y[])
 {
-	const char func[] = "mi64_div_by_scalar64";
 #if MI64_DIV_MONT64
+	const char func[] = "mi64_div_by_scalar64";
 	int dbg = q == 0x00000007FFFFFFFFull;
 #endif
 	uint32 i,nshift,lshift = -1,ptr_incr;
@@ -7025,7 +7064,7 @@ uint64 mi64_div_by_scalar64_u2(uint64 x[], uint64 q, uint32 lenu, uint64 y[])	//
 #if MI64_DIV_MONT64_U2
 	int dbg = 0;
 #endif
-	int i,j,npad = (lenu&1),len = lenu + npad,len2 = (len>>1),nshift,lshift = -1;	// Pad to even length
+	int npad = (lenu&1),len = lenu + npad,len2 = (len>>1),nshift,lshift = -1;	// Pad to even length
 	uint64 qinv,cy0,cy1,rpow,rem_save = 0,xsave,itmp64,mask,*iptr0,*iptr1,ptr_incr;
 	ASSERT((x != 0) && (len != 0), "Null input array or length parameter!");
 	ASSERT(q > 0, "0 modulus!");
@@ -7062,7 +7101,7 @@ See similar behavior for 4-way-split version of the algorithm.
 
 	cy0 = cy1 = (uint64)0;
 	if(!nshift) {	// Odd modulus, with or without quotient computation, uses Algo A
-		for(i = 0; i < len2; ++i) {
+		for(int i = 0; i < len2; ++i) {
 			tmp0  = x[i] - cy0;				tmp1 = x[i+len2] - cy1;
 			cy0 = (cy0 > x[i]);				cy1 = (cy1 > x[i+len2]);
 			tmp0 = tmp0*qinv + cy0;			tmp1 = tmp1*qinv + cy1;
@@ -7080,6 +7119,7 @@ See similar behavior for 4-way-split version of the algorithm.
 			iptr0 = y;	iptr1 = iptr0 + len2;
 			ptr_incr = 1;
 		}
+		int i,j;
 		// Inline right-shift of x-vector with modding - 1 less loop-exec here due to shift-in from next-higher terms:
 		for(i = 0, j = len2; i < len2-1; ++i, ++j, iptr0 += ptr_incr, iptr1 += ptr_incr) {
 			*iptr0 = (x[i] >> nshift) + (x[i+1] << lshift);
@@ -7245,7 +7285,7 @@ See similar behavior for 4-way-split version of the algorithm.
 #ifndef YES_ASM
 
 	bw0 = bw1 = (uint64)0;
-	for(i = 0; i < len2; ++i, ++iptr0, ++iptr1) {
+	for(int i = 0; i < len2; ++i, ++iptr0, ++iptr1) {
 		tmp0  = *iptr0 - bw0 - cy0;		tmp1 = *iptr1 - bw1 - cy1;
 		/*  Since may be working in-place, need an extra temp here due to asymmetry of subtract: */
 		bw0 = (tmp0 > *iptr0);			bw1 = (tmp1 > *iptr1);
@@ -7367,9 +7407,20 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 #if MI64_DIV_MONT64_U4
 	int dbg = 0;
 #endif
-	int i,j,len = (lenu+3) & ~0x3,len2 = (len>>1),len4 = (len>>2),npad = len-lenu,nshift,lshift = -1;	// Pad to multiple-of-4 length
-	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,itmp64,mask,*iptr0,*iptr1,*iptr2,*iptr3, ptr_incr,ptr_inc2;
-	uint64 *xy_ptr_diff, pads[3];
+	int i,len = (lenu+3) & ~0x3,len4 = (len>>2),npad = len-lenu,nshift,lshift = -1;	// Pad to multiple-of-4 length
+	uint64 qinv,cy0,cy1,cy2,cy3,rpow,rem_save = 0,mask,*iptr0;
+#ifndef YES_ASM
+	int len2 = (len>>1);
+	uint64 *iptr1,*iptr2,*iptr3;
+#else // YES_ASM
+  #ifndef USE_AVX2
+	int len2 = (len>>1);
+	uint64 *iptr1,*iptr2;
+	uint64 ptr_incr,ptr_inc2;
+  #endif
+	uint64 *xy_ptr_diff;
+#endif
+	uint64 pads[3];
 	// Local-alloc-related statics - these should only ever be updated in single-thread mode:
 	static int first_entry = TRUE;
 	static uint32 len_save = 10;	// Initial-alloc values
@@ -7404,11 +7455,15 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 		mask = ((uint64)-1 >> lshift);	// Save the bits which would be off-shifted if we actually right-shifted x[]
 		rem_save = x[0] & mask;	// (Which we don`t do since x is read-only; thus we are forced into accounting tricks :)
 		q >>= nshift;
+#ifdef YES_ASM
 		xy_ptr_diff = (uint64*)0;	// In even-modulus case, we use remaindering loop to store a right-justified copy
 				// of the input (x) vector in any output (y) vector, i.e. quotient loop uses y-vector as in-and-output.
+#endif
 	} else {
+#ifdef YES_ASM
 		xy_ptr_diff = (uint64*)((uint64)y - (uint64)x);	// 2-step cast to avoid GCC "initialization makes pointer from integer without a cast" warning
 						// The inner (uint64) casts are needed for the compiler to emit correctly functioning code.
+#endif
 	}
 
 	uint32 q32,qi32;
@@ -7416,14 +7471,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 	qi32 = qi32*((uint32)2 - q32*qi32);
 	qi32 = qi32*((uint32)2 - q32*qi32);	qinv = qi32;
 	qinv = qinv*((uint64)2 - q*qinv);
-
-	if(!nshift) {		// If odd modulus, have not yet copied input array to y...
-		iptr0 = (uint64*)x;
-	} else if (y) {		// If even modulus, right-justified copy of input array writen to quotient vec, if available...
-		iptr0 = y;
-	} else {			// ...or into local-alloc scratch vec if no quotient vec [AVX2 mode only;
-		iptr0 = svec;	// otherwise each word of x>>n discarded after it is used in REM accumulation]
-	}
 
 #ifndef YES_ASM
 
@@ -7497,13 +7544,12 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 
 #else
 
-	iptr1 = iptr0 + len4; iptr2 = iptr1 + len4; iptr3 = iptr2 + len4;
-	if(!y) {
-		ptr_incr = 0;
-		ptr_inc2 = 0;	// bytewise distance (iptr2-iptr0) and (iptr3-iptr1)
-	} else {
-		ptr_incr = 8;	// Use bytewise incr in inline-ASM build mode
-		ptr_inc2 = len2<<3;	// bytewise distance (iptr2-iptr0) and (iptr3-iptr1)
+	if(!nshift) {		// If odd modulus, have not yet copied input array to y...
+		iptr0 = (uint64*)x;
+	} else if (y) {		// If even modulus, right-justified copy of input array writen to quotient vec, if available...
+		iptr0 = y;
+	} else {			// ...or into local-alloc scratch vec if no quotient vec [AVX2 mode only;
+		iptr0 = svec;	// otherwise each word of x>>n discarded after it is used in REM accumulation]
 	}
 
   #ifdef USE_AVX2	// AVX2 version: Have a MULX instruction, full 256-bit (YMM-register-width) vector-int support.
@@ -7576,6 +7622,16 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 			// For even-modulus case, use inlined-double-precision (SHRD) dividend-vector shift because SSE2-based
 			// unlikely to be any faster.
 			// Note: MULQ assumes src1 in RAX, src2 in named register, lo"hi output halves into rax:rdx:
+
+	iptr1 = iptr0 + len4; iptr2 = iptr1 + len4; // iptr3 = iptr2 + len4;
+
+	if(!y) {
+		ptr_incr = 0;
+		ptr_inc2 = 0;	// bytewise distance (iptr2-iptr0) and (iptr3-iptr1)
+	} else {
+		ptr_incr = 8;	// Use bytewise incr in inline-ASM build mode
+		ptr_inc2 = len2<<3;	// bytewise distance (iptr2-iptr0) and (iptr3-iptr1)
+	}
 
 	if(!nshift) {	// Odd modulus, with or without quotient computation, uses Algo A
 
@@ -7871,8 +7927,6 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 
 #else
 
-	iptr2 = iptr0 + len2;
-
 	/*** Bizarrely, the MULX-based version of the quotient loop runs slower than the original on Haswell ***/
   #ifdef USE_AVX2	// Haswell-and-beyond version (Have a MULX instruction)
 					// Note: MULX reg1,reg2,reg3 [AT&T/GCC syntax] assumes src1 in RDX
@@ -7936,6 +7990,8 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 
   #else		// Pre-Haswell version (no MULX instruction)
 			// Note: MULQ assumes src1 in RAX, src2 in named register, lo"hi output halves into rax:rdx:
+
+	iptr2 = iptr0 + len2;
 
 	__asm__ volatile (\
 		"movq	%[__iptr0],%%r10	\n\t"/* Input pointers (point to [x|y]+{0,len2} if q [odd|even] */\
@@ -8308,7 +8364,7 @@ uint32 mi64_twopmodq(const uint64 p[], uint32 len_p, const uint64 k, uint64 q[],
 	static uint32 lenp_save = 10, lenq_save = 10;	// Initial-alloc values
 	static uint64 *pshift = 0x0, *qhalf = 0x0, *qinv = 0x0, *x = 0x0, *lo = 0x0, *hi = 0x0;
 	 int32 j;	// Current-Bit index j needs to be signed because of the LR binary exponentiation.
-	uint32 retval, idum, pbits;
+	uint32 pbits;
 	uint64 lead_chunk, lo64, cyout;
 	uint32 lenP, lenQ, qbits, log2_numbits, start_index, zshift;
   #if MI64_POW_DBG

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -6084,7 +6084,6 @@ Returns: The (n)th modular power of the twos-complement radix, R^n (mod q).
 #endif
 uint64 radix_power64(const uint64 q, const uint64 qinv, uint32 n)
 {
-//	const char func[] = "radix_power64";
 #if MI64_RAD_POW64_DBG
 	int dbg = 0;	//q == 16357897499336320049ull;
 #endif

--- a/src/mi64.h
+++ b/src/mi64.h
@@ -499,11 +499,11 @@ __device__ uint32 mi64_twopmodq_gpu(
   #ifndef YES_ASM
 	#define MONT_MUL64(__x,__y,__q,__qinv,__z)\
 	{\
-		uint64 lo,hi;					\
-		MUL_LOHI64(__x,__y,lo,hi);		\
-		MULL64(__qinv,lo,lo);			\
-		MULH64(__q,lo,lo);			\
-		__z = hi - lo + ((-(int64)(hi < lo)) & __q);	/* did we have a borrow from (hi-lo)? */\
+		uint64 l_lo,l_hi;					\
+		MUL_LOHI64(__x,__y,l_lo,l_hi);		\
+		MULL64(__qinv,l_lo,l_lo);			\
+		MULH64(__q,l_lo,l_lo);				\
+		__z = l_hi - l_lo + ((-(int64)(l_hi < l_lo)) & __q);	/* did we have a borrow from (l_hi-l_lo)? */\
 	}
   #else
 	#define MONT_MUL64(__Xx,__Xy,__Xq,__Xqinv,__Xz)\

--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -54,8 +54,9 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 {
 #if FAC_DEBUG
 	int dbg = STREQ(&char_buf[convert_uint128_base10_char(char_buf, q)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"
+	int32 pow;
 #endif
-	 int32 j, pow;	// j needs to be signed because of the LR binary exponentiation
+	 int32 j;	// j needs to be signed because of the LR binary exponentiation
 	uint32 curr_bit, leadb, start_index, nshift;
 	uint64 lo64;
 	uint128 pshift, qhalf, qinv, x, lo,hi, rsqr;

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -52,8 +52,9 @@
 // Conventional positive-power version of twopmodq192, returns true mod:
 uint192 twopmmodq192(uint192 p, uint192 q)
 {
-	 int32 j, pow;	// j needs to be signed because of the LR binary exponentiation
+	int32 j;	// j needs to be signed because of the LR binary exponentiation
 #if FAC_DEBUG
+	int32 pow;
 	int dbg = STREQ(&char_buf[convert_uint192_base10_char(char_buf, q)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"
 #endif
 	uint32 curr_bit, leadb, start_index, nshift;

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -87,8 +87,9 @@
 // Conventional positive-power version of twopmodq256, returns true mod:
 uint256 twopmmodq256(uint256 p, uint256 q)
 {
-	 int32 j, pow;	// j needs to be signed because of the LR binary exponentiation
+	int32 j;
 #if FAC_DEBUG
+	int32 pow;
 	int dbg = STREQ(&char_buf[convert_uint256_base10_char(char_buf, q)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"
 #endif
 	uint32 curr_bit, leadb, start_index, nshift;

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -87,7 +87,7 @@
 // Conventional positive-power version of twopmodq256, returns true mod:
 uint256 twopmmodq256(uint256 p, uint256 q)
 {
-	int32 j;
+	int32 j;	// j needs to be signed because of the LR binary exponentiation
 #if FAC_DEBUG
 	int32 pow;
 	int dbg = STREQ(&char_buf[convert_uint256_base10_char(char_buf, q)], "0");	// Replace "0" with "[desired decimal-form debug modulus]"

--- a/src/util.c
+++ b/src/util.c
@@ -96,38 +96,6 @@ void WARN(long line, char*file, char*warn_string, char*warn_file, int copy2stder
 
 /***************/
 
-/* ewm: Not sure what I intended this for... */
-void	VAR_WARN(char *typelist, ...)
-{
-	char *c;
-	 int32 ival;
-	uint32 uval;
-	double dval;
-
-	va_list varargs;
-	va_start(varargs, typelist);
-	/* Define a convenient spot to set a breakpoint: */
-	for(c = typelist; *c; c++)
-	{
-		switch(*c)
-		{
-			case 'i':
-				ival = va_arg(varargs, int32);
-				break;
-			case 'u':
-				uval = va_arg(varargs,uint32);
-				break;
-			case 'd':
-				dval = va_arg(varargs,double);
-				break;
-			default :
-				ASSERT(0,"0");
-				break;
-		}
-	}
-	va_end(varargs);
-}
-
 int mlucas_nanosleep(const struct timespec *req)
 {
 	struct timespec tmp = *req;

--- a/src/util.c
+++ b/src/util.c
@@ -1382,13 +1382,7 @@ int		file_valid_for_write(FILE*fp)
 /* Print key platform info, (on x86) set FPU mode, do some basic self-tests: */
 void host_init(void)
 {
-#ifdef MULTITHREAD
-	int ncpu, nthr;
-#endif
 	double dbl;
-	/*...time-related stuff	*/
-	clock_t clock1, clock2;
-	double tdiff;
 
 #if INCLUDE_HWLOC
 	/* Allocate and initialize topology object (extern hw_topology is defined in Mlucas.c): */
@@ -1448,11 +1442,7 @@ void host_init(void)
 	// Test the 64-bit 2^[+|-]p (mod q) functions:
 	uint32 imax = 100000;
 	fprintf(stderr,"INFO: Testing 64-bit 2^p (mod q) functions with %u random (p, q odd) pairs...\n",imax);
-	clock1 = clock();
 	ASSERT(test_twopmodq64(imax) == 0, "test_twopmodq64() returns nonzero!");
-	clock2 = clock();
-	tdiff = (double)(clock2 - clock1);
-//	printf("Time for %u 2^[+|-]p (mod q) call pairs =%s\n",imax, get_time_str(tdiff));
 #ifdef TEST_MI64_PRP
 	const uint32 max_test_dim = 1024;
 	uint32 i,ihi = 1000,j,jhi;
@@ -1830,6 +1820,7 @@ exit(0);
 
 	/* Test Multithreading via simple pthreading self-test: */
   #if 0
+	int ncpu, nthr;
 	ncpu = MAX_THREADS;
 	printf("INFO: Testing Multithreading support with %d threads...\n", ncpu);
 	// Toggle boolean 2nd arg here to enable verbose mode:
@@ -1940,7 +1931,6 @@ uint32 get_system_ram(void) {
 	/* get the number of CPUs from the system; For details, 'man sysctl', and/or bookmark this Apple Developer page:
 	https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctlbyname.3.html. */
 	uint64 totalram;	// Under OS X, this needs to be an int (size_t gave garbage results)
-	int mib[4];
 	size_t len = sizeof(totalram);
 	sysctlbyname("hw.memsize", &totalram, &len, NULL, 0);
 	return (totalram >> 20);
@@ -2508,7 +2498,7 @@ For the purpose of completeness, the other FPU control bits are as follows
 
 void check_nbits_in_types(void)
 {
-	uint32 i,j;
+	uint32 i;
 	double ftmp, fran, ferr, finv, fsrt;
 	double tpi = 3.1415926535897932384;
 	double ln2 = LOG2;
@@ -2808,7 +2798,7 @@ ASSERT(((uint64)FFT_MUL_BASE >> 16) == 1, "util.c: FFT_MUL_BASE != 2^16");
 	//	printf("FGT: prim-root of order 2^%2u = %" PRIu64 " + I*%" PRIu64 "\n",i, root_re,root_im);
 		// Check order-primitivity of roots of order > 1 by powering result up to 2nd order; result must == -1 (mod q):
 		if(i > 0) {
-			for(j = 1; j < i; j++) {
+			for(uint32 j = 1; j < i; j++) {
 				csqr_modq(root_re,root_im, &root_re,&root_im);
 				root_re = qreduce(root_re);	root_im = qreduce(root_im);	// Only partially reduce intermediates...
 			}
@@ -3528,10 +3518,10 @@ DEV uint32 popcount64(uint64 x)
 	return (uint32)i64;
 #else
 	uint8 *byte_arr = (uint8*)&x;
-	uint32 i,retval = 0;
+	uint32 retval = 0;
 	// May 2018: Unrolling the for-loop in favor of an inlined 8-fold sum gave a nice speedup:
   #if 0
-	for(i = 0; i < 8; i++) {
+	for(uint32 i = 0; i < 8; i++) {
 		retval += pop8[byte_arr[i]];
 	}
   #else
@@ -8940,12 +8930,11 @@ exit(0);
 		int ibig,iinc,isum;	/* ibig = #bigwords in loop-divided-by-threads sequence */
 		struct do_loop_test_thread_data tdat[nthreads];
 		pthread_t pth = pthread_self();
-		int        thr_id;         /* thread ID for a newly created thread */
 		pthread_t  p_thread;       /* thread's structure                     */
 		int        a = 1;  /* thread 1 identifying number            */
 		int        b = 2;  /* thread 2 identifying number            */
 		int ncpu = get_num_cores(), nshift, nextra;
-		printf("Mlucas running as system-created pthread %u, threading self-test will use %d user-created pthreads.\n", (int)pth, nthreads);
+		printf("Mlucas running as system-created pthread %lu, threading self-test will use %d user-created pthreads.\n", (long)pth, nthreads);
 		if(verbose) {
 			ASSERT(nthreads > 0,"Mlucas.c: nthreads > 0");
 			if(nthreads > ncpu) {
@@ -8954,7 +8943,7 @@ exit(0);
 		}
 		/* create a pair of threads, each of which will execute a simple timing loop().
 		Uncomment the prints in the thread-called function to 'see' the threads executing: */
-		thr_id = pthread_create(&p_thread, NULL, ex_loop, (void*)&a);
+		pthread_create(&p_thread, NULL, ex_loop, (void*)&a);
 		/* Thread which prints a hello message - Note the stdout prints resulting from this
 		and the surrounding thread-tests may appear in any order, depending on system scheduling of the respective threads: */
 		j = pthread_create(&p_thread, NULL, PrintHello, (void *)&b);
@@ -9006,7 +8995,7 @@ exit(0);
 						printf("ERROR; return code from pthread_join() is %d\n", rc);
 						exit(-1);
 					}
-					if(verbose) printf("Main: completed join with thread %d having a status of %d\n",tid,(int)status);
+					if(verbose) printf("Main: completed join with thread %d having a status of %ld\n",tid,(long)status);
 					isum += retval[tid];
 				}
 			}
@@ -9032,7 +9021,7 @@ exit(0);
 						printf("ERROR; return code from pthread_join() is %d\n", rc);
 						exit(-1);
 					}
-					if(verbose) printf("Main: completed join with thread %d having a status of %d\n",tid,(int)status);
+					if(verbose) printf("Main: completed join with thread %d having a status of %ld\n",tid,(long)status);
 					isum += retval[tid];
 				}
 			}
@@ -9064,9 +9053,11 @@ exit(0);
 	// A little hello-world testcode for the pthread stuff:
 	void *PrintHello(void *threadid)
 	{
+	  #if 0
 		int tid;
 		tid = *((int*)threadid);
-	//	printf("Hello World! It's me, thread #%ld!\n", tid);
+		printf("Hello World! It's me, thread #%ld!\n", tid);
+	  #endif
 		pthread_exit(NULL);
 	}
 
@@ -9118,7 +9109,6 @@ exit(0);
 	// or more core indices in the range does not map to a valid PU), return -1:
 	int num_sockets_of_core_set(hwloc_topology_t topology, int lidx_lo, int lidx_hi)
 	{
-		hwloc_obj_t obj;
 		if(!topology) return -1;
 		int topodepth = hwloc_topology_get_depth(topology);
 		// Logical PUs 1 level above topodepth:
@@ -9154,7 +9144,7 @@ exit(0);
 	// Returns: #logical cores (hwloc: logical processing units, objects of type HWLOC_OBJ_PU) specified in the substring.
 	uint32 parseAffinityTriplet(char*istr, int hwloc_topo)
 	{
-		int ncpu = 0, lo = -1,hi = lo,incr = 1, i,j,bit,word;
+		int ncpu = 0, lo = -1,hi = lo,incr = 1, i,bit,word;
 		char *char_addr = istr, *endp;
 		ASSERT(char_addr != 0x0, "Null input-string pointer!");
 		size_t len = strlen(istr);
@@ -9208,7 +9198,7 @@ exit(0);
 				if (obj_core->arity < incr) {
 					snprintf(cbuf,STR_MAX_LEN*2,"[hwloc] Error: Requested threads_per_core (%u) exceeds arity (%u) of HWLOC_OBJ_CORE[%u].\n",incr,obj_core->arity,i);	ASSERT(0,cbuf);
 				}
-				for (j = 0; j < incr; j++) {
+				for (int j = 0; j < incr; j++) {
 					obj_pu = obj_core->children[j];
 					// Set bit = (obj_pu->logical_index) in CORE_SET bitmap, used in thread-affinity setting:
 					bit = obj_pu->logical_index;
@@ -9397,7 +9387,11 @@ void set_mlucas_path(void)
 		has_err = TRUE;
 		goto out_pipe;
 	}
-	fgets(expanded_str, STR_MAX_LEN + 1, pipe_ptr);
+	if (fgets(expanded_str, STR_MAX_LEN + 1, pipe_ptr) == NULL) {
+		fprintf(stderr, "ERROR: couldn't get environment variable MLUCAS_PATH in set_mlucas_path()\n");
+		has_err = TRUE;
+		goto out_pipe;
+	}
 	if (getc(pipe_ptr) != EOF) {
 		fprintf(stderr, "ERROR: environment variable MLUCAS_PATH or cpp macro MLUCAS_DEFAULT_PATH is longer than STR_MAX_LEN in set_mlucas_path()\n");
 		has_err = TRUE;
@@ -9459,6 +9453,7 @@ int mkdir_p(char *path)
 	char tmp[4 * STR_MAX_LEN + 1] = "";
 	char *tok;
 	FILE *fp;
+	int err;
 
 	strcpy(mlucas_path, path);
 	if (mlucas_path[0] == '\0')
@@ -9475,7 +9470,11 @@ int mkdir_p(char *path)
 		strcpy(cmdstr, "mkdir ");
 		strcat(cmdstr, tmp);
 		strcat(cmdstr, " 2> /dev/null");
-		system(cmdstr);
+		err = system(cmdstr);
+		if (err != 0) {
+			fprintf(stderr, "ERROR: mkdir_p failed <%s>\n", cmdstr);
+			ASSERT(0, "Exiting.");
+		}
 	}
 
 	strcat(tmp, "_Mlucas_util_c_mkdir_p_tmp");
@@ -9486,7 +9485,10 @@ int mkdir_p(char *path)
 		fprintf(stderr, "ERROR: unable to open pipe fp in mkdir_p()\n");
 		ASSERT(0, "Exiting.");
 	}
-	fgets(tmp, STR_MAX_LEN + 1, fp);
+	if (fgets(tmp, STR_MAX_LEN + 1, fp) == NULL) {
+		fprintf(stderr, "ERROR: unable to retrieve file name in mkdir_p()\n");
+		ASSERT(0, "Exiting.");
+	}
 	pclose(fp);
 
 	fp = fopen(tmp, "a");
@@ -9497,7 +9499,11 @@ int mkdir_p(char *path)
 	strcpy(cmdstr, "rm -f ");
 	strcat(cmdstr, tmp);
 	strcat(cmdstr, " 2> /dev/null");
-	system(cmdstr);
+	err = system(cmdstr);
+	if (err != 0) {
+		fprintf(stderr, "ERROR: mkdir_p failed <%s>\n", cmdstr);
+		ASSERT(0, "Exiting.");
+	}
 	return 0;
 }
 
@@ -9573,7 +9579,7 @@ void mlucas_fprint(char*const cstr, uint32 echo_to_stderr)
 // Any failure to obtain a valid value for the option returns a NaN; the caller should check for this using isNaN(result):
 double mlucas_getOptVal(const char*fname, char*optname)
 {
-	const char func[] = "mlucas_getOptVal";
+//	const char func[] = "mlucas_getOptVal";
 	char cstr[STR_MAX_LEN], *cptr,*cadd;
 	ASSERT(fname != 0x0 && strlen(fname) > 0,"Null filename-pointer or empty string supplied to mlucas_getOptVal!");
 	FILE *fptr = mlucas_fopen(fname,"r");

--- a/src/util.c
+++ b/src/util.c
@@ -9470,11 +9470,10 @@ int mkdir_p(char *path)
 		strcpy(cmdstr, "mkdir ");
 		strcat(cmdstr, tmp);
 		strcat(cmdstr, " 2> /dev/null");
-		err = system(cmdstr);
-		if (err != 0) {
-			fprintf(stderr, "ERROR: mkdir_p failed <%s>\n", cmdstr);
-			ASSERT(0, "Exiting.");
-		}
+		// mkdir (no -p) fails whenever this path component already exists, which is the
+		// common case on every startup after the first - deliberately ignore that here,
+		// matching mkdir -p semantics; only cast to void to silence the unused-result warning:
+		(void)system(cmdstr);
 	}
 
 	strcat(tmp, "_Mlucas_util_c_mkdir_p_tmp");

--- a/src/util.h
+++ b/src/util.h
@@ -235,8 +235,6 @@ void	WARN	(long line, char*file, char*warn_string, char*warn_file, int copy2stde
 
 #define ASSERT(expr, assert_string) (void)((expr) || (ABORT(#expr, __FILE__, __LINE__, __func__, assert_string),0))
 
-void	VAR_WARN(char *typelist, ...);
-
 void	byte_bitstr(const uint8  byte, char*ostr);
 void	ui32_bitstr(const uint32 ui32, char*ostr);
 void	ui64_bitstr(const uint64 ui64, char*ostr);


### PR DESCRIPTION
Part of splitting @ldesnogu's warnings-cleanup PR #34 into smaller, independently-reviewable pieces.

Mechanical compiler-warning cleanup for the core non-radix sources — 11 commits touching `Mlucas.c`, `mi64.c`, `util.c` (incl. removing the unused `VAR_WARN` macro), and `twopmodq128/192/256.c` (unused vars/params, format specifiers, `sizeof` vs literal buffer length, etc.).

- All @ldesnogu's, cherry-picked from #34 with original authorship preserved; no content changes.
- Verified: nosimd build clean, LL self-test Res64 `71E61322CCFB396C` unchanged.

This is the base of a 3-PR stack from #34's remaining "core files" cluster:
1. **this PR** — pre-rename warning cleanups
2. the `cstr`/`in_line` global renames (stacked on this)
3. post-rename cleanups incl. the factor.c AVX-512 sieve change

It's independent and can merge first; the other two build on it.