### PR TITLE
Fix unsigned underflow in P-1 stage 2 buffer-count calculation

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2592,12 +2592,18 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				#else
 					printf("INFO: %u MB of available system RAM detected; will use up to %u%% = %u MB of that for p-1 stage 2.\n",SYSTEM_RAM,MAX_RAM_USE,j);
 				#endif
-					// Assume 5 of those n-double chunks are already used for Stage 1 residue and other stuff
-					PM1_S2_NBUF = (uint32)(j*1024./(n>>7)) - 5;
+					// Assume 5 of those n-double chunks are already used for Stage 1 residue and other stuff.
+					// Guard the '- 5' against unsigned wraparound when fewer than 5 residue-sized buffers fit
+					// in the available RAM (e.g. a large Fermat whose residue is several GB): without this the
+					// uint32 subtraction underflows to ~2^32, the 'need >= 24 buffers' assert below is fooled
+					// into passing, and Stage 2 then aborts trying to allocate billions of buffers (see #120).
+					PM1_S2_NBUF = (uint32)(j*1024./(n>>7));
+					PM1_S2_NBUF = (PM1_S2_NBUF > 5) ? (PM1_S2_NBUF - 5) : 0;
 					fprintf(stderr,"Available memory allows up to %u Stage 2 residue-sized memory buffers.\n",PM1_S2_NBUF);
 				} else {
 					fprintf(stderr,"User specified a maximum of %u Stage 2 residue-sized memory buffers.\n",PM1_S2_NBUF);
-					if( PM1_S2_NBUF > ((uint32)(j*1024./(n>>7)) - 5) )
+					// '+ 5' on the left rather than '- 5' on the right, to avoid the same unsigned underflow (see #120):
+					if( PM1_S2_NBUF + 5 > (uint32)(j*1024./(n>>7)) )
 						fprintf(stderr,"WARNING: User-specified maximum number of Stage 2 buffers may exceed %u MB of available RAM.\n",j);
 				}
 				ASSERT(PM1_S2_NBUF >= 24,"p-1 Stage 2 requires at least 24 residue-sized memory buffers!\n");

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -189,7 +189,7 @@ uint32 pm1_set_bounds(const uint64 p, const uint32 n, const uint32 tf_bits, cons
 	double dtmp = (SYSTEM_RAM*(double)MAX_RAM_USE*0.01)*1024./(n>>7);
 	sprintf(cbuf,"pm1_set_bounds: Stage 2 needs at least 24+5 buffers ... each buffer needs %u MB; avail-RAM allows %u such.\n",(n>>17),(uint32)dtmp);
 	mlucas_fprint(cbuf,pm1_standlone+1);
-	if(PM1_S2_NBUF && PM1_S2_NBUF > ((uint32)dtmp - 5)) {
+	if(PM1_S2_NBUF && PM1_S2_NBUF + 5 > (uint32)dtmp) {	// '+ 5' on the left, not '- 5' on the right, to avoid unsigned underflow when dtmp < 5 (see #120)
 		sprintf(cbuf,"WARNING: User-specified Stage 2 buffer count %u exceeds avail-RAM ... each buffer needs %u MB; avail-RAM allows %u such.\n",PM1_S2_NBUF,(n>>17),(uint32)dtmp);
 		mlucas_fprint(cbuf,pm1_standlone+1);
 	} else if(!PM1_S2_NBUF) {	// Respect any user-set value here, so long as it's >= minimum-buffer-count


### PR DESCRIPTION
Resolves #120.

## Problem
When fewer than 5 residue-sized buffers fit in the available-RAM budget — e.g. a large Fermat such as **F33**, whose residue is several GB, so only ~2 buffers fit in ~10 GB — the `- 5` in `ernstMain()`'s stage-2 setup (`Mlucas.c`):

```c
PM1_S2_NBUF = (uint32)(j*1024./(n>>7)) - 5;
```

underflowed the unsigned result: `2 - 5` → `4294967293` (`0xFFFFFFFD`), exactly the value in the report. The subsequent `ASSERT(PM1_S2_NBUF >= 24)` was fooled into passing, `pm1_bigstep_size()` then clamped the garbage count to 9984, and Stage 2 aborted with the confusing:

```
WARNING: 4294967293 buffers requested; Stage 2 allows a maximum of 10000.
Using 9984 Stage 2 memory buffers ...
ERROR: unable to allocate the needed 9984 buffers of p-1 Stage 2 storage.
Assertion '0' failed ...  Aborted (core dumped)
```

The same `(uint32)dtmp - 5` shape appears a second time, in `pm1_set_bounds()` (`src/pm1.c`).

## Fix
- Clamp the `- 5` to 0 in the auto-sizing path, so when there genuinely isn't enough RAM the existing `"p-1 Stage 2 requires at least 24 residue-sized memory buffers!"` assertion fires with its clear message instead of the ~2³² garbage path.
- Rewrite the two analogous user-set-buffer RAM-warning tests — one in the same `ernstMain()` block, one in `pm1_set_bounds()` (`src/pm1.c`) — to add 5 on the left rather than subtract 5 on the right. Same underflow, and it had additionally *suppressed* the "may exceed available RAM" warning in the too-little-RAM case.

Two commits, two files. The change is a no-op on the normal path (where far more than 5 buffers fit): both rewrites are exact no-ops whenever at least 5 buffers fit.

## Verification
- Reproduced the exact reported arithmetic: `avail=2` → old `avail-5 = 4294967293` (passes the `>=24` assert → 9984-buffer abort); new clamped `= 0` (correctly trips the `>=24` assert with the clear "need at least 24 buffers" message).
- `nosimd` build clean; FFT-192K/100-iter self-test residue unchanged (`Res64: 71E61322CCFB396C`); a normal p-1 run (M86243, which sizes thousands of buffers) is unaffected.

Full F33-scale reproduction requires many-GB residue buffers, so it isn't run in CI, but the fix targets exactly the unsigned-subtraction the reporter diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
