### PR TITLE
Verify self-test residues for command-line exponents / Fermat indices

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -4380,6 +4380,30 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 	// In fact it eases the logic to explicitly set selfTest = TRUE whenever iters is set (but not nec. the converse), so do that here:
 	if(iters) selfTest = TRUE;
 
+	// A user-specified self-test exponent (-m) or Fermat index (-f) is stored in the empty 0-pad slot of
+	// MvecPtr[]/FermVec[], whose reference residues are 0. The residue-verification path (below) then treats
+	// it as brand-new data (new_data = TRUE) and never checks the computed residues against the built-in
+	// reference table - even when the exponent/index + FFT length exactly match a tabulated entry (the bogus
+	// "Non-default exponent" warning is the symptom). For Fermat numbers, -f is the only way to run the
+	// self-test, so their residues were never verified at all (see #98/#123). If the user-specified
+	// exponent/index and FFT length match a reference-table entry, redirect the self-test to that entry so
+	// the residues are actually verified against the tabulated values.
+	if(selfTest && userSetExponent) {
+		if(modType == MODULUS_TYPE_FERMAT) {
+			for(i = 0; i < numFerm; i++) {
+				if(FermVec[i].Fidx == FermVec[numFerm].Fidx && FermVec[i].fftLength == FermVec[numFerm].fftLength) {
+					start = i; finish = i+1; userSetExponent = 0; break;
+				}
+			}
+		} else {
+			for(i = 0; i < numTest; i++) {
+				if(MvecPtr[i].exponent == MvecPtr[numTest].exponent && MvecPtr[i].fftLength == MvecPtr[numTest].fftLength) {
+					start = i; finish = i+1; userSetExponent = 0; break;
+				}
+			}
+		}
+	}
+
 	if(modType == MODULUS_TYPE_MERSENNE && !selfTest)
 	{
 		if(userSetExponent) {


### PR DESCRIPTION
Resolves #123.

## Problem
A self-test exponent given via `-m` (Mersenne) or `-f` (Fermat) is stored in the empty **0-pad slot** of the `MvecPtr[]` / `FermVec[]` reference-residue arrays, whose tabulated residues are `0`. The verification path decides "is this brand-new data we can't check?" from that zero residue (`new_data = TRUE`), so a command-line self-test was **always** treated as new data:

- Its computed residues were **never compared** against the built-in reference table.
- It printed the spurious `***** Non-default exponent - you will need to manually verify ... *****` warning even when the exponent was *exactly* the tabulated default for that FFT length (as the reporter put it, "warning A != A").
- For **Fermat** numbers, `-f` is the *only* way to run the self-test (there is no default-exponent path), so Fermat self-test residues were **never verified at all** — which is why every run in #98 happily wrote bad residues to `fermat.cfg`, and why `config-fermat.sh` cannot currently catch a wrong result.

## Fix
Before dispatching a command-line self-test, look up the specified exponent / Fermat-index **and** FFT length in the reference table. On a match, redirect the test (`start`/`finish`) to that populated entry so the existing residue-verification path runs, and clear the bogus "non-default" flag. Non-tabulated exponents/lengths are unaffected (still treated as new data). `config-fermat.sh` invokes `Mlucas -f N -fft F -iters …`, so its tabulated (index, length) combos now verify.

The PRP reference table (`MvecPRP[]`) is mostly unpopulated (zero residues), so `-prp` self-tests of a tabulated exponent still can't be verified — but the false warning is now correctly suppressed. Filling in PRP reference residues is a separate data task.

## Verification (nosimd)
- `-m 66431 -fft 3K -iters 100`: no longer prints the "non-default" warning, and verifies against `MersVec[3K]`.
- `-f 16 -fft 4K -iters 100`: now verifies against `FermVec` (previously new-data / unchecked).
- **Proof verification is genuinely active:** corrupting the `FermVec` F16 reference residue makes the self-test correctly report `*** Res64 Error ***`, where before the fix it passed silently (the #98 failure mode).
- Normal `-fftlen 192` self-test (no `-m`) unchanged: `Res64: 71E61322CCFB396C`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)