### PR TITLE
radix8: don't clamp CY_THREADS to a non-power-of-2 core count

### DIFF
--- a/src/radix8_ditN_cy_dif1.c
+++ b/src/radix8_ditN_cy_dif1.c
@@ -124,11 +124,18 @@ int radix8_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], 
 			i = leadz32(NTHREADS);
 			CY_THREADS = (((uint32)NTHREADS << i) & 0x80000000) >> (i-1);
 		}
-		if(CY_THREADS > MAX_THREADS)
-			CY_THREADS = MAX_THREADS;
 
-		ASSERT(CY_THREADS >= NTHREADS,"radix8_ditN_cy_dif1.c: CY_THREADS < NTHREADS");
-		ASSERT(isPow2(CY_THREADS)    ,"radix8_ditN_cy_dif1.c: CY_THREADS not a power of 2!");
+		if(CY_THREADS > MAX_THREADS)
+		{
+		//	Don't clamp CY_THREADS to a (possibly non-power-of-2) core count. On e.g. a 3-core VM/CPU,
+		//	NTHREADS=3 rounds up to 4; clamping that back to 3 both breaks the power-of-2 requirement
+		//	(which tripped the assert here) and silently changes this routine's thread count inside what is
+		//	only meant to be a clamp fix. Just warn about the over-subscription, exactly
+		//	as radix16/63/992 and the other leading radices already do (their clamp is likewise commented):
+		//	CY_THREADS = MAX_THREADS;
+			fprintf(stderr,"WARN: CY_THREADS = %d exceeds number of cores = %d\n", CY_THREADS, MAX_THREADS);
+		}
+		if(!isPow2(CY_THREADS))		{ WARN(HERE, "CY_THREADS not a power of 2!", "", 1); return(ERR_ASSERT); }
 		if(CY_THREADS > 1)
 		{
 			ASSERT(n8       %CY_THREADS == 0,"radix8_ditN_cy_dif1.c: n8      %CY_THREADS != 0 ... likely more threads than this leading radix can handle.");


### PR DESCRIPTION
## Problem
`radix8_ditN_cy_dif1()` rounds `NTHREADS` **up** to a power of 2 for `CY_THREADS`. Uniquely among the leading-radix carry routines, it still had the old **active** clamp:

```c
if(CY_THREADS > MAX_THREADS)
    CY_THREADS = MAX_THREADS;
```

On a host whose core count is **not a power of 2** — a 3-core VM, a container pinned to 3 CPUs (`--cpus=3`), or the old AMD tri-core parts — `NTHREADS=3` rounds up to 4, is clamped back to the 3-core `MAX_THREADS=3`, and the resulting non-power-of-2 `CY_THREADS` trips

```c
ASSERT(isPow2(CY_THREADS), "radix8_ditN_cy_dif1.c: CY_THREADS not a power of 2!");
```

aborting the run. (Surfaced by the self-test on GitHub's odd-core macOS runners.)

## Fix
Bring the block in line with radix16, which is the form the rest of the tree already uses — of the 58 `radixNN_ditN_cy_dif1.c` files, 34 carry the clamp commented out and radix8 was the only one where it was still live:

- comment out the clamp and `fprintf` an over-subscription warning instead, character-for-character as radix16 does;
- replace `ASSERT(isPow2(CY_THREADS), …)` with radix16's `if(!isPow2(CY_THREADS)) { WARN(HERE, "CY_THREADS not a power of 2!", "", 1); return(ERR_ASSERT); }`;
- delete `ASSERT(CY_THREADS >= NTHREADS, …)`. The clamp was the only thing that could ever violate it; with round-up and no clamp it holds by construction, so it is now vacuous.

`CY_THREADS` then stays a power of 2 on every core configuration (`NTHREADS=3 -> CY_THREADS=4`), and the assert can no longer fire.

`git blame` shows radix8's active clamp + round-up are original 2009 code, unchanged; radix16 and the others have used the commented-clamp form since v20. radix8 was simply never brought in line.

## Notes / scope
- Behavior on power-of-2-core hosts is **unchanged** — the clamp never fired there.
- **Why keep round-up rather than switch to round-down.** 32 of the files round *down* (`CY_THREADS = (((uint32)NTHREADS << i) & 0x80000000) >> i;`); radix8, radix63 and radix992 round *up* (`>> (i-1)`). Round-down would not be *unsafe* here: radix8 has no thread dispatch at all — no `tpool`, no `pthread_create`, no `cy_thread_data_t` — and every `_cy_*` / `_bjmodn*` / `_jstart` / `_jhi` array is `malloc`'d with `CY_THREADS` entries and only ever indexed by `ithread < CY_THREADS`, so `CY_THREADS < NTHREADS` cannot index out of bounds. The reason to keep round-up is narrower: switching would silently change radix8's thread-count semantics (`NTHREADS=3` would run 2 carry chunks rather than 4) inside a PR whose job is to fix the clamp. Converging radix8/63/992 on the majority round-down convention is worth doing, as its own change.
- **Still not fully in line with radix16:** the two remaining hard asserts, `ASSERT(n8 %CY_THREADS == 0, …)` and `ASSERT(n_div_nwt%CY_THREADS == 0, …)`, are left as `ASSERT`s, where radix16's equivalents are `WARN + return(ERR_ASSERT)`. Happy to convert those too if you want the whole block to match.
- Verified: single-thread residue unchanged; a forced 3-core (`MAX_THREADS=3`) self-test no longer asserts (`CY_THREADS=4`, over-subscription warning only).

*Correction to an earlier revision of this description, and to the explanatory comment the diff adds at the clamp (which I will fix on the next push): both justified keeping round-up on the grounds that radix8's "`CY_THREADS`-indexed carry dispatch requires `CY_THREADS >= NTHREADS`" and that a lower value would segfault. radix8 has no such dispatch and no such requirement — the real argument is the semantics one above. The earlier text also said the hard asserts were downgraded, plural; only the `isPow2` one is.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
