### PR TITLE
radix16_dif_dit_pass: make pfetch_dist an integer constant expression (fixes -O0 asm build)

### DIFF
--- a/src/radix16_dif_dit_pass.c
+++ b/src/radix16_dif_dit_pass.c
@@ -129,7 +129,20 @@ void radix16_dif_pass	(double a[],             int n, struct complex rt0[], stru
 #endif
 {
 #ifdef USE_SSE2
+	// pfetch_dist feeds an asm operand whose required form differs by target, so declare it to suit:
+	//   x86 (SSE2/AVX SSE2_RADIX16_*_TWIDDLE macros): an "e" (immediate) operand, which needs an
+	// integer *constant expression*. A `const int` variable only folds to an immediate once
+	// optimization is on, so at -O0 stricter modern compilers (e.g. gcc-16) reject it with
+	// "impossible constraint in 'asm'"; an enum is a true constant at every -O level.
+	//   ARMv8 (SSE2_RADIX16_*_TWIDDLE_V2 in radix16_dif_dit_pass_asm.h): an "m" (memory) operand
+	// ("ldr w14,%[__pfetch_dist]"), which must be an addressable lvalue - an enum constant is not,
+	// and gcc/clang reject it ("memory input is not directly addressable" / "invalid lvalue in asm
+	// input for constraint 'm'"). So keep a real variable on ARM.
+#ifdef USE_ARM_V8_SIMD
 	const int pfetch_dist = PFETCH_DIST;
+#else
+	enum { pfetch_dist = PFETCH_DIST };
+#endif
 	int pfetch_addr;	// Since had pre-existing L1-targeting pfetch here, add numerical suffix to differentiate cache levels being targeted by the various types of prefetching
 	static int max_threads = 0;
 #endif
@@ -2003,7 +2016,14 @@ void radix16_dit_pass	(double a[],             int n, struct complex rt0[], stru
 #endif
 {
 #ifdef USE_SSE2
+	// See the matching note in radix16_dif_pass: pfetch_dist feeds an "e" (immediate) asm operand on
+	// x86 (needs an integer constant expression to compile at -O0 under modern gcc) but an "m"
+	// (memory) operand on ARMv8 (needs an addressable lvalue), so declare it to suit the target.
+#ifdef USE_ARM_V8_SIMD
 	const int pfetch_dist = PFETCH_DIST;
+#else
+	enum { pfetch_dist = PFETCH_DIST };
+#endif
 	int pfetch_addr;
 	static int max_threads = 0;
 #endif


### PR DESCRIPTION
## Problem

Building the x86-SIMD Mlucas at `-O0` fails under strict modern compilers (e.g. gcc-16) with:

```
radix16_dif_dit_pass_asm.h:2469:9: error: impossible constraint in 'asm'
```

The `SSE2_RADIX16_{DIF,DIT}_TWIDDLE` macros bind `pfetch_dist` to an `"e"` (immediate) asm operand and reference it via `%c[__pfetch_dist]`. That constraint requires an integer **constant expression**, but `pfetch_dist` was declared:

```c
const int pfetch_dist = PFETCH_DIST;
```

A `const int` is a read-only *variable*, not a constant expression — it only satisfies `"e"` once constant-propagation folds it to an immediate, i.e. at `-O1` and above. At `-O0` there is nothing to fold, so the operand is unsatisfiable.

This is a latent code bug, not a compiler regression: older gcc and clang mask it because Mlucas ships at `-O3`, and every CI job builds at `-O1`+. It surfaces in local/debug builds — in particular, `threadpool.c` needs `-D_GNU_SOURCE`, and passing `CFLAGS=-D_GNU_SOURCE` overrides makemake's `?=` default and drops `-O3` to an effective `-O0`.

## Fix

Declare `pfetch_dist` via an `enum`, making it a true integer constant expression that satisfies the `"e"` operand at **every** optimization level and on every compiler. The value is unchanged.

**x86 SIMD only, deliberately.** The ARMv8 macros in the same header, `SSE2_RADIX16_{DIF,DIT}_TWIDDLE_V2`, take `pfetch_dist` as an `"m"` (memory) operand — `ldr w14,%[__pfetch_dist]` — which requires an addressable lvalue, and an enum constant is not one. So both hunks carve ARM out with `#ifdef USE_ARM_V8_SIMD` and keep the `const int` there. ARM ASIMD was never affected by the `-O0` failure above, and the Testing section below is x86 only.

`pfetch_dist` is the only `"e"` operand in the tree bound to a named variable rather than to a literal, which is why it is the only one that cannot fold at `-O0`. It accounts for all 19 `"e"` uses in `radix16_dif_dit_pass_asm.h`; the other 203 `"e"` bindings in `src/` (147 in `sse2_macro_gcc64.h`, 29 in `sse2_macro_gcc32.h`, 27 in `carry_gcc64.h`) are macro parameters that every caller supplies as a literal constant. The full `-O0` builds below completing end-to-end is the direct check on that. *(An earlier revision of this description said this was the only `"e"`-constraint site in the tree, full stop — that was wrong; the narrower variable-vs-literal claim is the correct one.)*

Those 19 uses are reached from `radix16_dif_dit_pass.c`, which is what this patch touches. `src/util.c` also instantiates the same macros with its own `const int pfetch_dist = 0;`, but only under `#ifdef TEST_SIMD`, which nothing in the tree or in `makemake.sh` defines — dead in every shipped build, though a `-O0 -DTEST_SIMD` build would still hit the original error.

## Testing

- Compiles at `-O0/-O1/-O2/-O3`, avx2 **and** avx512, under gcc-16.
- Full `-O0` avx2 and avx512 builds now succeed end-to-end (the previously-failing `CFLAGS="-D_GNU_SOURCE"` recipe).
- Behavior-neutral: avx2 (native) and avx512 (Intel SDE) self-tests at `-fftlen 192 -iters 100 -radset 0` still give the expected `Res64: 71E61322CCFB396C`.
- nosimd unaffected (the enum produces no unused-variable warning).
- ARM not built here; it keeps the pre-existing `const int` declaration unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
