### PR TITLE
twopmodq80: add missing asm memory clobbers; fix FAC_DEBUG and dead-AVX512_I landmines

### DIFF
--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -4840,7 +4840,7 @@ if(~pshift != p+78) {
 		uint64 twopmodq78_3WORD_DOUBLE_q16(uint64 p, uint64 k[], int init_sse2, int thr_id)
 		{
 		#if FAC_DEBUG
-			int dbg  = (p==17715697 && k[0] = 67885719840ull);
+			int dbg  = (init_sse2 == FALSE) && (p==17715697 && k[0] == 67885719840ull);	// == not =; guard k[] deref against init-mode calls
 		#endif
 			const char func[] = "twopmodq78_3WORD_DOUBLE_q16";
 			 int32 j = 0;	/* This needs to be signed because of the LR binary exponentiation. */
@@ -6222,7 +6222,7 @@ if(~pshift != p+78) {
 			  #ifdef MULTITHREAD
 				__r0  = sc_ptr;
 				mask_lo26 = sc_ptr + 0x300;
-				mask_lo52 = sc_ptr + 0x310;
+				mask_lo52 = sc_ptr + 0x308;	// 0x308 (not 0x310): consts are 1 AVX-512 reg (0x08) each, packed after mask_lo26 @0x300 - must match per-thread rebase site below
 				for(j = 0; j < max_threads; ++j) {
 					/* These remain fixed within each per-thread local store: */
 					// Need specific-length inits here since might be building overall in AVX-512 mode:
@@ -6259,7 +6259,7 @@ if(~pshift != p+78) {
 			// +0x140,160 - Insert another 2 pairs of padding slots here for high-product-words register spills (we spill 2 of 3 words)
 			// Consts: only get 1 AVX-512 reg (8 uint64s) per:
 				mask_lo26 = sc_ptr + 0x300;
-				mask_lo52 = sc_ptr + 0x310;
+				mask_lo52 = sc_ptr + 0x308;	// 0x308 (not 0x310): consts are 1 AVX-512 reg (0x08) each, packed after mask_lo26 @0x300 - must match per-thread rebase site below
 			// Total: Equivalent of 12*4 + 2 = 50 AVX-512 slots, alloc 56
 				VEC_U64_INIT((vec_u64*)mask_lo26, 0x0000000003FFFFFFull);
 				VEC_U64_INIT((vec_u64*)mask_lo52, 0x000FFFFFFFFFFFFFull);

--- a/src/twopmodq80.h
+++ b/src/twopmodq80.h
@@ -1188,7 +1188,7 @@ extern "C" {
 			: [__fq0] "m" (Xfq0)	/* All inputs from memory addresses here */\
 			 ,[__pshift] "m" (Xpshift)	\
 			 ,[__j]		"m" (Xj)		\
-			: "cl","rax","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+			: "cc","memory","cl","rax","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 		);\
 		}
 
@@ -1620,7 +1620,7 @@ extern "C" {
 			: [__fq0] "m" (Xfq0)	/* All inputs from memory addresses here */\
 			,[__pshift] "m" (Xpshift)	\
 			,[__j]		"m" (Xj)		\
-			: "cl","rax","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+			: "cc","memory","cl","rax","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 		);\
 		}
 
@@ -1843,7 +1843,7 @@ extern "C" {
 			: [__fq0] "m" (Xfq0)	/* All inputs from memory addresses here */\
 			,[__pshift] "m" (Xpshift)	\
 			,[__j]		"m" (Xj)		\
-			: "cl","rax","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
+			: "cc","memory","cl","rax","rcx","rdx","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15"	/* Clobbered registers */\
 		);\
 		}
 


### PR DESCRIPTION
1. **Missing `"cc","memory"` clobbers (live code):** the `SSE2_twopmodq78_modmul_q8` (AVX/AVX2) and both `SSE2_twopmodq78_modmul_q4` macro variants store into the `Xfq0` data region through `%%rdx` (e.g. `vmovaps %%ymm3,0x1c0(%%rdx)`) but declared no `"memory"` clobber — formally invalid asm that currently survives only because neighbouring blocks' clobbers bracket it. Every sibling macro (q16/q32/q64) already declares `"cc","memory"`; these three now match.
2. **FAC_DEBUG compile error (twopmodq78_3WORD_DOUBLE_q16):** `k[0] = 67885719840ull` inside a condition — `=` should be `==` (invalid-lvalue hard error in any FAC_DEBUG build); also guarded with `init_sse2 == FALSE` so init-mode calls don't read `k[0]`.
3. **Dead `USE_AVX512_I` q64:** `mask_lo52` was written at `sc_ptr+0x310` but read at `+0x308`; unified to `0x308` (consts pack one 8-word register apart, matching the q32 counterpart's consistent `0x180→0x188` spacing; `0x310` left a phantom gap).

## Testing
Compile-clean and warning-count-neutral vs main in nosimd/SSE2/AVX2/AVX-512 modes. FAC_DEBUG AVX2 build: pristine main fails at the `=` typo, fixed tree compiles with 0 errors. Integration branch carrying this passes Mlucas/Mfactor self-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)