### PR TITLE
twopmodq128-256: guard lead-bits extraction against shift-by-64 UB when j == 0

### DIFF
--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -248,7 +248,8 @@ if(dbg) printf("twopmodq128:\n");
 			j = leadz64(pshift.d1);
 			start_index = 128-j-7;
 			/* Extract leftmost 7 bits of pshift and subtract from 127: */
-			zshift = 127 - (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 57);
+			/* j==0 => shift-by-64 UB; guard the cross-word term: */
+			zshift = 127 - (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 57);
 		} else {
 			j = leadz64(pshift.d0);
 			start_index =  64-j-7;
@@ -462,7 +463,7 @@ if(dbg) printf("twopmodq128x2:\n");
 			j = leadz64(pshift.d1);
 			start_index = 128-j-7;
 			/* Extract leftmost 7 bits of pshift and subtract from 127: */
-			zshift = 127 - (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 57);
+			zshift = 127 - (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 57);
 			pshift.d1 = ~pshift.d1;
 		}
 		else
@@ -647,7 +648,7 @@ uint64 twopmodq128x2B(uint64 *p_in, uint128 q)
 			j = leadz64(pshift.d1);
 			start_index = 128-j-7;
 			/* Extract leftmost 7 bits of pshift and subtract from 127: */
-			zshift = 127 - (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 57);
+			zshift = 127 - (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 57);
 			pshift.d1 = ~pshift.d1;
 		} else {
 			j = leadz64(pshift.d0);
@@ -766,7 +767,7 @@ uint64 twopmodq128_q4(uint64* p_in, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		if(pshift.d1)
 		{
 			j = leadz64(pshift.d1);
-			lead7 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 57);
+			lead7 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 57);
 			start_index = 128-j-7;
 			pshift.d1 = ~pshift.d1;
 		}
@@ -1022,7 +1023,7 @@ if(dbg) printf("twopmodq128_q8:\n");
 		if(pshift.d1)
 		{
 			j = leadz64(pshift.d1);
-			lead7 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 57);
+			lead7 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 57);
 			start_index = 128-j-7;
 			pshift.d1 = ~pshift.d1;
 		}

--- a/src/twopmodq160.c
+++ b/src/twopmodq160.c
@@ -110,7 +110,8 @@ if(dbg)printf("twopmodq160:\n");
 		{
 			j = leadz64(pshift.d1);
 			/* Extract leftmost 8 bits of pshift (if > 159, use the leftmost 7) and subtract from 160: */
-			lead8 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 56);
+			/* j==0 => shift-by-64 UB; guard the cross-word term: */
+			lead8 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 159)
 			{
 				lead8 >>= 1;

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -259,7 +259,8 @@ uint192 twopmodq192(uint192 p, uint192 q)
 		{
 			j = leadz64(pshift.d2);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d2<<j) + (pshift.d1>>(64-j))) >> 56);
+			/* j==0 => shift-by-64 UB; guard the cross-word term: */
+			lead8 = (((pshift.d2<<j) + (j ? (pshift.d1>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;
@@ -272,7 +273,7 @@ uint192 twopmodq192(uint192 p, uint192 q)
 		{
 			j = leadz64(pshift.d1);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 56);
+			lead8 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;
@@ -532,7 +533,7 @@ uint64 twopmodq192_q4(uint64 *p_in, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		{
 			j = leadz64(pshift.d2);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d2<<j) + (pshift.d1>>(64-j))) >> 56);
+			lead8 = (((pshift.d2<<j) + (j ? (pshift.d1>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;
@@ -545,7 +546,7 @@ uint64 twopmodq192_q4(uint64 *p_in, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		{
 			j = leadz64(pshift.d1);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 56);
+			lead8 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;
@@ -930,7 +931,7 @@ uint64 twopmodq192_q4_qmmp(uint64 *p_in, uint64 k0, uint64 k1, uint64 k2, uint64
 		{
 			j = leadz64(pshift.d2);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d2<<j) + (pshift.d1>>(64-j))) >> 56);
+			lead8 = (((pshift.d2<<j) + (j ? (pshift.d1>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;
@@ -943,7 +944,7 @@ uint64 twopmodq192_q4_qmmp(uint64 *p_in, uint64 k0, uint64 k1, uint64 k2, uint64
 		{
 			j = leadz64(pshift.d1);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 56);
+			lead8 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;
@@ -1211,7 +1212,7 @@ uint64 twopmodq192_q8(uint64 *p_in, uint64 k0, uint64 k1, uint64 k2, uint64 k3, 
 		{
 			j = leadz64(pshift.d2);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d2<<j) + (pshift.d1>>(64-j))) >> 56);
+			lead8 = (((pshift.d2<<j) + (j ? (pshift.d1>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;
@@ -1224,7 +1225,7 @@ uint64 twopmodq192_q8(uint64 *p_in, uint64 k0, uint64 k1, uint64 k2, uint64 k3, 
 		{
 			j = leadz64(pshift.d1);
 			/* Extract leftmost 8 bits of pshift (if > 191, use the leftmost 7) and subtract from 192: */
-			lead8 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 56);
+			lead8 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 56);
 			if(lead8 > 191)
 			{
 				lead8 >>= 1;

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -271,21 +271,22 @@ uint256 twopmodq256(uint256 p, uint256 q)
 		{
 			j = leadz64(pshift.d3);
 			/* Extract leftmost 8 bits of pshift and subtract from 256: */
-			lead8 = (((pshift.d3<<j) + (pshift.d2>>(64-j))) >> 56);
+			/* j==0 => shift-by-64 UB; guard the cross-word term: */
+			lead8 = (((pshift.d3<<j) + (j ? (pshift.d2>>(64-j)) : 0ull)) >> 56);
 			start_index = 256-j-8;
 		}
 		else if(pshift.d2)
 		{
 			j = leadz64(pshift.d2);
 			/* Extract leftmost 8 bits of pshift and subtract from 192: */
-			lead8 = (((pshift.d2<<j) + (pshift.d1>>(64-j))) >> 56);
+			lead8 = (((pshift.d2<<j) + (j ? (pshift.d1>>(64-j)) : 0ull)) >> 56);
 			start_index = 192-j-8;
 		}
 		else if(pshift.d1)
 		{
 			j = leadz64(pshift.d1);
 			/* Extract leftmost 8 bits of pshift and subtract from 128: */
-			lead8 = (((pshift.d1<<j) + (pshift.d0>>(64-j))) >> 56);
+			lead8 = (((pshift.d1<<j) + (j ? (pshift.d0>>(64-j)) : 0ull)) >> 56);
 			start_index = 128-j-8;
 		}
 		else


### PR DESCRIPTION
Common fix across the scalar twopmodq files: the powering-loop lead-bits extraction computes `((TOP << j) + (NEXT >> (64-j))) >> 56` after `j = leadz64(TOP)`. When TOP's MSB is set, `j == 0` and `NEXT >> 64` is undefined behaviour — x86 masks the count to `>> 0`, silently injecting the full lower word into the lead bits (wrong `start_index`/`zshift` → wrong residue), and other targets/compilers may do worse.

Guarded the cross-word term with `(j ? (NEXT >> (64-j)) : 0ull)` at every affected site:
- twopmodq128.c — 5 sites; twopmodq192.c — 8 sites (incl. `_q4/_q4_qmmp/_q8`); twopmodq256.c — 3 sites (d3/d2/d1 cascade); twopmodq160.c — 1 site (its `pshift.d2` site is provably `j >= 32` per its own ASSERT and was correctly left alone).
- twopmodq128_96.c / twopmodq96.c use single-word pshift (no cross-word term) — untouched.

Not triggered by current self-test data (exponent magnitudes keep `j ≥ 10`), but reachable for moduli sized right at a word boundary; found while chasing a case where garbage in a struct's top word set the MSB.

## Testing
All four files compile warning-count-neutral vs main; the integration branch carrying this passes the full Mfactor `test_fac` (64/128/192/256-bit Fermat + 63-96-bit factor sections) and Mlucas self-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)