### PR TITLE
twopmodq160: fix Fermat-mod final subtraction and FAC_DEBUG decl order

### DIFF
--- a/src/twopmodq160.c
+++ b/src/twopmodq160.c
@@ -43,16 +43,16 @@ The key 3-operation sequence here is as follows:
 */
 uint64 twopmodq160(uint64 *p_in, uint64 k)
 {
-#if FAC_DEBUG
-	int dbg = STREQ(&char_buf[convert_uint192_base10_char(char_buf, p)], "0");
-	uint160 y,z;
-#endif
 	 int32 j;	/* This needs to be signed because of the LR binary exponentiation. */
 	uint64 lead8, lo64;
 	uint160 p /*= {p_in[0],p_in[1],p_in[2]}*/, q, qhalf, qinv, x, lo, hi;	// MSVC gives "illegal initialization" error for this p-init...
 	static uint160 psave = {0ull,0ull,0ull}, pshift;
 	static uint32 start_index, zshift, first_entry = TRUE;
 	p.d0 = p_in[0];	p.d1 = p_in[1];	p.d2 = p_in[2];	// ... so do it the hard way here.
+#if FAC_DEBUG
+	int dbg = STREQ(&char_buf[convert_uint192_base10_char(char_buf, p)], "0");
+	uint160 y,z;
+#endif
 	uint32 FERMAT;
 	if(p.d2 != 0ull)
 		FERMAT = isPow2_64(p.d2) && (p.d1 == 0ull) && (p.d0 == 0ull);
@@ -60,6 +60,7 @@ uint64 twopmodq160(uint64 *p_in, uint64 k)
 		FERMAT = isPow2_64(p.d1) && (p.d0 == 0ull);
 	else
 		FERMAT = isPow2_64(p.d0);
+	FERMAT <<= 1;	// *2 is b/c need to add 2 to the usual Mers-mod residue in the Fermat case
 
 #if FAC_DEBUG
 if(dbg)printf("twopmodq160:\n");
@@ -298,7 +299,8 @@ if(dbg) printf("2x= %s\n", &char_buf[convert_uint192_base10_char(char_buf, x)]);
 #if FAC_DEBUG
 	if(dbg) printf("Final x = %s\n", &char_buf[convert_uint192_base10_char(char_buf, x)]);
 #endif
-	q.d0 -= FERMAT;
+	// For Fn with n > 50-or-so it is not uncommon to have q = b*2^64 + 1, thus need to check for borrow
+	lo.d2 = lo.d1 = 0ull; lo.d0 = FERMAT;	SUB160(q,lo,q);	// Since carry may propagate > 1 word (e.g. F133 testfac), use general SUB
 	SUB160(x,q,x);
 #if FAC_DEBUG
 	if(dbg) printf("Final x-q=%s\n", &char_buf[convert_uint192_base10_char(char_buf, x)]);


### PR DESCRIPTION
The (currently uncalled — all call sites commented out) 160-bit scalar modpow's Fermat-mod path was doubly wrong:
1. Missing the `FERMAT <<= 1;` every sibling routine (twopmodq128/128_96/192/256) applies — Fermat case would subtract 1 instead of 2.
2. `q.d0 -= FERMAT;` had no borrow propagation — Fermat factors routinely have `q.d0 == 1`, so the subtraction wraps without borrowing from `q.d1`. Replaced with the general `SUB160` pattern used by twopmodq192/256 ("carry may propagate > 1 word").

Also moved the FAC_DEBUG `dbg` init below the declaration of `p` it references (use-before-declaration compile error in FAC_DEBUG builds).

Latent (routine has no live callers), but it now matches its 128/192/256 siblings so re-enabling it can't silently produce wrong Fermat-factor verdicts.

## Testing
Compiles warning-count-neutral vs main; pristine main fails to compile with `-DFAC_DEBUG=1` (`'p' undeclared`), fixed tree compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)