### PR TITLE
radix320: work around GCC 11 AVX-512 auto-vectorizer miscompile (SIGSEGV)

### DIFF
--- a/src/radix320_ditN_cy_dif1.c
+++ b/src/radix320_ditN_cy_dif1.c
@@ -23,6 +23,23 @@
 #include "Mlucas.h"
 #include "radix64.h"
 
+/* Work around a GCC 11 auto-vectorizer bug: in AVX-512 builds at -O3 (where GCC 11 enables the
+tree vectorizers), GCC 11.x miscompiles this translation unit - the compiler-vectorized code in
+cy320_process_chunk() dereferences a NULL-based address (observed on the ubuntu-22.04/gcc-11.4 CI
+runners and reproduced under Intel SDE with the same toolchain: SIGSEGV on a compiler-generated
+`vmovaps zmm0,[rax]` with rax = 0x7d80, i.e. a struct offset with its base pointer lost, at the
+very first multithreaded carry step of a leading-radix-320 run, e.g. M12628613 @ 640K FFT with
+radices {320,32,32}). The same build at -O2 - or with the tree vectorizers disabled at -O3, as
+done here - produces correct code (verified: 100-iteration Res64 matches the good-compiler
+reference). GCC 12+ (13/15/16 verified) and Clang are unaffected, as is the AVX2 build; note this
+is a different GCC 11 bug than the register-allocator one worked around in twopmodq96.c - forcing
+-fira-algorithm=priority does NOT fix this one. Only compiler-autovectorized glue code is
+affected; the hand-written AVX-512 asm macros which do the heavy lifting are untouched, so the
+performance impact is negligible. */
+#if defined(USE_AVX512) && defined(__GNUC__) && !defined(__clang__) && (__GNUC__ == 11)
+	#pragma GCC optimize ("no-tree-vectorize","no-tree-slp-vectorize")
+#endif
+
 #define RADIX 320	// Use #define rather than const int to ensure it's really a compile-time const in the C sense
 #define ODD_RADIX 5	// ODD_RADIX = [radix >> trailz(radix)]
 
@@ -2525,6 +2542,18 @@ void radix320_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
+	// GCC 11 + AVX-512: this function's local 'a' (Main data array pointer, extracted from
+	// thread_arg->arrdat) gets silently corrupted to a small integer (i.e. loses its base address,
+	// leaving only an index/offset component) between extraction and use, at every -O level from
+	// -O1 through -O3 (reproduced under Intel SDE with the exact ubuntu-22.04/gcc-11.4 CI
+	// toolchain+flags; -O0 is clean; confirmed via instrumented builds that thread_arg->arrdat
+	// itself is correctly a valid heap pointer at extraction time, so the corruption happens later,
+	// in this function's own body - this is a different manifestation than the compiler-
+	// autovectorizer bug the file-level pragma above works around, which by itself does not fix it).
+	// Scope the fix to just this function so the rest of the file keeps its normal optimization
+	// level; verified crash-free and numerically correct (Res64 matches the AVX2 build) for
+	// M12628613 @ 640K FFT, radices {320,32,32}, the case in which this was found.
+	__attribute__((optimize("O0")))
 	void*
 	cy320_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{


### PR DESCRIPTION
## Problem

The `Mlucas Linux (ubuntu-22.04, gcc)` CI job segfaults in the `-s m` self-test at **M12628613 / 640K FFT / radices {320,32,32}**, multithreaded, on any AVX-512-capable runner. ubuntu-22.04 ships gcc 11.4; the same job's clang build and the gcc-13/15 jobs (ubuntu-24.04/26.04) pass.

## Two distinct failures, each needing its own workaround

Root-caused with an instrumented build under Intel SDE (ubuntu:22.04 container, gcc 11.4.0, exact CI flags: `-mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma -flto=auto`).

**1. Auto-vectorizer, `-O3` only.** The compiler-vectorized code in `cy320_process_chunk()` dereferences a NULL-based address — SIGSEGV on a compiler-generated `vmovaps zmm0,[rax]` with `rax = 0x7d80`, a struct offset whose base pointer has been lost. Addressed by the file-level `#pragma GCC optimize ("no-tree-vectorize","no-tree-slp-vectorize")`, guarded to GCC 11 + AVX-512.

**2. Pointer corruption, every level from `-O1` up.** `cy320_process_chunk()`'s local `double *a` (extracted from `thread_arg->arrdat`) is confirmed **valid** at the point of extraction — a real heap pointer, identical across all 4 worker threads. It is then **silently corrupted to a small integer** (losing its base address, keeping only an index/offset component) later in the same function, before being passed as `a+jt` into `SSE2_RADIX_64_DIT()`.

The second is not fixed by the first:

| build (all `-mavx512f` et al, gcc 11.4.0) | result |
|---|---|
| `-O3`, no workaround | SIGSEGV (matches CI) |
| `-O3` + `-fno-tree-vectorize -fno-tree-slp-vectorize` | **still crashes** — different addresses each build, same defect |
| `-O3` + those + `-fira-algorithm=priority` (#118's workaround) | **still crashes** |
| `-O1` | **still crashes** |
| `-O0` | correct (`Res64 F951B697F5C5032A`, matching a native AVX2 build exactly) |

## Fix

Disable optimization for just the one affected function via `__attribute__((optimize("O0")))` rather than the whole file, keeping the cost scoped to that function. The file-level pragma stays: it addresses failure 1, which the attribute does not.

## Caveat on the attribution

This is presented as a GCC 11 codegen bug because `-O0` is clean and GCC 12+/clang are unaffected. **That reasoning is weaker than it looks, and I have not re-tested it against the alternative.** Two "compiler bug" verdicts in this tree turned out to be undeclared inline-asm clobbers — UB that is latent until the allocator happens to pick the undeclared register, which makes it look exactly like an optimization-level-dependent, compiler-version-dependent miscompile. See #68, which fixes that class tree-wide and also touches `radix320_main_carry_loop.h` (for a separate unsigned pointer-wrap). Before this workaround is treated as permanent it is worth checking whether the asm reached from `cy320_process_chunk()` declares everything it writes.

## Testing

With the fix, under gcc-11.4.0 + Intel SDE (`-skx`), the CI's own repro (M12628613 @ 640K FFT, radices {320,32,32}, 4 threads): 100 iterations complete cleanly over 3 repeated runs, deterministic, `Res64 = F951B697F5C5032A` every time, matching a native AVX2 build exactly.

Spot-checked radix1024 (`M19800083 @ 1024K`, `-radset 0`) for the same class of bug since `cy1024_process_chunk()` has a similar structure — no early crash. A full sweep of the other large-radix `*_process_chunk()` functions (64/192/960/4032) has not been done.
