### PR TITLE
radix1008/4032: reduce scalar-mode Fermat cycle-index increment mod nwt, not nwt16

### DIFF
--- a/src/radix1008_ditN_cy_dif1.c
+++ b/src/radix1008_ditN_cy_dif1.c
@@ -1291,7 +1291,11 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 				jhi = NDIVR/CY_THREADS;	// Earlier setting = NDIVR/CY_THREADS/2 was for simulating bjmodn evolution, need 2x that here
 				// Get value of (negative) increment resulting from (jhi-jstart)/stride execs of *cycle[] += wts_idx_inc* (mod nwt*):
 			#ifndef USE_SSE2
-				j = ((int64)wts_idx_incr * ( (jhi-jstart)>>(L2_SZ_VD-2) ) % nwt16);	// []>>(L2_SZ_VD-2) is fast subst. for []/stride
+				// Scalar-double mode: icycle[] holds plain (non-pointerized) cycle indices in [0,nwt), and the
+				// negative-wrap correction on the next line adds nwt, so this increment must be reduced mod nwt -
+				// NOT mod nwt16 (= nwt*sizeof(vec_dbl)), which is the SIMD/pointerized modulus. Cf. radix28/56/
+				// 60/224/240/960, which all use nwt here.
+				j = ((int64)wts_idx_incr * ( (jhi-jstart)>>(L2_SZ_VD-2) ) % nwt);	// []>>(L2_SZ_VD-2) is fast subst. for []/stride
 			#else
 				j = ((int64)wts_idx_inc2 * ( (jhi-jstart)>>(L2_SZ_VD-2) ) % nwt16);	// Cast wts_idx_inc* to signed 64-bit to avoid
 						// overflow of product; further compute (jhi-jstart)/stride prior to multiply to gain more bits-to-spare.

--- a/src/radix4032_ditN_cy_dif1.c
+++ b/src/radix4032_ditN_cy_dif1.c
@@ -1245,7 +1245,11 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 				jhi = NDIVR/CY_THREADS;	// Earlier setting = NDIVR/CY_THREADS/2 was for simulating bjmodn evolution, need 2x that here
 				// Get value of (negative) increment resulting from (jhi-jstart)/stride execs of *cycle[] += wts_idx_inc* (mod nwt*):
 			#ifndef USE_SSE2
-				j = ((int64)wts_idx_incr * ( (jhi-jstart)>>(L2_SZ_VD-2) ) % nwt16);	// []>>(L2_SZ_VD-2) is fast subst. for []/stride
+				// Scalar-double mode: icycle[] holds plain (non-pointerized) cycle indices in [0,nwt), and the
+				// negative-wrap correction on the next line adds nwt, so this increment must be reduced mod nwt -
+				// NOT mod nwt16 (= nwt*sizeof(vec_dbl)), which is the SIMD/pointerized modulus. Cf. radix28/56/
+				// 60/224/240/960, which all use nwt here.
+				j = ((int64)wts_idx_incr * ( (jhi-jstart)>>(L2_SZ_VD-2) ) % nwt);	// []>>(L2_SZ_VD-2) is fast subst. for []/stride
 			#else
 				j = ((int64)wts_idx_inc2 * ( (jhi-jstart)>>(L2_SZ_VD-2) ) % nwt16);	// Cast wts_idx_inc* to signed 64-bit to avoid
 						// overflow of product; further compute (jhi-jstart)/stride prior to multiply to gain more bits-to-spare.


### PR DESCRIPTION
## Problem

In the `CY_THREADS` fan-out loop that pre-advances the `*cycle[]` index tables to each thread's starting offset, the scalar-double (`#ifndef USE_SSE2`) branch reduces the increment **mod `nwt16`** instead of **mod `nwt`**:

```c
    j = ((int64)wts_idx_incr * ( (jhi-jstart)>>(L2_SZ_VD-2) ) % nwt16);
    ...
    icycle[i] += j;    icycle[i] += ( (-(int)((uint32)icycle[i] >> 31)) & nwt);
```

`nwt16` is `nwt*sizeof(vec_dbl)` — the modulus for the *pointerized* SIMD cycle tables. In scalar mode `icycle[]` holds plain indices in `[0,nwt)`, and the negative-wrap correction adds a single `nwt`, so an increment as large as `-(nwt16-1)` cannot be brought back into range. `icycle[]` therefore goes large and negative — and further so for each successive thread, because the loop accumulates — after which the `wt_arr[icycle]` / `wtinv_arr[icycle]` lookups in `fermat_carry_norm_errcheckB` read well outside the `foo_array` block those pointers index into.

Observed with 4 threads at F24/1008K (`nwt = ODD_RADIX = 63`, so `nwt16 = 504`): `wts_idx_incr = -55` is transferred correctly, but `icycle[0..4]` reach `-425,-424,…`, then `-850,…`, then `-1275,…` — one progressively worse set per worker thread.

**Effects**, for Fermat-mod runs in a scalar (non-SIMD) multithreaded build with a leading radix of **1008** or **4032**: out-of-bounds reads of global data, and silently **wrong weights (hence wrong residues)** whenever those reads land on mapped memory.

SIMD builds are unaffected — they take the `wts_idx_inc2` / `nwt16` branch, which is correct. Every sibling file (`radix28/56/60/224/240/960`) already uses `nwt` here; only these two had `nwt16`.

## Fix

Use `nwt` in the scalar branch of both files, with a comment explaining the two moduli.

## How it was found

AddressSanitizer, which reports a `global-buffer-overflow` 8-byte read in `cy1008_process_chunk` at the first `fermat_carry_norm_errcheckB` call. Note this only became visible once the ASan jobs actually run: on `main` the ASan build fails to compile (`mi64.c: 'asm' operand has impossible constraints`, fixed by #71) and the job is masked by `continue-on-error`, so it reports success without ever producing a binary.

The `radix4032` instance is the same typo and would have been the *next* failure — `config-fermat.sh` reaches 4032K at F26, just past where the F24/1008K abort stopped the script.

## Verification

NOSIMD build with `-fsanitize=address,undefined`:

| Case | Before | After |
| --- | --- | --- |
| `./Mlucas -f 24 -fft 1008 -iters 100 -cpu 0:3` | ASan global-buffer-overflow, exit 1 | clean, exit 0 |
| `./Mlucas -f 26 -fft 4032 -iters 100 -cpu 0:3` | (same defect) | clean, exit 0 |

Multithreaded residues now agree with single-threaded: F24/1008K = `DB9F01963ED9DC8B` for both, on both `{1008,16,32}` and `{1008,32,16}` radix sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
