### PR TITLE
Mfactor: free the five one-time allocations that leak at exit (fixes LeakSanitizer failures)

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -742,7 +742,10 @@ int main(int argc, char *argv[])
 
 /* Allocate factor_k array and align on 16-byte boundary: */
 	factor_ptmp = ALLOC_UINT64(factor_ptmp, 24);
-	factor_k = ALIGN_UINT64(factor_ptmp);	factor_ptmp = 0x0;
+	// Retain the base pointer: factor_k is an *interior* (64-byte-aligned) pointer into the
+	// factor_ptmp allocation, so only factor_ptmp can be passed to free() - and it is, near the
+	// end of main(). Nulling it here made that free() a no-op on NULL, leaking the allocation.
+	factor_k = ALIGN_UINT64(factor_ptmp);
 	ASSERT(((uint64)factor_k & 0x3f) == 0, "factor_k not 64-byte aligned!");
 
 /*...initialize logicals and factoring parameters...	*/
@@ -2509,7 +2512,8 @@ candidate factors that survive sieving.	*/
 	}
 
 	// Free the allocated memory:
-	free((void *)factor_ptmp);
+	free((void *)factor_ptmp);	factor_ptmp = 0x0;
+	free((void *)k_to_try);		k_to_try = 0x0;
 	free((void *)p);
 	free((void *)kdeep);
 	free((void *)bit_map);

--- a/src/factor_test.h
+++ b/src/factor_test.h
@@ -754,6 +754,9 @@ ASSERT(0 == mi64_div_by_scalar64(p, 458072843161ull, i, p), "M7331/458072843161 
 			ASSERT(0,"0");
 		}
 	}
+	free((void *)p ); p  = 0x0;	// Done with the ffacBig scratch arrays; p/q/q2 are not used past this loop
+	free((void *)q ); q  = 0x0;
+	free((void *)q2); q2 = 0x0;
 
 	/* Test 63-bit factors using the 63, 64 and 96-bit modmul routines */
 #ifdef FACTOR_STANDALONE


### PR DESCRIPTION
## Problem

Once the ASan CI jobs actually execute, **LeakSanitizer fails every Mfactor run** — exit 1, `16320 byte(s) leaked in 5 allocation(s)`. The ASan job runs the six Mfactor word-width binaries without an `|| true`, so this fails the step.

All five are one-time allocations held until exit, so none is a runtime problem — but Mlucas proper is already leak-clean under ASan (`-s tt`/`-s t` exit 0 with no leaks), so Mfactor should be too rather than the jobs needing `detect_leaks=0`.

| Site | Bytes | Cause |
| --- | --- | --- |
| `factor_test.h:733-735` | 3 × 5120 | `test_fac()` calloc's the `p`/`q`/`q2` scratch arrays for the `ffacBig` >256-bit Fermat-factor loop and never frees them |
| `factor.c:745` | 448 | `factor_ptmp = 0x0` right after `ALIGN_UINT64()` discards the base pointer |
| `factor.c` (`k_to_try`) | 512 | never freed |

The `factor_ptmp` one is the interesting case: `factor_k` is an **interior** 64-byte-aligned pointer into the `factor_ptmp` block, so `factor_ptmp` is the only pointer that may be passed to `free()`. `main()` *already* frees it — but line 745 had set it to `NULL` first, making that `free()` a no-op on NULL. So the intent was there; the nulling defeated it.

## Fix

- Free `p`/`q`/`q2` as soon as the `ffacBig` loop that uses them finishes (they are not referenced after it).
- Keep the `factor_ptmp` base pointer so the existing `free()` in `main()` actually frees the block.
- Free `k_to_try` alongside it.

## Verification

NOSIMD Mfactor builds with `-fsanitize=address,undefined`, running the CI's own command `./Mfactor[_word] -m 127 -bmax 20` for all six word widths:

| | before | after |
| --- | --- | --- |
| exit status | 1 (LeakSanitizer) | **0** |
| leaks | 16320 B / 5 allocs | **0** |
| ASan / UBSan errors | 0 / 0 | 0 / 0 |
| `Factoring self-tests completed successfully` | — | **present** |

Note on baseline: on a plain-`main` base the run reaches the self-test marker but then aborts in the checkpoint-savefile code (`'passnow' not found in Line 10 of factoring restart file`), which is a separate defect fixed by #114. The clean `exit(0)` for all six widths above was therefore measured with #114 and #138 also applied.

This was only visible because the ASan jobs now run at all: on `main` the ASan build fails to compile (`mi64.c: 'asm' operand has impossible constraints`, fixed by #71) and the job is masked by `continue-on-error`, so it reports success without producing a binary. It was further hidden behind the F24/1008K abort fixed by #156, since the Mfactor runs come *after* `config-fermat.sh` in that job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
