### PR TITLE
radix16/32_wrapper_square: fix UB left-shift of negative value in AVX-512 residual path

### DIFF
--- a/src/radix16_wrapper_square.c
+++ b/src/radix16_wrapper_square.c
@@ -4679,8 +4679,13 @@ loop:
 	  #ifdef USE_AVX
 		if(j1 < j2) {
 		//	printf("j1,j2 = %d,%d; (j1 < j2), skip loop-control and goto jump_new.\n",j1,j2);
-			j1pad = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* floating padded-array 1st element index is here */
-			j2pad = j2 + ( (j2 >> DAT_BITS) << PAD_BITS );	/* floating padded-array 2nd element index is here */
+			// j1 (and thus j2, similarly derived) can be negative on this branch (the whole point of
+			// which is to handle the AVX-512 j1<=160 residual case) - a signed left-shift of a negative
+			// value is undefined behavior in C, so use the equivalent multiply-by-2^PAD_BITS instead of
+			// "<< PAD_BITS" here. Same bug and fix as the identical pattern in radix32_wrapper_square.c
+			// (reproduced as a clang -O3 AVX-512 SIGSEGV via UBSan+ASan under Intel SDE there).
+			j1pad = j1 + ( (j1 >> DAT_BITS) * (1 << PAD_BITS) );	/* floating padded-array 1st element index is here */
+			j2pad = j2 + ( (j2 >> DAT_BITS) * (1 << PAD_BITS) );	/* floating padded-array 2nd element index is here */
 			goto jump_new;
 		}
 	  #endif

--- a/src/radix32_wrapper_square.c
+++ b/src/radix32_wrapper_square.c
@@ -5166,8 +5166,14 @@ loop:
 	  #ifdef USE_AVX
 		if(j1 < j2) {
 		//	printf("j1,j2 = %d,%d; (j1 < j2), skip loop-control and goto jump_new.\n",j1,j2);
-			j1pad = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* floating padded-array 1st element index is here */
-			j2pad = j2 + ( (j2 >> DAT_BITS) << PAD_BITS );	/* floating padded-array 2nd element index is here */
+			// j1 (and thus j2, similarly derived) can be negative on this branch (the whole point of
+			// which is to handle the AVX-512 j1<=160 residual case) - a signed left-shift of a negative
+			// value is undefined behavior in C, so use the equivalent multiply-by-2^PAD_BITS instead of
+			// "<< PAD_BITS" here. (Reproduced as a clang -O3 AVX-512 SIGSEGV via UBSan+ASan under Intel
+			// SDE: j1>>DAT_BITS evaluates to -1 for small negative j1, and "-1 << PAD_BITS" then yields
+			// a garbage j1pad, causing an out-of-bounds a[] access a few lines below.)
+			j1pad = j1 + ( (j1 >> DAT_BITS) * (1 << PAD_BITS) );	/* floating padded-array 1st element index is here */
+			j2pad = j2 + ( (j2 >> DAT_BITS) * (1 << PAD_BITS) );	/* floating padded-array 2nd element index is here */
 			goto jump_new;
 		}
 	  #endif


### PR DESCRIPTION
## Problem

`Mlucas Linux (ubuntu-24.04, clang)` SIGSEGV'd in the `-s tt` self-test at **M173431 / 8K FFT / radices {8,16,32}**, on the AVX-512 build only. Initially looked flaky — 22 SDE reproduction attempts with **gcc 11.4.0** (the same toolchain used to root-cause #148 and #118) all came back clean. That's because the CI job that actually failed uses **clang 18.1.3** (Ubuntu 24.04's default), a completely different compiler I hadn't tested. With a matching clang-18 build, the crash reproduces 100% given the exact self-test sequence (a single isolated `-radset` invocation does *not* reproduce it — the prior radix-set attempt's state matters).

## Root cause

Not a compiler miscompile. Both `radix32_wrapper_square.c` and `radix16_wrapper_square.c` have an AVX-512-only branch (explicitly commented "this conditional will only get taken in the AVX-512 case with its (j1 <= 160) - modified conditionals") that intentionally lets `j1` go negative to handle a residual/lookahead case. The very next line then does:

```c
j1pad = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );
```

`j1 >> DAT_BITS` is negative on this branch, and **a signed left-shift of a negative value is undefined behavior in C** (C11 6.5.7p4) — regardless of the actual bit pattern. clang 18 at `-O3` turns this into a garbage `j1pad`, which then causes an out-of-bounds `a[]` read (`ASan: SEGV on unknown address`, confirmed via a full stack trace: `radix32_wrapper_square → mers_process_chunk → worker_thr_routine`). gcc 11 apparently doesn't miscompile this same UB the same way, which is why it was invisible until the clang CI job's ASan/AVX-512 combination actually ran for real.

## Fix

Replace the left-shift with the equivalent `* (1 << PAD_BITS)` — ordinary signed multiplication is well-defined for negative operands, unlike a shift.

## Audit of the other 32 occurrences

Every other `(j1|j2 >> DAT_BITS) << PAD_BITS` call site in the codebase was checked for the same negative-value reachability:

- **`radix32_wrapper_square.c` / `radix16_wrapper_square.c`**, one more occurrence each: their normal `jump_in:` monotonic loop-entry point, where `j1` is provably non-negative (standard forward loop from a non-negative start). Safe.
- **`radix12_ditN_cy_dif1.c`** (×2): `j1` is a bitmask-AND result plus a small non-negative bit-reversal table lookup. Always ≥ 0. Safe.
- **`radix{8,16,32}_dif_dit_pass.c`** (×6, one inside dead `#if 0` debug code): standard `for(j = jlo; j < jhi; ...) { j1 = j; ... }` loops with `jlo = m*incr >= 0`. Safe.
- **`radix{8,16,32}_ditN_cy_dif1.c`** (×3): `j1 = NDIVR-2` (or `n8-2`) style — only negative if the FFT length were smaller than the leading radix itself, never reachable via `get_fft_radices()`. Safe.
- **`radix16_pairFFT_mul.c`**: same `jump_in:` pattern as the wrapper_square files. Safe.
- **`test_fft_radix.c`** (×6): the file's only call site is gated behind `#ifdef TEST_FFT_RADIX`, which itself `#error`s when `USE_SSE2` (hence any SIMD mode including AVX-512) is defined — unreachable in any real build.

So exactly **one more** live instance existed (in `radix16_wrapper_square.c`, byte-for-byte the same pattern), now fixed alongside the original.

## Testing

Reproduced and verified with the exact CI toolchain and flags (ubuntu:24.04 container, clang 18.1.3, `-mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma -flto=auto -O3`) under Intel SDE (`sde64 -skx`):
- Before: `M173431 -fft 8 -radset 3` within the natural `-s tt` self-test sequence → SIGSEGV every time.
- After: same sequence completes cleanly (`exit=0`), the previously-crashing radix set now fails gracefully with a roundoff-reject (matching gcc's behavior for the same case) instead of crashing, and other radix sets at the same FFT length produce the exact reference `Res64` (`85301536E4CA9B11`).
- Confirmed via ASan+UBSan (clang) that the specific UB warning (`left shift of negative value -1`) and the SEGV are both gone.

## Note for maintainers

A broader `-s t` sweep with this fix applied turned up a **separate, unrelated** issue further into the self-test (an unaligned AVX-512 vector access in `radix32_wrapper_square.c` at a different FFT length/radix combo, previously hidden behind this crash). That's a distinct bug outside the scope of this PR — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
