### PR TITLE
mers_mod_square: disable radix32_wrapper_square in AVX-512 builds (memory corruption)

### DIFF
--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -270,6 +270,22 @@ The scratch array (2nd input argument) is only needed for data table initializat
 
 	if(first_entry)
 	{
+	  #ifdef USE_AVX512
+		// radix32_wrapper_square's AVX-512 sincos/main-array-address setup corrupts memory and SIGSEGVs
+		// (radix32_wrapper_square.c, the "a[rdum]" read) for every radix combination tried so far under
+		// SDE+ASan/UBSan, regardless of the other radices in RADIX_VEC: M341749 @ 16K {16,16,32},
+		// M4837331 @ 240K {240,16,32}, M383521 @ 18K {36,8,32}, M673469 @ 32K {16,32,32} all reproduce
+		// this. Root cause not fully isolated (input j1/ws_j1[] values into the call are legitimate;
+		// something inside the function's own multi-thousand-line AVX-512 processing body corrupts j1's
+		// own storage) and no combination with a trailing radix of 32 has been observed to succeed on
+		// AVX-512 - so reject the whole radix32_wrapper_square path here rather than risk further memory
+		// corruption. (radix32_wrapper_square is still used by, and presumably fine on, non-AVX-512 SIMD
+		// modes; this guard is AVX-512-specific.)
+		if(RADIX_VEC[NRADICES-1] == 32) {
+			WARN(HERE, "mers_mod_square: radix32_wrapper_square is not supported in AVX-512 mode; skipping this radix set.", "", 1);
+			return ERR_RADIX0_UNAVAILABLE;
+		}
+	  #endif
 		if(!arr_scratch) {
 			sprintf(cbuf, "Init portion of %s requires non-null scratch array!",func);
 			ASSERT(0, cbuf);


### PR DESCRIPTION
## Problem

`radix32_wrapper_square` (invoked whenever the trailing/last radix in
`RADIX_VEC` is 32) corrupts memory and SIGSEGVs under AVX-512, at
`radix32_wrapper_square.c:1790` (an `a[rdum]` read). This was found while
investigating a specific reported crash, but turned out to affect every
trailing-radix-32 combination tried, not just one:

| Test case | FFT length | Radices |
|---|---|---|
| M341749 | 16K | {16,16,32} |
| M4837331 | 240K | {240,16,32} |
| M383521 | 18K | {36,8,32} |
| M673469 | 32K | {16,32,32} |

## Investigation

Using Intel SDE (`sde64 -skx`) to emulate AVX-512 on non-AVX-512 hardware,
with clang 18 + ASan/UBSan (matching the CI's own `ubuntu-24.04, clang` job
toolchain):

- Confirmed the crash is **not** caused by a prior, now-fixed bug in the same
  file (the AVX-512 residual-branch negative-shift UB fixed in #159) - this
  is a separate, still-open issue that was hidden behind that earlier crash.
- Confirmed it's **not** a threading bug: while investigating, a genuine,
  separate data race was found and fixed in #161 (every threadpool-completion
  wait in the codebase busy-polled an unsynchronized field instead of using
  the pool's own `threadpool_drain()`); fixing that race did not resolve this
  crash.
- Confirmed the **inputs are correct**: instrumented the dispatch site in
  `mers_mod_square.c` to print the exact `ws_i[l]`/`ws_j1[l]`/etc. values
  passed into each `radix32_wrapper_square` call - they're legitimate,
  in-range values at every call site, including the ones that go on to crash.
- Instrumented `radix32_wrapper_square`'s own internal "increasing block
  size" loop (`i`, `m`, `j1`, `j2`, `blocklen`, `blocklen_sum`, `k` at each
  iteration) and found `j1` - a local variable the function initializes
  itself from a legitimate small positive input (e.g. 1024) - goes wildly
  out of range (e.g. `801608448`) partway through a single call, with no
  explicit assignment to `j1` anywhere in the intervening code. This looks
  like something in the function's several-thousand-line AVX-512-specific
  processing body (sincos/twiddle setup, dyadic-square, DIT pass - all driven
  by dense nested `#ifdef USE_AVX512` macro expansions) is clobbering `j1`'s
  own stack storage, rather than a simple index-arithmetic mistake.
- Tried three progressively broader guard conditions (penultimate radix
  `==16`, then `<32`), each of which was disproven by a subsequent crash on a
  combination it didn't cover (`{36,8,32}` has a penultimate radix of 8;
  `{16,32,32}` has a penultimate radix of 32). No combination with a trailing
  radix of 32 was observed to succeed on AVX-512 across repeated full
  `-s t` self-test sweeps.

Given the exact corrupting write was not isolated in the time available, and
three narrower attempts at scoping the fix were each proven wrong by a further
test case, this PR takes the safe path used elsewhere in this codebase for
AVX-512-unsupported combinations (e.g. `radix20_ditN_cy_dif1.c`'s "No AVX-512
support" self-rejection): skip the whole `radix32_wrapper_square` path via
`WARN(...) + return ERR_RADIX0_UNAVAILABLE` when built with AVX-512, rather
than risk further memory corruption.

## Fix

In `mers_mod_square.c`'s `first_entry` init block, before any of the
per-radix-set setup work: if `RADIX_VEC[NRADICES-1] == 32` under
`#ifdef USE_AVX512`, warn and gracefully reject the radix set (matching the
existing `ERR_RADIX0_UNAVAILABLE` convention), instead of proceeding into
`radix32_wrapper_ini`/`radix32_wrapper_square`.

`radix32_wrapper_square` remains in use, presumably correctly, on
non-AVX-512 SIMD modes (SSE2/AVX/AVX2) - this guard is AVX-512-specific.

## Testing

A full `-s t` self-test sweep under SDE + clang-18 + AVX-512 + ASan/UBSan,
which previously crashed 100% of the time (at whichever trailing-radix-32
combination it reached first), now completes cleanly end-to-end: exit 0,
zero sanitizer reports, with every affected radix set cleanly skipped and
reported via the standard "N of M radix-sets passed" self-test summary
rather than crashing the whole run.

## Scope / follow-up

This is a mitigation, not a root-cause fix - it trades some AVX-512
performance/coverage (radix32_wrapper_square-using radix sets fall back to
being unavailable rather than used) for correctness. A maintainer with more
time for register/stack-layout-level debugging of the AVX-512 macro
expansions in `radix32_wrapper_square.c` could likely find and fix the actual
corrupting write, at which point this guard could be relaxed or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)