### PR TITLE
Fix CPU feature detection: test the actual AVX2 bit, gate XGETBV correctly

### DIFF
--- a/src/get_cpuid.c
+++ b/src/get_cpuid.c
@@ -465,7 +465,10 @@
 	#ifdef USE_AVX
 		uint32 a,b,c,d;
 		CPUID(1,0,a,b,c,d);
-		if(c & 0x18000000) {			// CPU supports AVX?
+		// Both bits must be lit, so - just as in has_avx2() below - can't use an "is result of AND nonzero?"-style
+		// check here: XGETBV faults with #UD unless OSXSAVE (bit 27) is set, so an OR-test would crash this very
+		// probe on an AVX-capable CPU whose OS has not enabled XSAVE:
+		if((c & 0x18000000) == 0x18000000) {	// CPU supports AVX and OS has enabled XGETBV?
 			XGETBV(0,a,d);
 			return (a & 0x6) == 0x6;	//  OS supports AVX?
 		} else {
@@ -479,8 +482,11 @@
 	// May 2015: Build-for-valgrind gives bad FMA-flag result on my Haswell/debian(v6)/gcc-4.4.5:
 	// a,b,c,d = 000206A7,00100800,1F9AE3BF,BFEBFBFF
     //                                 ^ lowest bit in E = 0, expect 1!
-	/* AVX2 requires us to check both AVX and FMA support, the former of which described in has_avx() and
-	the latter of which is encoded in bit 12 of ECX returned by calling CPUID with input EAX = 1: */
+	/* AVX2 requires us to check AVX and FMA support - the former of which described in has_avx() and the latter of
+	which is encoded in bit 12 of ECX returned by calling CPUID with input EAX = 1 - *and* the AVX2 feature flag
+	itself, which is CPUID.(EAX=07H, ECX=0):EBX.AVX2[bit 5]. Checking only AVX+FMA is not enough: the AMD Bulldozer
+	family from Piledriver onward (FX-83xx/FX-9xxx, A10-6800K, Steamroller, Excavator) supports AVX and FMA3 but
+	has no AVX2, and would be falsely reported as AVX2-capable: */
 	uint32	has_avx2()
 	{
 	#ifdef USE_AVX
@@ -490,7 +496,13 @@
 		// Since checking for > 1 lit bits here, can't simply use "is result of AND nonzero?)-style check as above:
 		if((c & 0x18001000) == 0x18001000) {			// CPU supports AVX+FMA?
 			XGETBV(0,a,d);
-			return (a & 0x6) == 0x6;	//  OS supports AVX?
+			if((a & 0x6) == 0x6) {		//  OS supports AVX?
+				CPUID(7,0,a,b,c,d);
+			//	printf("has_avx2: CPUID(7,0) returns [b] = %8X\n",b);
+				return (b & 0x20) != 0;	// CPU supports AVX2?
+			} else {
+				return 0;
+			}
 		} else {
 			return 0;
 		}
@@ -528,6 +540,11 @@
 		uint32 a,b,c,d;
 		CPUID(1,0,a,b,c,d);
 		printf("has_imci512: CPUID(1,0) returns [a,b,c,d] = [%8X,%8X,%8X,%8X]\n",a,b,c,d);
+		// IMCI-512 has no CPUID feature-flag bit of its own, and a k1om binary can only execute on the 1st-gen
+		// Xeon Phi (KNF,KNC) which implements it, so the compile-time target is the detection. Must return
+		// *something* here: falling off the end of a non-void function is UB, and the caller (util.c) uses the
+		// value to decide between "INFO: Build uses k1om" and ASSERT(0):
+		return 1;
 	#else
 		return 0;
 	#endif

--- a/src/util.c
+++ b/src/util.c
@@ -1962,12 +1962,14 @@ uint32 get_system_ram(void) {
 		char in_line[STR_MAX_LEN];
 		FILE*fp = mlucas_fopen("/proc/cpuinfo", "r");
 		ASSERT(fp != 0x0, "/proc/cpuinfo file not found!");
+		int retval = 0;
 		while(fgets(in_line, STR_MAX_LEN, fp) != 0x0) {
-			if(strstr(in_line, "asimd") != 0)
-				return 1;
+			if(strstr(in_line, "asimd") != 0) {
+				retval = 1;	break;
+			}
 		}
 		fclose(fp);	fp = 0x0;
-		return 0;
+		return retval;
 	}
 
   #elif __ARM_ARCH >= 8 // Rest of the preprocessor-conditional is the old version:


### PR DESCRIPTION
Four defects in the CPU-feature-detection code. The first one is the important one: it changes which CPUs Mlucas accepts, so both directions are verified below.

## 1. `has_avx2()` never tested the AVX2 feature bit — `src/get_cpuid.c:484-500`

```c
if((c & 0x18001000) == 0x18001000) {			// CPU supports AVX+FMA?
	XGETBV(0,a,d);
	return (a & 0x6) == 0x6;	//  OS supports AVX?
}
```

`c` is `CPUID.(EAX=1):ECX`, so `0x18001000` is bit 12 (FMA) | bit 27 (OSXSAVE) | bit 28 (AVX). **AVX2 itself is `CPUID.(EAX=07H, ECX=0):EBX[bit 5]`, which the function never read.** Any CPU with AVX + FMA3 but no AVX2 was therefore reported as AVX2-capable — that is exactly the AMD Bulldozer family from Piledriver onward (Family 15h models 02h/30h/60h/70h: FX-83xx / FX-9xxx, A10-6800K, Steamroller, Excavator), which have AVX + FMA3 + FMA4 + XOP and no AVX2.

Two reachable consequences on such a CPU:

* **AVX2 build:** the startup guard at `src/util.c:2145-2160`, whose entire purpose is to abort with `"#define USE_AVX2 invoked but no FMA support detected on this CPU!"`, instead prints `"INFO: Build uses AVX2 instruction set."` and lets the run proceed to the first VEX.256 integer instruction → SIGILL with no Mlucas-side diagnostic.
* **AVX build:** `src/util.c:2164-2167` falsely prints `"INFO: CPU supports AVX2 instruction set, but using AVX-enabled build."`, inviting the user to rebuild into the case above.

Fixed by adding the leaf-7 check, using the same `OSXSAVE → XGETBV → leaf 7` shape `has_avx512()` already uses.

## 2. `has_avx()` executed `XGETBV` behind an OR-test — `src/get_cpuid.c:463-477`

```c
if(c & 0x18000000) {			// CPU supports AVX?
	XGETBV(0,a,d);
```

`0x18000000` is OSXSAVE | AVX and this is only a *nonzero* test, so the branch is taken if **either** bit is set. The function's own header comment (`:461-462`) says both must be checked ("encoded in bit 28 and 27, respectively"), and both siblings do require both. With AVX set but OSXSAVE clear — an AVX-capable CPU whose OS never set `CR4.OSXSAVE` — `XGETBV` raises `#UD`, so Mlucas takes SIGILL *inside its own "do we have AVX?" probe* instead of cleanly answering "no", which CPUID alone can answer. Changed to an AND-test.

I considered leaving this as intentional and concluded it is not: the header comment states the intent is an AND, `has_avx2()`'s comment at `:490` explicitly notes that a multi-bit test cannot use the nonzero style, and `has_avx512()` correctly tests bit 27 alone before `XGETBV`. `has_avx()` is the odd one out. Note the AND-test is a strict narrowing only in the OSXSAVE-clear case, where AVX is unusable anyway. The reachable OS set is archaic (Linux < 2.6.30, Windows Vista pre-SP1), so this is latent — but the Boolean is objectively wrong.

## 3. `has_imci512()` fell off the end of a non-void function — `src/get_cpuid.c:525-534`

The `USE_IMCI512` arm had no `return` (UB; `-Wreturn-type` diagnoses it). `src/util.c:2111-2126` consumes that indeterminate value to choose between `"INFO: Build uses k1om / IMCI-512 instruction set."` and `ASSERT(0, "...no FMA support detected...")`, so a `makemake.sh k1om` build could bogusly succeed or bogusly abort depending on register contents. IMCI-512 has no CPUID feature-flag bit of its own and a k1om binary can only execute on the 1st-gen Xeon Phi (KNF/KNC) that implements it, so the compile-time target *is* the detection: `return 1`. The mirror-image call at `util.c:2130` in a plain AVX-512 build was already safe (the `return 0` arm is live there).

## 4. `has_asimd()` leaked the `/proc/cpuinfo` descriptor — `src/util.c:1960-1971`

The `return 1` inside the `fgets` loop bypassed the `fclose(fp)` below it, leaking one `FILE*`/fd per run on ARM-Linux builds. Set a flag and `break` so the single `fclose` covers both exits.

## Deliberately not touched

`has_avx512()` (`get_cpuid.c:536-559`). I audited its full sequence — OSXSAVE (`ECX[27]`) → `XGETBV` → `(XCR0 & 0xE6) == 0xE6` (opmask/ZMM-hi256/ZMM-hi16 in `XCR0[7:5]` **and** XMM/YMM in `XCR0[2:1]`) → `CPUID.(7,0):EBX[16]` — against Intel's documented Figure-2-1 flow (quoted in the source itself at `get_cpuid.c:502-524`) and found it correct. It is unchanged; the diff contains no hunk in that function. Its returning `0x10000` rather than `1` is harmless — all four call sites (`util.c:2113/2132/2147`, `mi64.c:2420`) use it as a truth value.

## Reference the encodings were verified against

gcc's own `<cpuid.h>` (`/usr/lib/gcc/x86_64-pc-linux-gnu/16/include/cpuid.h`):

* leaf 1 ECX: `bit_FMA (1 << 12)`, `bit_OSXSAVE (1 << 27)`, `bit_AVX (1 << 28)`
* `/* Extended Features Leaf (%eax == 7, %ecx == 0) */ /* %ebx */ … #define bit_AVX2 (1 << 5)`

This matches Intel SDM Vol. 2, CPUID instruction (Table 3-8, structured extended feature leaf) and the AVX-512 detection flow already quoted in this file.

## Verification

Host: Intel Core i9-10885H (Comet Lake — AVX2, **no** AVX-512), gcc 16.1.1, Linux.

**No false negative on real AVX2 hardware.** Clean `bash makemake.sh avx2` build (zero errors, no new warnings); `obj_avx2/Mlucas -s tt` passes with the expected residues

```
13K Res64: E3BC90B0E652C7C0
14K Res64: DB8E39C67F8CCA0A
15K Res64: B3C5A1C03E26BB17
```

and startup still reports `INFO: Build uses AVX2 instruction set.` Cross-checked against ground truth: `/proc/cpuinfo` and `lscpu` both list `avx2`, and live `CPUID.(7,0):EBX = 0x029C67AF` has bit 5 set.

**Other build modes.** Clean `bash makemake.sh avx` and `bash makemake.sh nosimd` builds; each starts, runs `-fft 192 -iters 100` to the same `Res64: 71E61322CCFB396C`, and reports its instruction set correctly — the AVX build prints `INFO: CPU supports AVX2 instruction set, but using AVX-enabled build.` (true on this host, and the exact `util.c:2166` path that was mis-advertising on Piledriver), the nosimd build prints `INFO: CPU supports SSE2 instruction set, but using scalar floating-point build.`

**True positive on the broken case — synthetic, not on hardware.** I have no AMD Piledriver-class hardware, and Intel SDE has no Bulldozer-family model, so this was demonstrated logically: a standalone harness feeds synthetic CPUID register values through the old and new predicates side by side.

```
                                                                     | avx2:              | avx:
AMD Piledriver (FX-8350)   ecx1=18001000 xcr0=07 ebx7=00000008 | old=1 new=0 truth=0 <-- OLD WRONG | old=1      new=1
AMD Excavator (Carrizo)    ecx1=18001000 xcr0=07 ebx7=00000108 | old=1 new=0 truth=0 <-- OLD WRONG | old=1      new=1
Intel Sandy Bridge         ecx1=18000000 xcr0=07 ebx7=00000000 | old=0 new=0 truth=0               | old=1      new=1
Intel Haswell (real AVX2)  ecx1=18001000 xcr0=07 ebx7=00000020 | old=1 new=1 truth=1               | old=1      new=1
AVX set, OSXSAVE clear     ecx1=10001000 xcr0=00 ebx7=00000020 | old=0 new=0 truth=0               | old=SIGILL new=0
this host (live CPUID)     ecx1=7FFAFBFF xcr0=21F ebx7=029C67AF| old=1 new=1 truth=1               | old=1      new=1
```

(the `avx` columns model item 2: `SIGILL` marks the case where the old OR-test reaches `XGETBV` with `CR4.OSXSAVE` clear.)

**Item 3** was shown as a `-Wreturn-type` warning (`control reaches end of non-void function`) on the old function body that is absent from the new one — again a compile-only demonstration, since no Xeon Phi KNC hardware was available and `makemake.sh:268` passes only `-DUSE_IMCI512` with no AVX-512 assembler flags, so that build mode very likely cannot link on any current toolchain regardless.

**Item 4** was shown by running the old and new bodies 1000 times each and counting `/proc/self/fd`: 1000 leaked descriptors before the fix, 0 after. (Correcting an earlier assumption of mine: LeakSanitizer does *not* flag this, because a leaked `FILE*` stays reachable through glibc's open-file list — it is a descriptor leak, not an LSan-visible one.) Not tested on ARM hardware; the changed arm only compiles under `CPU_IS_ARM_EABI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
