### PR TITLE
Fix P-1 stage 2 silently discarding a found factor on restart

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2633,45 +2633,68 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 						if((i = fgetc(fp)) != MODULUS_TYPE) {
 							snprintf(cbuf,sizeof(cbuf), "ERROR: %s: MODULUS_TYPE != fgetc(fp)\n",g_cstr); ASSERT(0,cbuf);
 						}
-						itmp64 = 0ull; 	for(j = 0; j < 8; j++) { i = fgetc(fp);	itmp64 += (uint64)i << (8*j); }
+						// Must check for EOF on *every* one of the 8 nsquares bytes, not just the last one: the stage 2
+						// checkpoint-write opens this file in "wb" mode, i.e. truncates it, so a kill/crash/power-loss
+						// during such a write leaves a < 10-byte .s2 behind. Folding the resulting EOF (= -1) returns
+						// into itmp64 as 0xFF bytes would yield a garbage stage 2 q of checkpoint; treat any short read
+						// as "no usable checkpoint data" instead, and leave psmall and the S2 bounds at their defaults,
+						// which makes the ensuing pm1_stage2() call redo stage 2 from B2_start:
+						int ibyte;	// Needs to be a signed int to allow an unambiguous compare vs EOF
+						itmp64 = 0ull;
+						for(j = 0; j < 8; j++) {
+							if((ibyte = fgetc(fp)) == EOF) break;
+							itmp64 += (uint64)ibyte << (8*j);
+						}
 						fclose(fp); fp = 0x0;
-						if(i != EOF)	// Needed to handle case where .s2 file was touched but ended up empty or < 10 bytes long
-							psmall = i;
-						itmp64 &= 0x00FFFFFFFFFFFFFFull;	// Mask off psmall to get stage 2 q of checkpoint data
-						fprintf(stderr,"Read iter = %" PRIu64 " and relocation-prime psmall = %u from savefile %s.\n",itmp64,psmall,g_cstr);
-						// Now parse logfile to get proper B2 and validate corresponding B2_start vs B2/[psmall from .s2 file].
-						// Logfiles can be messy and include one or more aborted-restarts; we want the last B2_start-containing
-						// entry followed by a savefile-write entry, as inferred from presence of a "% complete" substring:
-						j = filegrep(STATFILE,"% complete",cbuf,-1);	// Trailing -1 means return last such match, if any, in cbuf
-						filegrep(STATFILE,"B2_start = ",cbuf,j);	// Trailing j-arg means return last such match before line j, if any, in cbuf
-						// If match "B2_start =", read bigstep D from match-line and infer relocation-prime psmall from D:
-						if(strlen(cbuf)) {
-							char_addr = strstr(cbuf,"B2_start = ");
-							B2_start = (uint64)strtoull(char_addr+11, &cptr, 10);	ASSERT(B2_start != -1ull, "strtoull() overflow detected.");
-							char_addr = strstr(cbuf,"B2 = ");
-							B2 = (uint64)strtoull(char_addr+5, &cptr, 10);	ASSERT(B2 != -1ull, "strtoull() overflow detected.");
-							char_addr = strstr(cbuf,"Bigstep = ");
-							if(char_addr) {
-								i = strtoul(char_addr+10, &endp, 10);
-								if((i%210) == 0)
-									i = 11;
-								else if((i%330) == 0)
-									i = 7;
-								else {
-									fprintf(stderr,"WARNING: Bigstep value %u read from logfile %s unsupported ... ignoring.\n",i,g_cstr);
-									i = 0;
+						if(j < 8) {
+							snprintf(cbuf,sizeof(cbuf),"WARNING: stage 2 savefile %s is truncated [< 10 bytes] ... ignoring its checkpoint data; stage 2 will restart from B2_start.\n",g_cstr);
+							mlucas_fprint(cbuf,1);
+						} else {
+							psmall = (uint32)(itmp64 >> 56);	// Relocation-prime psmall is stored in the high byte of the nsquares field
+							itmp64 &= 0x00FFFFFFFFFFFFFFull;	// Mask off psmall to get stage 2 q of checkpoint data
+							fprintf(stderr,"Read iter = %" PRIu64 " and relocation-prime psmall = %u from savefile %s.\n",itmp64,psmall,g_cstr);
+							// Now parse logfile to get proper B2 and validate corresponding B2_start vs B2/[psmall from .s2 file].
+							// Logfiles can be messy and include one or more aborted-restarts; we want the last B2_start-containing
+							// entry followed by a savefile-write entry, as inferred from presence of a "% complete" substring:
+							j = filegrep(STATFILE,"% complete",cbuf,-1);	// Trailing -1 means return last such match, if any, in cbuf
+							filegrep(STATFILE,"B2_start = ",cbuf,j);	// Trailing j-arg means return last such match before line j, if any, in cbuf
+							// If match "B2_start =", read bigstep D from match-line and infer relocation-prime psmall from D:
+							if(strlen(cbuf)) {
+								char_addr = strstr(cbuf,"B2_start = ");
+								B2_start = (uint64)strtoull(char_addr+11, &cptr, 10);	ASSERT(B2_start != -1ull, "strtoull() overflow detected.");
+								char_addr = strstr(cbuf,"B2 = ");
+								B2 = (uint64)strtoull(char_addr+5, &cptr, 10);	ASSERT(B2 != -1ull, "strtoull() overflow detected.");
+								// Relocation-prime as inferred from the logfile's bigstep D. Init = the .s2 file's own psmall,
+								// so that a logfile line lacking a "Bigstep = " field means "nothing to cross-check against"
+								// rather than "psmall = 0"; a *malformed* bigstep does set this to 0, so that the mismatch
+								// is caught by the ensuing ASSERT:
+								uint32 psmall_log = psmall;
+								char_addr = strstr(cbuf,"Bigstep = ");
+								if(char_addr) {
+									i = strtoul(char_addr+10, &endp, 10);
+									if((i%210) == 0)
+										psmall_log = 11;
+									else if((i%330) == 0)
+										psmall_log = 7;
+									else {
+										fprintf(stderr,"WARNING: Bigstep value %u read from logfile %s unsupported ... ignoring.\n",i,g_cstr);
+										psmall_log = 0;
+									}
 								}
+								// Now compare the params from the restartfile vs those captured in the log:
+								if(psmall)
+									ASSERT(psmall == psmall_log && (B2_start == (uint64)psmall * B1 || B2_start == B2 / psmall), "Stage 2 params mismatch those captured in the .stat logfile!");
+								else
+									psmall = psmall_log;
+								// Note we do *not* shortcut to the stage 2 GCD if the checkpoint's q >= B2: only pm1_stage2()
+								// reads the stage 2 residue from the .s2 savefile, so jumping straight to the GCD from here
+								// would hand it the stage 1 residue, and gcd(3^E1 (mod N),N) == 1 always, i.e. any factor
+								// found by the completed stage 2 would be reported as "no factor" and the .s2 savefile
+								// holding it then deleted. pm1_stage2() handles the (savefile q >= B2) case itself, taking
+								// the same early-return-to-GCD path but with the stage 2 residue properly read in first.
+								// Must reset B2_start = B1, since stage 2 code expects that to properly (re)init relocation-params:
+								B2_start = B1;
 							}
-							// Now compare the params from the restartfile vs those captured in the log:
-							if(psmall)
-								ASSERT(psmall == i && (B2_start == psmall * B1 || B2_start == B2 / psmall), "Stage 2 params mismatch those captured in the .stat logfile!");
-							else
-								psmall = i;
-							// If stage 2 q of checkpoint >= B2, proceed directly to GCD:
-							if(itmp64 >= B2)
-								goto PM1_STAGE2_GCD;
-							// Lastly, must reset B2_start = B1, since stage 2 code expects that to properly (re)init relocation-params:
-							B2_start = B1;
 						}
 					}	// endif( S2 restart file exists? )
 				}
@@ -2708,7 +2731,6 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				// If gcd_str non-empty on return, it means one of the intermediate S2 GCDs turned up a factor,
 				// prompting an early-return, In this case the S2 code will have reset B2 to reflect the actual interval run.
 				// Otherwise do end-of-scheduled-S2 GCD - S2 residue returned in arrtmp, no need to call convert_res_FP_bytewise():
-			PM1_STAGE2_GCD:
 				if(strlen(gcd_str)) {
 					s2_partial = TRUE;	// Clue the JSON-generating function to partial-s2-ness
 				} else {

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1014,7 +1014,7 @@ based on iteration count versus PM1_S1_PROD_BITS as computed from the B1 bound, 
 	int jhi;
 #endif
 	// num_b is #buffers per unit of extended-pairing-window size M; wsize is #bytes needed per 'word' of the associated bitmap
-	uint32 bigstep_pow2,rsize, np=0,ns=0,ierr,nerr,m2,m_is_odd,m_is_even,num_b,psmall,wsize, k,k0=0, nmodmul = 0,nmodmul_save = 0, p1,p2;
+	uint32 bigstep_pow2,rsize, np=0,ns=0,ierr,nerr,m2,m_is_odd,m_is_even,num_b,psmall,wsize, k=0,k0=0, nmodmul = 0,nmodmul_save = 0, p1,p2;
 #if USE_PP1_MULTS
 	uint32 word,bit;
 #elif defined(PM1_DEBUG)
@@ -1769,8 +1769,14 @@ MME = 0;
 			}
 			mlucas_fprint(cbuf,pm1_standlone+1);
 			restart = TRUE;
-			if(qlo >= B2)	// qlo >= S2 upper limit - nothing to do but proceed to gcd
+			if(qlo >= B2) {	// qlo >= S2 upper limit - nothing to do but proceed to gcd
+				snprintf(cbuf,STR_MAX_LEN*2, "INFO: %s savefile q[%" PRIu64 "] >= B2[%" PRIu64 "] ... stage 2 for this interval is complete; proceeding to GCD of the stage 2 residue.\n",func,qlo,B2);
+				mlucas_fprint(cbuf,pm1_standlone+1);
+				// k is used as a scratch variable by the MULTITHREAD setup code above, so (re)zero the
+				// bigstep-block counters to make the ensuing "#blocks/#modmul" summary print accurate:
+				k = k0 = 0;
 				goto S2_RETURN;
+			}
 		}
 	}
 
@@ -2519,7 +2525,9 @@ S2_RETURN:
 #endif
 	// (k - k0) = #bigstep-blocks (passes thru above loop) used in stage 2; np + ns + 2*(k - k0) = #modmul:
 	nmodmul = np + ns + 2*(k - k0);	// This is actually redundant, but just to spell it out
-	snprintf(cbuf,STR_MAX_LEN*2,"M = %2u: #buf = %4u, #pairs: %u, #single: %u (%5.2f%% paired), #blocks: %u, #modmul: %u\n",m,m*num_b,np,ns,100.0*2*np/(2*np+ns),k-k0,nmodmul);
+	// Note the (2*np+ns) guard: on the 'savefile q >= B2, nothing left to do' early-return above we never
+	// entered the bigstep loop, so np = ns = 0 and the %-paired figure would otherwise print as nan:
+	snprintf(cbuf,sizeof(cbuf),"M = %2u: #buf = %4u, #pairs: %u, #single: %u (%5.2f%% paired), #blocks: %u, #modmul: %u\n",m,m*num_b,np,ns,(2*np+ns) ? 100.0*2*np/(2*np+ns) : 0.0,k-k0,nmodmul);
 	mlucas_fprint(cbuf,pm1_standlone+1);
 #ifndef PM1_STANDALONE
 

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1770,7 +1770,7 @@ MME = 0;
 			mlucas_fprint(cbuf,pm1_standlone+1);
 			restart = TRUE;
 			if(qlo >= B2) {	// qlo >= S2 upper limit - nothing to do but proceed to gcd
-				snprintf(cbuf,STR_MAX_LEN*2, "INFO: %s savefile q[%" PRIu64 "] >= B2[%" PRIu64 "] ... stage 2 for this interval is complete; proceeding to GCD of the stage 2 residue.\n",func,qlo,B2);
+				snprintf(cbuf,sizeof(cbuf), "INFO: %s savefile q[%" PRIu64 "] >= B2[%" PRIu64 "] ... stage 2 for this interval is complete; proceeding to GCD of the stage 2 residue.\n",func,qlo,B2);
 				mlucas_fprint(cbuf,pm1_standlone+1);
 				// k is used as a scratch variable by the MULTITHREAD setup code above, so (re)zero the
 				// bigstep-block counters to make the ensuing "#blocks/#modmul" summary print accurate:


### PR DESCRIPTION
## The bug

A P-1 run that restarts with a stage-2 (`.s2`) savefile whose checkpoint `q` is `>= B2` reports **`Stage 2: No factor found.`** even when the saved stage-2 residue *does* contain a factor. It then writes a `"status":"NF"` JSON result line advertising the full `"B1"`/`"B2"` interval as searched-and-empty, and **deletes the `.s2` savefile**, destroying the only copy of the residue that held the factor. The assignment is retired and the user is told nothing.

Demonstrated end-to-end on M(250013), same binary, same bounds, same exponent: one run reports `Found 14-digit factor in Stage 2: 30586418411057`, the restart reports no factor (full before/after logs below).

## Root cause

`src/Mlucas.c:2661-2663` (line numbers on current `main`, 590a1a6):

```c
// If stage 2 q of checkpoint >= B2, proceed directly to GCD:
if(itmp64 >= B2)
	goto PM1_STAGE2_GCD;
```

The `goto` jumps past the `pm1_stage2()` call at `Mlucas.c:2674` to the label at `Mlucas.c:2702`. But `pm1_stage2()` is the **only** code that reads the stage-2 residue out of the `.s2` file — the block that takes the shortcut (`Mlucas.c:2617-2632`) opens that file, reads only its first 10 bytes (`TEST_TYPE`, `MODULUS_TYPE`, and the 8-byte `nsquares` field carrying `psmall<<56 | q`) and closes it again.

So at the label, `arrtmp[]` still holds the **stage-1** residue, and `gcd(2,p,arrtmp,...)` at `Mlucas.c:2707` computes `gcd(3^E1 mod N, N)`, which is **always 1**, since `gcd(3,N) == 1` for both `N = 2^p-1` and `N = F_m`. The answer is unconditionally "no factor".

The shortcut is easy to reach: the last stage-2 checkpoint of *every completed* stage 2 stores `q + bigstep` (`pm1.c:2463`) and fires when `(q + bigstep) >= qhi = B2 + m*bigstep` (`pm1.c:2439`, `pm1.c:2051`), i.e. records a value `> B2`. So **any** restart after stage 2 has finished takes it — e.g. a kill/crash/power-loss during the final GCD, which for a 100M-bit modulus is a multi-minute `mpz_gcd`, so the window is not narrow. Lowering `B2` in `worktodo.ini` between runs does the same.

### Second, worse path into the same shortcut

`src/Mlucas.c:2627-2631`:

```c
itmp64 = 0ull; 	for(j = 0; j < 8; j++) { i = fgetc(fp);	itmp64 += (uint64)i << (8*j); }
fclose(fp); fp = 0x0;
if(i != EOF)	// Needed to handle case where .s2 file was touched but ended up empty or < 10 bytes long
	psmall = i;
```

The comment states the intent — cope with a `.s2` that "ended up empty or < 10 bytes long" — but the `i != EOF` test guards only the assignment to `psmall`. `itmp64` has *already* been accumulated from the same `fgetc()` results, and each `EOF` (`-1`) stored into the `uint32 i` becomes `0xFFFFFFFF`, contributing `0xFF` bytes. A truncated `.s2` therefore yields an astronomically large `itmp64`, which trivially satisfies `if(itmp64 >= B2)`.

Such a file arises naturally: the checkpoint write opens the savefile with `mlucas_fopen(savefile,"wb")` (`pm1.c:2459`), which truncates it — so a crash *during a checkpoint write* leaves a short `.s2`, and that same event is what causes the following restart. In that case **stage 2 is never executed at all**, yet the run still emits `"status":"NF"` with the full `B1`/`B2`. (A *completely* empty `.s2` instead aborts loudly at `Mlucas.c:2621`, so only the 2-to-9-byte window is silent.)

## The fix

* **Delete the `goto`** (and with it the now-unreferenced `PM1_STAGE2_GCD` label). `pm1_stage2()` already handles this exact case correctly: `read_ppm1_savefiles()` at `pm1.c:1727` loads the real stage-2 residue into `arrtmp`, and only *then* does `if(qlo >= B2) goto S2_RETURN` (`pm1.c:1751`) fall through to the caller's GCD. The shortcut was redundant as well as wrong.
  The cost is that this rare restart path now pays the stage-2 buffer-init modmuls (~12% of a full stage 2 in the test case below, 26 s of a 90 s stage 2) before the early return. That seemed a clearly acceptable price for not losing the factor; hoisting the savefile read above buffer-init in `pm1_stage2()` would remove even that, but is a bigger and riskier restructuring, so I left it alone.
* **Check for `EOF` on every one of the 8 `nsquares` bytes**, and on a short read warn and ignore the savefile's checkpoint data entirely — so a truncated `.s2` can never be read as "stage 2 already complete". `read_ppm1_savefiles()` then rejects the short file inside `pm1_stage2()`, which sets `qlo = B2_start` and redoes stage 2 in full. Also uses a signed `int` for the `fgetc()` result so the `EOF` compare is unambiguous.
* **`src/pm1.c` collateral on the early-return path**, which this fix makes the *normal* path for such a restart: initialize `k` (it is read uninitialized at `pm1.c:2498` in a non-threaded build, and is clobbered as a scratch variable by the MULTITHREAD setup code at `pm1.c:1180-1186` otherwise), zero `k`/`k0` at the `qlo >= B2` return, and guard the `%`-paired division so the summary line stops printing a garbage block/modmul count and `nan%`. Plus an `INFO:` line stating why no stage-2 work was done.
* **A dedicated `uint32 psmall_log`** for the relocation prime inferred from the `.stat` logfile, instead of reusing `i`. The byte loop now uses its own `int ibyte`, so `i` no longer incidentally holds the `.s2` file's psmall byte at the bottom of the block; without a dedicated local the retained cross-check would compare against whatever `i` last held (`MODULUS_TYPE`, from the earlier header check) whenever the grepped logfile line carries no `"Bigstep = "` field. `psmall_log` is initialized to the savefile's own `psmall`, so "no Bigstep field" unambiguously means "nothing to cross-check against", while a *malformed* bigstep still sets it to 0 and the `ASSERT` fires. Correct in all three sub-cases: valid, malformed and absent bigstep.

## Verification

AVX2 build on x86_64 Linux, GMP enabled, gcc 16.1.1. **This box has no AVX-512 hardware, and I did not exercise the Windows, macOS, ARM or nosimd builds** — the change is architecture-independent C in the P-1 driver, but I want to be explicit about what was actually run.

`M(250013)` has the factor `30586418411057 = 2*k*p + 1` with `k = 2^3 * 241 * 31727`; its only prime `> B1 = 10000` is `31727`, so it is a stage-2 find. Assignment `Pminus1=1,2,250013,-1,10000,2000000` → FFT 16K, `D = 840`, `M = 104`, `psmall = 11`, `B2_start = 110000`.

**Phase 1 — clean uninterrupted run.** Identical before and after the fix:

```
M = 104: #buf = 9984, #pairs: 79736, #single: 794 (99.50% paired), #blocks: 2354, #modmul: 85238
Found 14-digit factor in Stage 2: 30586418411057
{"status":"F", "exponent":250013, ..., "B1":10000, "B2":2000000, "partial-stage-2":false, "factors":["30586418411057"], ...}
```

**Phase 2 — "killed during the final GCD".** Stage-1 savefile and `.stat` logfile restored, plus a genuine mid-stage-2 `.s2` checkpoint (captured at `q = 1963080`, which already contains the factor since the relocated semiprime `11*31727 = 348997` was swept long before) whose `nsquares` field was patched to `11<<56 | 2000840` — exactly what the final checkpoint of a completed stage 2 writes.

*Before (stock `main`, no source modifications):*
```
Read iter = 2000840 and relocation-prime psmall = 11 from savefile p250013.s2.
Stage 2: No factor found.
{"status":"NF", "exponent":250013, ..., "B1":10000, "B2":2000000, ...}
```
and `p250013.s2` was gone afterwards — the factor-bearing residue deleted, no diagnostic.

*After:*
```
Read iter = 2000840 and relocation-prime psmall = 11 from savefile p250013.s2.
Using 9984 Stage 2 memory buffers, D = 840, M = 104, psmall = 11.
Buffer-init done; clocks = 00:00:25.758, MaxErr = 0.000152588.
Read stage 2 savefile p250013.s2 ... restarting stage 2 from q = 2000840.
INFO: pm1_stage2 savefile q[2000840] >= B2[2000000] ... stage 2 for this interval is complete; proceeding to GCD of the stage 2 residue.
M = 104: #buf = 9984, #pairs: 0, #single: 0 ( 0.00% paired), #blocks: 0, #modmul: 0
Found 14-digit factor in Stage 2: 30586418411057
{"status":"F", "exponent":250013, ..., "factors":["30586418411057"], ...}
```

**Phase 3 — truncated `.s2`** (`03 01 48 f4 1d`: valid `TEST_TYPE` + `MODULUS_TYPE`, then cut off mid-`nsquares`).

*Before:*
```
Read iter = 71775015239808072 and relocation-prime psmall = 0 from savefile p250013.s2.
Stage 2: No factor found.
{"status":"NF", "exponent":250013, ..., "B1":10000, "B2":2000000, ...}
```
`pm1_stage2()` was never called — zero stage-2 work, run finished in seconds, assignment retired as NF.

*After:*
```
WARNING: stage 2 savefile p250013.s2 is truncated [< 10 bytes] ... ignoring its checkpoint data; stage 2 will restart from B2_start.
...
Stage 2 q0 = 110040, k0 = 131
M = 104: #buf = 9984, #pairs: 79736, #single: 794 (99.50% paired), #blocks: 2354, #modmul: 85238
Found 14-digit factor in Stage 2: 30586418411057
{"status":"F", ..., "factors":["30586418411057"], ...}
```
i.e. the full stage 2 is redone, with the same modmul count as the clean phase-1 run, and the factor is found.

**Phase 5 — logfile with no `Bigstep` field.** The narrow case the `psmall_log` local exists for: the phase-1 artifacts with the `.s2`'s psmall byte zeroed and `", Bigstep = 840"` stripped from the `.stat` line. Stock `main` reports `psmall = 0`, resumes from `q = 1963080` and finds `30586418411057`; this branch is byte-identical.

**Phase 4 — no-factor regression.** `Pminus1=1,2,250037,-1,10000,200000`, an exponent with nothing to find in that range. Before and after are identical, including the stage-2 statistics, so a genuine NF is still reported as NF and no false factor is manufactured:
```
M = 41: #buf = 3936, #pairs: 9781, #single: 226 (98.86% paired), #blocks: 258, #modmul: 10523
Stage 2: No factor found.
{"status":"NF", "exponent":250037, ..., "B1":10000, "B2":200000, ...}
```

**No collateral damage:**
* Full clean `bash makemake.sh avx2` build, warning summary byte-identical to `main`.
* `obj_avx2/Mlucas -s tt`: `Res64` for 13K/14K/15K = `E3BC90B0E652C7C0` / `DB8E39C67F8CCA0A` / `B3C5A1C03E26BB17`, matching the known-good references. (The 1K/2K "Excessive level of roundoff error" rejections are the pre-existing #101 noise, unchanged.)
* `src/pm1.c` still compiles standalone under `-DPM1_STANDALONE`.

## Note on scope

This is one of three independent P-1 stage-2 defects in the same area. The other two — a restart dropping the trailing `M/2` D-intervals' unpaired primes, and small-prime relocation switching on `m2+1` intervals too late — are prime-*coverage* bugs in `pm1.c`, fixed separately in #177.

Two lines here are carried on behalf of other PRs, so that each contested line has exactly one owner: the `(uint64)` cast in the stage-2 parameter `ASSERT` (#177's fix for a `psmall * B1` overflow — this PR relocates and renames that line, so the cast has to travel with it), and `sizeof(cbuf)` on the `pm1.c` `"M = %2u"` snprintf (#92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

