### PR TITLE
Gerbicz check: repair the corrupt check-product copy, not the good one

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1896,8 +1896,8 @@ READ_RESTART_FILE:
 				if(!mi64_cmp_eq(b_uint64_ptr,d_uint64_ptr,n)) {	// Houston, we have a problem
 					s1 = consensus_checksum(s1,s2,s3);
 					if(s1 == sum64(b_uint64_ptr, n)) {	/* b-data good; no-op */
-					} else if(s1 == sum64(d_uint64_ptr, n)) {	// c-data good, copy back into b
-						memcpy(d, b, nbytes);
+					} else if(s1 == sum64(d_uint64_ptr, n)) {	// d-data good, copy back into b
+						memcpy(b, d, nbytes);
 					} else	// Catastrophic data corruption
 						ASSERT(0, "Catastrophic data corruption detected in G-checkproduct integrity validation ... rolling back to last good G-check. ");
 				}


### PR DESCRIPTION
## The bug

`src/Mlucas.c:1900` — the Gerbicz-check self-healing mechanism copies the **corrupt** array over the **good** one, so a detected corruption is never repaired.

### The redundancy mechanism

The G-check product `b[]` is shadowed by a redundant copy `d[]` plus a triply-redundant whole-array checksum `s1`/`s2`/`s3`, so that a single-word corruption of either array can be detected *and repaired* (h/t George Woltman, per the comment at 1924-1925). `b[]` is the master, `d[]` the shadow — every re-sync in the file is `memcpy(d, b, nbytes)`:

| line | context |
|---|---|
| 1676 | initial `d = b` |
| 1875 | save un-updated check-product before a G-check |
| 1927 | per-update re-sync, paired with `s1 = sum64(b); s2 = s3 = s1;` |
| 2190 / 2198 | post-G-check re-sync, same pairing |

The integrity check runs before each `b[]`-update:

```c
1895:  // prior to each b[]-update, check integrity of array data:
1896:  if(!mi64_cmp_eq(b_uint64_ptr,d_uint64_ptr,n)) {	// Houston, we have a problem
1897:      s1 = consensus_checksum(s1,s2,s3);
1898:      if(s1 == sum64(b_uint64_ptr, n)) {	/* b-data good; no-op */
1899:      } else if(s1 == sum64(d_uint64_ptr, n)) {	// c-data good, copy back into b
1900:          memcpy(d, b, nbytes);
1901:      } else	// Catastrophic data corruption
1902:          ASSERT(0, "Catastrophic data corruption detected in G-checkproduct integrity validation ... ");
```

Both branches were checked:

* **1898, checksum matches `sum64(b)`** — `b[]` good, `d[]` corrupt. The empty body is *correct*: `d[]` is unconditionally re-synced from `b[]` at 1927 a few lines later.
* **1899, checksum matches `sum64(d)`** — `d[]` good, `b[]` corrupt. This is the branch that must repair, and its own comment says **"copy back into b"**. But `memcpy(dest, src)` means line 1900 is `d <- b`: it overwrites the surviving good copy with the corrupt one and leaves the corrupt check-product in `b[]`. Net effect: both branches leave `b[]` untouched and `d[]` equal to corrupt `b[]`, so the redundancy scheme buys nothing.

`nbytes = nalloc<<3` (1409-1410) is exactly one full residue array (`b = a + nalloc; c = b + nalloc; d = c + nalloc`, 1426), i.e. the length/units are right and match every other `b`/`d` `memcpy` — only the argument order is wrong.

## The fix

```diff
-					} else if(s1 == sum64(d_uint64_ptr, n)) {	// c-data good, copy back into b
-						memcpy(d, b, nbytes);
+					} else if(s1 == sum64(d_uint64_ptr, n)) {	// d-data good, copy back into b
+						memcpy(b, d, nbytes);
```

(The branch comment's "c-data" is also corrected to "d-data" — the arrays compared are `b` and `d`.)

## Verification: fault injection, before/after

Instrumented build of this tree: `ITERS_BETWEEN_GCHECK_UPDATES = 100`, `ITERS_BETWEEN_GCHECKS = 10000`, prints in the three 1896 branches, env-gated single-word corruption of `b[]` injected right after the 1926-1929 re-sync (so `b[]` and `d[]` are known-equal and the checksum is known-good at the moment of corruption), and an env switch selecting the old vs new `memcpy` argument order — so both behaviours come from one binary and nothing else differs.

Test case `PRP=1,2,46601,-1`, `CheckInterval = 1000`, AVX2, 4 threads, FFT 3K. G-checks land at iters 10000/20000/30000/40000; corruption is injected at iter 20100 and detected at 20200.

**Uncorrupted control:** 4/4 `Gerbicz check passed`, `"res64":"3E61CFB244B02110"`, `"gerbicz":0`, exit 0.

**Before — `memcpy(d, b, nbytes)`, 1-ulp bit flip (`b_uint64_ptr[7] ^= 1`):**
```
***FI: flipped low bit of b[7] at iter 20100
***INTEG: b[] != d[] detected at iter 20200
***INTEG: consensus says d good / b corrupt -> memcpy(d,b) [UPSTREAM 590a1a6]
***INTEG: post-repair: good-checksum=D0B71BE742674E47  sum64(b)=D0B71BE742674E48 [b STILL CORRUPT]  sum64(d)=D0B71BE742674E48 [d CLOBBERED]
```
The consensus checksum correctly identifies `d[]` as the good copy; the "repair" then destroys it. (This particular 1-ulp perturbation happens to fall below the carry-step rounding threshold, so the run still finishes correctly — it demonstrates the inverted repair, not the downstream damage.)

**After — `memcpy(b, d, nbytes)`, same injection:**
```
***FI: flipped low bit of b[7] at iter 20100
***INTEG: b[] != d[] detected at iter 20200
***INTEG: consensus says d good / b corrupt -> memcpy(b,d) [FIXED]
***INTEG: post-repair: good-checksum=D0B71BE742674E47  sum64(b)=D0B71BE742674E47 [b OK]  sum64(d)=D0B71BE742674E47 [d OK]
At iteration 30000, shift = 13103: Gerbicz check passed.
At iteration 40000, shift = 28447: Gerbicz check passed.
"res64":"3E61CFB244B02110"  "gerbicz":0
```

**Before — `memcpy(d, b, nbytes)`, one whole-word corruption (`b[7] += 1.0`):**
```
***FI: b[7] += 1.0 at iter 20100
***INTEG: b[] != d[] detected at iter 20200
***INTEG: consensus says d good / b corrupt -> memcpy(d,b) [UPSTREAM 590a1a6]
***INTEG: post-repair: good-checksum=D0B71BE742674E47  sum64(b)=D0B71BA742674E47 [b STILL CORRUPT]  sum64(d)=D0B71BA742674E47 [d CLOBBERED]
...
Unhandled Error of type[9] = ERR_ROUNDOFF in FFT(b)*FFT(c) step - please send e-mail ...
```
`SIGABRT` (core dumped) at iter 20200, no result line emitted, the assignment is not retired. Deltas as small as `+0.0625` produce the same abort at this FFT length.

**After — `memcpy(b, d, nbytes)`, same `b[7] += 1.0` injection:**
```
***FI: b[7] += 1.0 at iter 20100
***INTEG: b[] != d[] detected at iter 20200
***INTEG: consensus says d good / b corrupt -> memcpy(b,d) [FIXED]
***INTEG: post-repair: good-checksum=D0B71BE742674E47  sum64(b)=D0B71BE742674E47 [b OK]  sum64(d)=D0B71BE742674E47 [d OK]
At iteration 30000, shift = 13103: Gerbicz check passed.
At iteration 40000, shift = 28447: Gerbicz check passed.
"res64":"3E61CFB244B02110"  "gerbicz":0
```

The repair now heals the array exactly: `b[]` is restored bit-for-bit, the **subsequent** Gerbicz checks at 30000 and 40000 pass, `"gerbicz":0`, and the final residue `3E61CFB244B02110` matches the uncorrupted control run exactly (identical intermediate shift counts 13103/28447 as well, i.e. the run is bit-identical to the control from the repair onward).

## Consequence in real runs

Single-word corruption of the Gerbicz check-product — exactly the failure mode this code exists to absorb ("not uncommon on e.g. cellphones", comment at 1993) — is detected and then made unrecoverable. With `ITERS_BETWEEN_GCHECKS = 10^6` the outcomes are either an immediate `ERR_ROUNDOFF` hard abort in the `FFT(b)*FFT(c)` step, or a failed Gerbicz check up to 10^6 iterations later that rolls the run back to the last `.G` checkpoint and discards that work — where a working repair would have cost one `memcpy`. This is on the main PRP path of every Mersenne PRP and Fermat Pépin run. It cannot produce a silently wrong final residue (the G-check-failure path itself is sound), so the impact is lost work / spurious error counts / spurious aborts.

## Collateral-damage check

* Clean full `bash makemake.sh avx2` build, no new warnings (the pre-existing `-Wcomment`/`-Wpointer-sign`/`-Wunused-label`/`-Wuninitialized` counts are unchanged from main).
* `obj_avx2/Mlucas -s tt` passes with the expected residues: 13K `E3BC90B0E652C7C0`, 14K `DB8E39C67F8CCA0A`, 15K `B3C5A1C03E26BB17`. (The "Excessive level of roundoff error ... radix set will not be used" lines at 1K/2K are the known pre-existing behaviour tracked by #101.)
* Uncorrupted `PRP=1,2,46601,-1` with the fixed non-instrumented binary: `res64 3E61CFB244B02110`, byte-identical to the same run against a pristine build of `main` — the fix changes nothing on the no-corruption path, which is the only path a healthy run takes.

Tested on x86-64 Linux, AVX2, GCC 16.1.1. Not exercised on AVX-512 / Windows / ARM, but the change is a single argument swap in architecture-independent driver code.
