### PR TITLE
SQR_LOHI192: propagate the dropped cross-term carry (wrong result for ~25% of inputs, C and asm)

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -6402,7 +6402,8 @@ On Alpha, this needs a total of 12 MUL instructions and 42 ALU ops.
 		MUL_LOHI64(__x.d0,__x.d2, __e , __f );	/*   x0*x2 */\
 		MUL_LOHI64(__x.d1,__x.d2, __i , __j );	/*   x1*x2 */\
 		/* Add last pair (bottom layer) cross terms: */\
-		__b += __e;	__i += __f + (__b < __e);	/* f is a UMULH output, so f + CY cannot overflow */\
+		__b += __e;	__f += (__b < __e);	/* f is a UMULH output, so f + CY cannot overflow */\
+		__i += __f;	__j += (__i < __f);	/* ...but i + (f + CY) can, so ripple that carry into j */\
 		__hi.d2 = ((int64)__j < 0);\
 		/* Interleave left-shift of the 4-word result with squaring MULs: */\
 		/*** I wish I could say that interleaving the MULs and ALU stuff gives a speedup, but on x86_64 I get same speed if I do */\
@@ -6433,10 +6434,12 @@ On Alpha, this needs a total of 12 MUL instructions and 42 ALU ops.
 		/* Evaluate the cross-terms first, then right-shift those 1 place while we compute the w0-w5 terms: */\
 	"movq	%[__x0],%%rax	\n\t	mulq	%[__x1]	\n\t	movq	%%rax,%%r11	\n\t	movq	%%rdx,%%r12	\n\t"/* _a:_b = x0*x1 */\
 	"movq	%[__x0],%%rax	\n\t	mulq	%[__x2]	\n\t	movq	%%rax,%%rdi	\n\t	movq	%%rdx,%%r13	\n\t"/* _e:_f = x0*x2 */\
-	"movq	%[__x1],%%rax	\n\t	mulq	%[__x2]	\n\t		movq %%rdx,%%r14  \n\t	movq	%%rdx,%%r15	\n\t"/* _i:_j = x1*x2; leave _i in rax, make 2 copies of rdx */\
+	"movq	%[__x1],%%rax	\n\t	mulq	%[__x2]	\n\t		movq %%rdx,%%r14  \n\t"/* _i:_j = x1*x2; leave _i in rax, _j in r14 */\
 		/* Add last pair (bottom layer) cross terms: */\
 		"addq	%%rdi,%%r12		\n\t"/* _b += _e */\
 		"adcq	%%rax,%%r13		\n\t"/*	_i += _f + (_b < _e); _f is a UMULH output, so f + CY cannot overflow */\
+		"adcq	$0,%%r14		\n\t"/*	_j += (_i < _f); ...but _i + (_f + CY) can, so ripple that carry into _j */\
+		"movq	%%r14,%%r15		\n\t"/* copy of the now-final _j, for _w5 */\
 		"shrq	$63,%%r15		\n\t"/* _w5 = (_j >> 63) */\
 		/* Interleave left-shift of the 4-word result with squaring MULs: */\
 	"movq	%[__x0],%%rax	\n\t	mulq	%%rax	\n\t	movq	%%rax,%[__lo0] \n\t	movq	%%rdx,%%r10	\n\t"/* w0:w1 = x0^2 */\


### PR DESCRIPTION
## The bug

`SQR_LOHI192` — the scalar 192-bit squaring macro — computes the **wrong answer for ~25% of
uniform-random inputs**, in *both* of its bodies:

* `src/imul_macro1.h:6405` — portable-C "Standard-C version #2" (used by ARM/aarch64, RISC-V, PPC,
  s390x, 32-bit x86, and any non-GCC-flavoured compiler)
* `src/imul_macro1.h:6439` — the x86_64 inline-asm twin (used by every GCC/Clang x86-64 build)

Both build the doubled cross-term rhombus as a 4-word accumulator `(__a,__b,__i,__j)` at word
positions 1..4, then fold the `x0*x2` product `(__e,__f)` (positions 2,3) into it:

```c
__b += __e;	__i += __f + (__b < __e);	/* f is a UMULH output, so f + CY cannot overflow */
```

The comment is correct about `__f + CY` (`__f` is a UMULH output, so `__f <= 2^64-2`) and beside the
point: the carry **out of `__i` into `__j`** is never propagated. It really does occur — the
accumulator has to hold `x0*x1 + 2^64*x0*x2 + 2^128*x1*x2`, which is only bounded by `2^256`, not
`2^192`. The asm form has the identical defect; there the `adcq`'s carry-out is destroyed by the very
next instruction:

```
"addq	%%rdi,%%r12	\n\t"  /* _b += _e */
"adcq	%%rax,%%r13	\n\t"  /* _i += _f + CY   <-- carry out of _i dropped */
"shrq	$63,%%r15	\n\t"  /* clobbers CF */
```

The accumulator is then doubled (`shldq $1` / `<<1`), so a carry lost at word 4 surfaces as a deficit
of exactly **2 in output word 4** (`__hi.d1`).

### Witness

```
x = { d0 = 0xffd53b348b517adb, d1 = 0xffff1afc3a492b21, d2 = 0xfffffe8e94cc2519 }

hi.d1 = 0x385fa481adf7d193   (both the C and the asm body, before this PR)
hi.d1 = 0x385fa481adf7d195   (exact; cross-checked with Python big-ints)
```

`lo.d0-2` and `hi.d0`/`hi.d2` are correct; only `hi.d1` is short by 2.

## The fix

Ripple the carry. In C, split the fold into two add/compare pairs — the idiom the `#if 0`'d
"arrangement #1" body at `:6343` and the `MUL_LOHI64_SUBROUTINE` body at `:6258` already get right:

```c
__b += __e;	__f += (__b < __e);	/* f is a UMULH output, so f + CY cannot overflow */
__i += __f;	__j += (__i < __f);	/* ...but i + (f + CY) can, so ripple that carry into j */
```

In asm, one extra `adcq $0,%%r14` (`__j` cannot overflow: `__j <= 2^64-2` before the carry), and the
copy of `_j` that feeds `_w5 = _j >> 63` is now taken *after* that carry has been added instead of
straight off `rdx`. Net cost: one instruction. Registers, constraints and clobbers are unchanged
(`r14`/`r15` were already clobber-listed).

The pipelined `SQR_LOHI192_q4`/`_q8` (`:6492`/`:6601`) have a separate, already-correct
implementation and are untouched.

## Verification

**1. Macro-level differential harness.** `SQR_LOHI192` compared against an independent
`unsigned __int128` schoolbook-multiply oracle (cross-checked against Python big-ints), compiled four
times from the same headers to cover both bodies:

| variant | selects |
|---|---|
| A | `YES_ASM` + `MULH64_FAST` — the shipping config on x86-64 |
| B | asm MULs, slow-MULH64 C bodies |
| C | all portable-C bodies — what ARM/RISC-V/PPC/32-bit-x86 compile |
| D | portable-C + slow-MULH64 |

Five input generators: (0) uniform random 64-bit words; (1) a 20-value boundary pool
(0, 1, 2, 3, 2^64-1, 2^64-2, 2^63, 2^63±1, 2^32, 2^32±1, 0x5555…, 0xaaaa…, …); (2) per-word mixes of
random and boundary values; (3) "runs of set/clear bits" (random value OR'd with `~0<<k` or AND'd with
`(1<<k)-1`) — the regime that stresses carry chains hardest; and (4) the interleave of modes 0-3.
Being a squaring, every case is an equal-operand case by construction.

**5 000 000 inputs per generator per variant:**

| input generator | mismatches before | after |
|---|---|---|
| uniform random | 1 251 145 / 5 000 000 (25.0 %) | **0** |
| boundary-value pool | 746 217 / 5 000 000 (14.9 %) | **0** |
| random/boundary per-word mix | 912 134 / 5 000 000 (18.2 %) | **0** |
| runs of set/clear bits | 1 236 396 / 5 000 000 (24.7 %) | **0** |
| interleaved modes 0-3 | 1 036 730 / 5 000 000 (20.7 %) | **0** |
| **total** | **5 182 622 / 25 000 000 cases** | **0 / 25 000 000** |

25 000 000 cases x 4 variants = **100 000 000 macro invocations**, zero mismatches after the fix.
(At the original 200 000-input volume the numbers are 49 630/200 000 uniform-random and
41 042/200 000 mixed-mode, i.e. the 24.8 % figure this was first spotted at.)

The same harness sweeps 115 other multiword macros; their per-macro mismatch counts are **identical
before and after**, only the `sqr_lohi192` line disappears — so nothing else moved.

**2. End-to-end, through `twopmodq192()`.** For 200 random 192-bit primes `q` per width with
`p = q-1`, Fermat's little theorem makes the correct return value exactly `1` — this is precisely the
check already performed in-tree at `factor_test.h:585`. Count returning `1`:

| q width | before | after this PR | after this PR + #142 |
|---|---|---|---|
| 130 / 150 / 165 / 175 bits | 200/200 | 200/200 | 200/200 |
| 185 bits | **152/200** | 200/200 | 200/200 |
| 191 bits | **0/200** | 200/200 | 200/200 |
| 192 bits | **0/200** | 1/200 | 200/200 |

The widths ≤ 175 bits passing either way is exactly why this was never caught: the largest `q` in
`src/fac_test_dat192.h` is ~2^176, which drops the per-squaring failure probability to ~2^-16.
The residual 192-bit-`q` column is a *different*, already-reported defect — the `j == 0`
shift-by-64 UB in the lead-bits extraction that #142 fixes; with both patches applied the routine is
correct across the full 192-bit range. Applying #142 alone leaves 0/200 at 191 and 192 bits, so the
two are independent.

Same picture for `twopmmodq192()` with a 190-bit odd modulus: 118/200 wrong before, **0/200** after.

**3. No collateral damage.** Full clean `bash makemake.sh avx2`, then `obj_avx2/Mlucas -s tt`:

```
13K = E3BC90B0E652C7C0    14K = DB8E39C67F8CCA0A    15K = B3C5A1C03E26BB17
```

matching the reference residues (the 1K/2K "excessive roundoff" notices are the known behaviour
tracked by #101/#104).

**4. The affected configuration builds and self-tests clean.**
`makemake.sh nosimd mfac 3word` builds and its startup `test_fac()` passes, including
`Testing 192-bit Fermat factors...` and `Testing 128x2-bit factors using 160 and 192-bit modmul
routines...`. (That build needs LTO disabled to link at all, because of the pre-existing inline-asm
label collision that #82 fixes — unrelated to this change; `makemake.sh avx2 mfac 3word` is rejected
outright by `factor.h:108`, since P3WORD is incompatible with `USE_FMADD`.)

## Reachability

Live call sites of the *scalar* `SQR_LOHI192`, all traced:

* **`twopmmodq192()` (`src/twopmodq192.c:155`, `:196`) — reachable from the DEFAULT `Mlucas`
  binary.** `Mlucas.c:5292` calls it in the PRP-cofactor known-factor verification, whenever a
  supplied `KNOWN_FACTORS[]` entry occupies 3 limbs (2^128 < factor < 2^192), to compute
  `pow' = 2^nsquares (mod factor-1)`. This is not a factoring-only path — no `-DP3WORD` needed.
* **`twopmodq192()` (`src/twopmodq192.c:415`)** — the scalar 192-bit TF modpow, reached from
  `factor.c:3462` in a `-DP3WORD` Mfactor build with `TRYQ == 1` (which `factor.h:53` forces when
  `TRYQ` is not otherwise set). `3word` is a documented, user-selectable Mfactor build mode
  (`bash makemake.sh mfac 3word`, `MAX_BITS_Q = 192`), so this is user-reachable, not dead code.
* **`twopmodq192_q4`/`_q8` (`:695-698`, `:1066-1069`, `:1370-1377`)** — the `#else` arms of
  `#if PIPELINE_MUL192`. `PIPELINE_MUL192` defaults to 1 under P3WORD but `factor.h:47-51`
  explicitly documents `-DPIPELINE_MUL192=0` as a user override; in that configuration the *default*
  3-word TF path uses the broken scalar macro for every squaring.
* **`test_fac()` (`factor_test.h:585`, `:697`)** — called unconditionally at Mfactor startup
  (`factor.c:1047`), in *every* word mode, not just P3WORD.
* `twopmodq160.c:248` — latent; `twopmodq160()` has no live callers.

Corrections to what I initially assumed: `factor.c:3859` is inside a `#if 0` block, so it is *not* a
live call site; and the `-DP3WORD` self-test does **not** currently fail, because its test vectors top
out around 2^176 (see the width table above).

## Related, not fixed here (reported so it isn't lost)

While confirming the reachability above I found a second, independent defect on the
`Mlucas.c:5292` path: `twopmmodq192()` computes `qhalf` at `src/twopmodq192.c:68`, *before* the
`RSHIFT192(q,nshift,q)` at `:86` strips trailing zero bits from the modulus, and never recomputes it.
Every mod-doubling step then compares against a stale threshold. Since the modulus on that path is
`KNOWN_FACTORS[i] - 1`, i.e. always even, `nshift >= 1` always. Measured on 200 random 3-limb
factors per width: **52/200 wrong at 130 bits, 56/200 at 150, 39/200 at 170, 50/200 at 185** — and
recomputing `qhalf` after the shift takes all of those to 0/200 (this PR alone does not, since the
two defects are independent). That is very likely a cause of open issue #32, "Assertion failed:
Full-residue == 3^nsquares (mod q) check fails!" — the assertion immediately after that call. It will
get its own PR.

I also re-checked the immediate neighbours for the same defect shape: the `#if 0` "arrangement #1"
body (`:6343`) and the `MUL_LOHI64_SUBROUTINE` body (`:6258`) both use the correct `__cyN`
accumulator idiom; `SQR_LOHI192_q4`/`_q8`, `MUL_LOHI192`, `MULL192` (C *and* asm) and `MULH192` are
all exact in the harness. A grep for the `__i += __f + (...)` shape across `imul_macro*.h` finds this
one site only.

## What I could not test

This box is **AVX2 x86-64 / GCC 16.1.1 / Linux only**. Specifically:

* **No 32-bit x86, ARM/aarch64, RISC-V, PPC or s390x hardware.** Those targets compile the
  portable-C body, which *was* executed here via harness variants C and D — the same preprocessor
  state those platforms see (`YES_ASM` suppressed) — but not on real hardware.
* **No MSVC, SunStudio/ICC or NVCC build.** The `MUL_LOHI64_SUBROUTINE` macro set (x86_64 +
  SunStudio/ICC) could not be compiled at all; separately, its `SQR_LOHI192` body is one of the ones
  that already uses the correct idiom, so it needs no change.
* **No AVX-512 hardware** (irrelevant here — this macro is scalar integer code with no SIMD variant).
* No real GIMPS PRP-cofactor run with a 3-limb known factor was performed; the `twopmmodq192`
  evidence above is from calling the routine directly with the same operand shapes
  `Mlucas.c:5292` passes it.
