### PR TITLE
Validate that every known factor divides the modulus, not just the first (PRP-CF late-abort + crash-loop)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -6355,7 +6355,8 @@ Returns: The number of factors read in.
 */
 uint32 extract_known_factors(uint64 p, char *fac_start) {
 	uint32 i, findex, lenf, nchar, nfac = 0;
-	uint64 *fac = 0x0, twop[4], quo[4],rem[4];	// fac = ptr to each mi64-converted factor input string;
+	uint64 *fac = 0x0, *kfac = 0x0, twop[4], quo[4],rem[4];	// fac = ptr to each mi64-converted factor input string;
+											// kfac = ptr to the KNOWN_FACTORS[] slot that factor was just stored in;
 	uint256 p256,q256,res256;
 	char *cptr = fac_start+1;
 	ASSERT(fac_start[0] == '\"',"Known-factors line of worktodo must consist of a comma-separated list of such enclosed in double-quotes!");
@@ -6391,15 +6392,23 @@ uint32 extract_known_factors(uint64 p, char *fac_start) {
 		mi64_set_eq(KNOWN_FACTORS + 4*nfac++,fac,lenf);
 		// Verify that F is a base-3 Fermat-PRP via binary modpow, 3^(q-1) == 1 (mod q):
 		ASSERT(mi64_pprimeF(fac,3ull,lenf),"Factor-is-base-3-PRP check fails!");
-		// Verify that it's a factor via binary modpow:
+		// Verify that it's a factor via binary modpow. Must test the factor we just parsed, which the above
+		// mi64_set_eq stored - zero-padded to 4 limbs - in slot (nfac-1), *not* KNOWN_FACTORS[0..3]: using the
+		// latter made the check a no-op for every factor after the first, so a non-dividing 2nd..10th factor
+		// was only caught much later, by the C = N/F remainder ASSERT in Suyama_CF_PRP:
+		kfac = KNOWN_FACTORS + 4*(nfac-1);
 		p256.d0 = p; p256.d1 = p256.d2 = p256.d3 = 0ull;
-		q256.d0 = KNOWN_FACTORS[0];	q256.d1 = KNOWN_FACTORS[1];	q256.d2 = KNOWN_FACTORS[2];	q256.d3 = KNOWN_FACTORS[3];
+		q256.d0 = kfac[0];	q256.d1 = kfac[1];	q256.d2 = kfac[2];	q256.d3 = kfac[3];
 		res256 = twopmmodq256(p256,q256);
 		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
-			ASSERT(CMPEQ256(res256,ONE256),"Factor-divides-modulus check fails!");
+			i = CMPEQ256(res256,ONE256);
 		} else {
 			res256.d0 += 1ull;	// Fermat case: check that 2^p == -1 == q - 1 (mod q):
-			ASSERT(CMPEQ256(res256,q256),"Factor-divides-modulus check fails!");
+			i = CMPEQ256(res256,q256);
+		}
+		if(!i) {
+			snprintf(g_cstr,sizeof(g_cstr),"%s: known-factor #%u [%s] of this assignment does not divide the modulus ... please correct or remove that entry.",WORKFILE,nfac,cbuf);
+			ASSERT(0,g_cstr);
 		}
 		// If find any duplicate-entries in input list, warn & remove:
 		if(nfac > 1) {


### PR DESCRIPTION
## The bug

`extract_known_factors()` (`src/Mlucas.c`) validates every alleged known factor of a PRP-CF
assignment three ways: proper form (`q = 2.k.p+1`, or `k.2^(n+2)+1` for Fermat), base-3
Fermat-PRP, and "does this actually divide the modulus". The first two checks use the
just-parsed local `fac[]`. The third did not:

```c
mi64_set_eq(KNOWN_FACTORS + 4*nfac++,fac,lenf);
...
// Verify that it's a factor via binary modpow:
p256.d0 = p; p256.d1 = p256.d2 = p256.d3 = 0ull;
q256.d0 = KNOWN_FACTORS[0];	q256.d1 = KNOWN_FACTORS[1];	q256.d2 = KNOWN_FACTORS[2];	q256.d3 = KNOWN_FACTORS[3];
res256 = twopmmodq256(p256,q256);
if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
	ASSERT(CMPEQ256(res256,ONE256),"Factor-divides-modulus check fails!");
} else {
	res256.d0 += 1ull;	// Fermat case: check that 2^p == -1 == q - 1 (mod q):
	ASSERT(CMPEQ256(res256,q256),"Factor-divides-modulus check fails!");
}
```
(`src/Mlucas.c:6391-6400` at 590a1a6)

This sits inside the per-factor `while` loop. The factor just parsed lives in
`KNOWN_FACTORS + 4*(nfac-1)`, but the code unconditionally loads `KNOWN_FACTORS[0..3]` -
the **first** factor. So for every factor after the first, the divides-the-modulus test
re-verifies factor #1 and passes vacuously. Only the first known factor of a list is ever
genuinely validated.

## Why it matters

A PRP-CF assignment whose 2nd..10th factor is wrong - a worktodo typo, a hand-edited
assignment line, a factor pasted in from a different exponent - passes parsing. The only
backstop is the `C = N/F should have 0 remainder!` ASSERT in `Suyama_CF_PRP`
(`src/Mlucas.c:3421`), which is reached **after** the entire PRP test has been performed.
That is a hard abort: nothing is written to `results.txt`, the worktodo entry is never
retired, and on restart the savefile is re-read and the run aborts again - this time in
`read_ppm1_savefiles`, on the `Full-residue == base^nsquares (mod q)` check, which is
likewise run against the bogus factor. The result is a **permanent crash loop** the user
can only escape by hand-editing `worktodo.txt`, with no diagnostic pointing at the real
cause. On the multi-million-digit exponents PRP-CF is used for, that is weeks to months of
compute discarded.

A correct check already exists at parse time and costs one modpow; it was simply
mis-indexed.

## The fix

Build `q256` from `KNOWN_FACTORS + 4*(nfac-1)` - the slot `mi64_set_eq` just wrote, which
is zero-padded to 4 limbs because `KNOWN_FACTORS[]` is cleared at the start of every
assignment (`src/Mlucas.c:441`) - and replace the two bare
`"Factor-divides-modulus check fails!"` ASSERTs with one message that names the offending
factor and its position in the list, so the rejection is actionable:

```
ERROR: Function extract_known_factors, at line 6408 of file ../src/Mlucas.c
Assertion '0' failed: worktodo.txt: known-factor #2 [559213] of this assignment does not
divide the modulus ... please correct or remove that entry.
```

For a single-factor assignment (the common case) `4*(nfac-1) == 0`, so behaviour is
bit-identical to before.

## Reproduction, before and after

Small exponent so the failure arrives in seconds rather than months:
M46601 = 279607 . 372809 . 51727111 . C14010, with 559213 (= 2.6.46601+1; prime, base-3
PRP, form-valid, but does **not** divide M46601) spliced into the known-factor list.
AVX2 build, gcc 16.1.1, FFT 3K.

| worktodo | stock main (590a1a6) | this branch |
|---|---|---|
| `...,3,5,"559213,279607,372809"` | rejected at parse (`Mlucas.c:6396`) | rejected at parse, names factor #1 |
| `...,3,5,"279607,559213,372809"` | **accepted**; all 46601 squarings run, then abort at `Suyama_CF_PRP:3421` | rejected at parse, names factor #2 |
| `...,3,5,"279607,372809,559213"` | **accepted**; same late abort | rejected at parse, names factor #3 |
| `...,3,5,"279607,18446744073713532469"` (bogus 2-limb factor) | **accepted**; still squaring when killed | rejected at parse, names factor #2 |

Stock-main log for the 2nd-position case:
```
 worktodo.txt entry: PRP=1,2,46601,-1,99,0,3,5,"279607,559213,372809"
Suyama-PRP on cofactors of M46601: using FFT length 3K = 3072 8-byte floats.
Fermat-PRP residue (A)     = 0X3E61CFB244B02110, 6073296951,44687172017
3^(F-1) residue (B)        = 0X9458C5FA182A448E,14406856932,22376625060
ERROR: Function Suyama_CF_PRP, at line 3421 of file ../src/Mlucas.c
Assertion '1 == mi64_div(bi,BASE_MULTIPLIER_BITS, j,lenf, ci,0x0)' failed: C = N/F should have 0 remainder!
```
and the crash loop on the next two invocations, with `results.txt` never created and
`worktodo.txt` unchanged:
```
 INFO: restart file p46601 found...reading...
ERROR: Function read_ppm1_savefiles, at line 5306 of file ../src/Mlucas.c
Assertion '0' failed: Full-residue == 3^nsquares (mod q) check fails!
```
With this branch, all four bad lists are rejected during worktodo parsing, before any FFT
work is done and before any savefile exists.

## Verification that working PRP-CF is not regressed

Since this is validation code, a false rejection would be as bad as a false acceptance.
Same M46601 setup, stock-main binary vs this branch, comparing the emitted `results.txt`
JSON line (timestamp field excluded):

| known-factor list | result |
|---|---|
| `"279607"` | identical JSON |
| `"279607,372809,51727111"` | identical JSON |
| `"279607,279607,372809,51727111"` | identical JSON; duplicate still detected, warned about and dropped |
| `"51727111,279607,372809"` (different order) | identical JSON |

The 3-factor case was also checked against an independent Python big-int computation of the
Suyama quantities:

| quantity | Python | Mlucas (this branch) |
|---|---|---|
| A = 3^(N-1) mod N, Res64 | `3E61CFB244B02110` | `3E61CFB244B02110` |
| B = 3^(F-1) mod N, Res64 | `CA05575CDB02A1E2` | `CA05575CDB02A1E2` |
| C = N/F, Res64 | `7B702900CB0A487` | `7B702900CB0A487` |
| R = (A-B) mod C, Res64 | `1764BC66C4860030` | `1764BC66C4860030` |
| R mod 2^35-1, 2^36-1 | `5991093428, 52382048141` | `5991093428, 52382048141` |
| res2048 leading 128 bits | `A8C1B67552C63D6340F302D9BA319C1A` | `A8C1B67552C63D6340F302D9BA319C1A` |

verdict `COMPOSITE [C14010]` in both. The 1-factor case likewise matches Python:
`A = 3E61CFB244B02110`, `C = A3610801B4E54E79`, `(A-B)/C` quotient `39443`,
`R = 31F21E194B6B0455` with 35m1,36m1 = `26502959927, 63013788020`.

## Fermat-mod path - partially verified, stated honestly

The Fermat branch of the same check (`2^p == -1 == q-1 (mod q)`) had the identical defect
and is fixed the same way. I verified it **at parse time only**:

* F18 with the genuine list `"13631489,81274690703860512587777"` and F16 with
  `"825753601,188981757975021318420037633"` are accepted (in both cases the 2nd factor is
  2 limbs, so this also exercises the multi-limb path in a non-first position);
* F18 with a bogus 2nd factor `7340033` (= 7.2^20+1, prime, base-3 PRP, does not divide
  F18) is rejected naming factor #2.

I could not run a Fermat PRP-CF assignment to completion to compare residues: on stock main
*and* on this branch, a Fermat cofactor assignment picks a default FFT length that is not of
the Fermat-legal `k.2^n` form (3K for F16, 13K for F18), fails the `fermat.cfg` lookup, and
spins in the `ERR_RUN_SELFTEST_FORLENGTH` self-test loop (writing Mersenne self-test entries
to `mlucas.cfg`) until it gives up. That behaviour is identical with and without this patch,
so it is pre-existing and unrelated, but it does mean the Fermat PRP-CF arithmetic itself is
not covered by my testing here.

## Build / self-test

Full clean `bash makemake.sh avx2` - no errors, no new warnings - then
`obj_avx2/Mlucas -s tt`, exit 0, Res64 `13K = E3BC90B0E652C7C0`,
`14K = DB8E39C67F8CCA0A`, `15K = B3C5A1C03E26BB17`.

This box has no AVX-512 hardware, and the change is plain scalar C in the worktodo parser,
so no SIMD-specific path is involved; Windows/ARM/macOS were not exercised.

## Related, deliberately not fixed here

Found while tracing this, in the same area but different defects - left for separate PRs so
this one stays reviewable:

* `src/Mlucas.c:3364-3368` (and the identical dead-code copy at `6446-6453`): the
  known-factor product is accumulated into the 20-limb stack array `curr_fac[]`, and
  `ASSERT(lenf <= 20, ...)` is evaluated only *after* the loop that can already have
  overflowed it. `KNOWN_FACTORS[]` admits 10 factors of up to 4 limbs, so a legal input can
  reach 40 limbs. Latent today (real PRP-CF assignments carry small factors).
* `src/Mlucas.c:3389`: `ASSERT(j = (p+63)>>6, "uint64 vector length got clobbered!")` uses
  `=` where `==` was meant, so the check can never detect what it is written to detect (same
  defect class as #102).
* The `Factor not of required form!` and `Factor-is-base-3-PRP check fails!` ASSERTs a few
  lines above are correctly indexed - they use the local `fac[]` - but their messages also
  do not say *which* factor failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
