### PR TITLE
Restore four ASSERT self-checks defeated by an = instead of ==

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3389,7 +3389,7 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	convert_res_FP_bytewise(b, (uint8 *)ci, n, p, &itmp64, &Res35m1, &Res36m1);	// Res64 reserved for Fermat-PRP result; use itmp64 here
 	sprintf(g_cstr, "%u^(F-1) residue (B)        = %#016" PRIX64 ",%11" PRIu64 ",%11" PRIu64 "\n",PRP_BASE,itmp64,Res35m1,Res36m1);
 	strcat(cbuf,g_cstr);	mlucas_fprint(cbuf,1);
-	ASSERT(j = (p+63)>>6,"uint64 vector length got clobbered!");
+	ASSERT(j == (p+63)>>6,"uint64 vector length got clobbered!");
 	mi64_set_eq(bi,ci,j);	// Copy packed-bit result into low j limbs of B-vec (treated as a uint64 array)
 	itmp64 = mi64_sub(ai,bi, ai,j);
 	// If result < 0, need to add Modulus - for N = Fm,Mp this means +-1 in LSW, respectively.

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1727,7 +1727,10 @@ undo_initial_ffft_pass:
 	// [action] Prior to returning, print a "retry successful" informational and rezero ROE_ITER and ROE_VAL.
 	// *** v20: For PRP-test Must make sure we are at end of checkpoint-file iteration interval, not one of the Gerbicz-update subintervals ***
 	if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0) {	// In interactive (timing-test) mode, use ROE_ITER to accumulate #iters-with-dangerous-ROEs
-		ASSERT((ierr == 0) && (iter = ihi+1), "[2a] sanity check failed!");
+		// On normal loop-completion iter = ihi+1; the early-exit-on-interrupt case is filtered out by the
+		// ERR_INTERRUPT return above, *except* for a signal arriving during the final iteration, in which
+		// case the interval did complete but the post-loop iter-- leaves iter = ihi - hence 2nd clause:
+		ASSERT((ierr == 0) && (iter == ihi+1 || !MLUCAS_KEEP_RUNNING), "[2a] sanity check failed!");
 		ROE_ITER = 0;
 		ROE_VAL = 0.0;
 		sprintf(cbuf,"Retry of iteration interval with fatal roundoff error was successful.\n");

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -2142,7 +2142,10 @@ undo_initial_ffft_pass:
 	// [action] Prior to returning, print a "retry successful" informational and rezero ROE_ITER and ROE_VAL.
 	// *** v19: For PRP-test Must make sure we are at end of checkpoint-file iteration interval, not one of the Gerbicz-update subintervals ***
 	if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0) {	// In interactive (timing-test) mode, use ROE_ITER to accumulate #iters-with-dangerous-ROEs
-		ASSERT((ierr == 0) && (iter = ihi+1), "[2a] sanity check failed!");
+		// On normal loop-completion iter = ihi+1; the early-exit-on-interrupt case is filtered out by the
+		// ERR_INTERRUPT return above, *except* for a signal arriving during the final iteration, in which
+		// case the interval did complete but the post-loop iter-- leaves iter = ihi - hence 2nd clause:
+		ASSERT((ierr == 0) && (iter == ihi+1 || !MLUCAS_KEEP_RUNNING), "[2a] sanity check failed!");
 		ROE_ITER = 0;
 		ROE_VAL = 0.0;
 		sprintf(cbuf,"Retry of iteration interval with fatal roundoff error was successful.\n");

--- a/src/qfloat.c
+++ b/src/qfloat.c
@@ -3795,7 +3795,7 @@ int qtest(void)
 
 	q = qfmul_pow2(QPI, 125);	/* This gives pi*2^125, which should still fit into a signed 128-bit int. */
 	i128 = qfnint(q);
-	ASSERT((i128.d1 = (uint64)0x6487ED5110B4611Aull && i128.d0 == (uint64)0x62633145C06E1000ull),"ERROR 92 in qfloat.c");
+	ASSERT((i128.d1 == (uint64)0x6487ED5110B4611Aull && i128.d0 == (uint64)0x62633145C06E1000ull),"ERROR 92 in qfloat.c");
 
 #if TIMING_TEST
 	exit(0);


### PR DESCRIPTION
## The blind spot

Four `ASSERT`s in the tree contain an `=` where `==` was meant. All four have the same shape:

```c
ASSERT((x = y), "...");
```

The assignment is *already* parenthesised, because it is an argument to a macro. GCC's and Clang's
`-Wparentheses` deliberately treats an extra layer of parens around an assignment-in-boolean-context
as the author saying "yes, I meant to assign here", and suppresses the diagnostic. So none of these
produced a warning in any build mode — I re-checked with `-Wall -Wextra -Wparentheses
-Wint-in-bool-context` across gcc 16 and clang 22 in nosimd/sse2/avx/avx2/avx512, and there is no
warning at any of the four sites. That is why they survived. A targeted grep for
`ASSERT((<lvalue> = ` is worth keeping in the toolbox for exactly this reason.

Each is an always-true expression, so each is a **self-check that has never been able to fail.**

## The four sites

### 1. `qtest()` in `src/qfloat.c` — MEDIUM

```c
q = qfmul_pow2(QPI, 125);	/* This gives pi*2^125, which should still fit into a signed 128-bit int. */
i128 = qfnint(q);
ASSERT((i128.d1 = (uint64)0x6487ED5110B4611Aull && i128.d0 == (uint64)0x62633145C06E1000ull),"ERROR 92 in qfloat.c");
```

`=` binds looser than `&&`, so this parses as

```c
i128.d1 = ( 0x6487ED5110B4611Aull && (i128.d0 == 0x62633145C06E1000ull) )
```

— assign 0 or 1 to `i128.d1`, then assert that. The high 64 bits of `qfnint(pi*2^125)` were never
compared with anything; the constant `0x6487ED5110B4611A` was just a truthy literal. Only the low
limb was actually verified. The four sibling checks immediately above all use `==`, which settles
the intent.

**Consequence.** This is the one that matters. `ASSERT` here is not `NDEBUG`-gated
(`util.h`: `#define ASSERT(expr, s) (void)((expr) || (ABORT(...),0))`), and `qtest()` is called from
`host_init()`, so this runs on **every** Mlucas startup. A qfloat regression that corrupted only the
*upper* limb of a 128-bit round-to-nearest — precisely the top-of-range case this check exists to
cover — would sail through startup validation, and the bad constants would then flow into the FFT
twiddle tables qfloat initialises.

### 2/3. `mers_mod_square()` and `fermat_mod_square()` — LOW/MEDIUM

Identical line in both files, in the post-loop retry-succeeded block:

```c
if(!INTERACT && ROE_ITER > 0 && ihi%ITERS_BETWEEN_CHECKPOINTS == 0) {
	ASSERT((ierr == 0) && (iter = ihi+1), "[2a] sanity check failed!");
	ROE_ITER = 0;
	ROE_VAL = 0.0;
	sprintf(cbuf,"Retry of iteration interval with fatal roundoff error was successful.\n");
```

`(iter = ihi+1)` yields `ihi+1`, always nonzero, so the clause the comment directly above it exists
for — *"Must make sure we are at end of checkpoint-file iteration interval, not one of the
Gerbicz-update subintervals"* — never tested anything. Only `ierr == 0` survived.

**Consequence.** The roundoff-error-retry-success path clears `ROE_ITER`/`ROE_VAL` and tells the user
*"Retry of iteration interval with fatal roundoff error was successful"* without ever confirming that
the retried interval actually ran to the end of the checkpoint interval. That is the one path where
you most want the assertion. (The assignment itself is dead — `iter` is not read again before the
`return(ierr);` two lines later.)

### 4. `Suyama_CF_PRP()` in `src/Mlucas.c` — INFORMATIONAL

```c
ASSERT(j = (p+63)>>6,"uint64 vector length got clobbered!");
mi64_set_eq(bi,ci,j);
```

The assertion string states the intent unambiguously: verify `j` still holds the value set ~40 lines
earlier by `j = (p+63)>>6;` (just above the `mi64_set_eq(ai,ci,j)` that copies the Fermat-PRP residue
back into A-vec). As written it re-assigns it and asserts nonzero. There are **no assignments to `j`**
between the two — the only intervening use is that `mi64_set_eq(ai,ci,j)` read — and `j` is a plain
local `uint32`, not touched through any pointer, so today this is a no-op and restoring it changes
nothing observable. Included for consistency, and because `j` is used immediately afterwards as a
limb count for `mi64_set_eq`/`mi64_sub`, where a clobbered value would be a buffer-length bug.

## Why this cannot introduce a new abort

This is the real risk of the change: these conditions have never been evaluated as checks, so
restoring them means they can now fire, and Mlucas's `ASSERT` is always-on. Per site:

**Site 1 (`qfloat.c`).** The value is a compile-time-deterministic function of the `QPI` constant, so
either it always holds or it never does. Verified by hand first: `2*pi = 0x6.487ED5110B4611A62633145C06E0E28…`,
so `pi*2^125 = 0x6487ED5110B4611A_62633145C06E0E28…`, whose top 64 bits are exactly the asserted
constant — and the rounding that turns the exact tail `…0E28` into the (already-passing) asserted low
limb `…1000` cannot carry into the high limb. Then verified by execution: because `qtest()` runs at
every startup, *every* binary invocation in the verification below exercises the restored
comparison. No `ERROR 92 in qfloat.c` in any run, in either build mode.

**Sites 2/3 (`*_mod_square.c`).** From the code, `for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)`
plus `ASSERT(ihi > ilo)` means normal completion leaves `iter == ihi+1`, and any early exit at
`iter < ihi` is converted to `ERR_INTERRUPT` and returned before this block. But there is one corner
where the bare `iter == ihi+1` would be false on a *successfully completed* interval, and I did not
want to plant it:

> A signal arriving during the **final** iteration lets the loop finish normally with `iter == ihi+1`,
> after which the post-loop `if(!MLUCAS_KEEP_RUNNING) iter--;` drops it to `ihi`, and `if(iter < ihi)`
> then declines to set `ERR_INTERRUPT` — so the early-return above does not filter this case out.

On current `main` that corner is dead, because `sig_handler` does `exit(1)` before it reaches
`MLUCAS_KEEP_RUNNING = 0`, so the flag is never actually cleared. But it comes alive the moment the
interrupt path is re-enabled (cf. #100 / PR #108), and it would then be an abort on the very path
where a clean savefile write matters most. So the restored condition is

```c
ASSERT((ierr == 0) && (iter == ihi+1 || !MLUCAS_KEEP_RUNNING), "[2a] sanity check failed!");
```

with a comment explaining the exemption. This is a real check on every normal path
(`MLUCAS_KEEP_RUNNING` set ⇒ `iter` must be `ihi+1`) and cannot fire in the signal corner. Happy to
drop the second clause if you'd rather have the literal original — but then that corner should be
fixed first.

**Site 4 (`Mlucas.c`).** Provable no-op, as described above.

## Verification

Everything below is on this box: x86-64, gcc 16.1.1, AVX2 (no AVX-512 hardware).

* Clean `bash makemake.sh avx2` and `bash makemake.sh nosimd` — both succeed, no new warnings in any
  of the four touched files.
* `obj_avx2/Mlucas -s tt`: reference residues match — 13K `E3BC90B0E652C7C0`, 14K
  `DB8E39C67F8CCA0A`, 15K `B3C5A1C03E26BB17`. The full set of distinct Res64 values, and the count of
  pre-existing `Return with code ERR_ASSERT` lines (4, all from the known "CY routines with radix < 16
  do not support shifted residues" limitation), are **identical** to an `upstream/main` build of the
  same tree.
* `obj_avx2/Mlucas -s s`: completes, zero assertion output of any kind.
* `obj_nosimd/Mlucas -s tt`: likewise identical to an `upstream/main` nosimd build — same distinct
  Res64 set, same 29 pre-existing `ERR_ASSERT` returns (the known scalar-radix breakage, cf. #152).
  Included because `qtest()` is SIMD-independent startup code and cheap to cover.
* No `ERROR 92 in qfloat.c`, no `[2a] sanity check failed`, no `uint64 vector length got clobbered`
  in any of the above.

**Sites 2/3 were exercised, not just reasoned about.** The `[2a]` block needs `ROE_ITER > 0` to
survive across a `mod_square` call, which is hard to provoke naturally (a fatal ROE returns
`ERR_ROUNDOFF` immediately, and `Mlucas.c` zeroes `ROE_ITER` before retrying at the next-larger FFT
length). So I built a throwaway instrumented binary that (a) forced entry into the `[2a]` block on
every checkpoint boundary with the restored assert live, and (b) additionally evaluated the restored
predicate on *every* `mod_square` return and printed any violation. Then, with `CheckInterval = 5000`
in `mlucas.ini`:

* full production PRP test of **M216091** (`PRP=1,2,216091,-1`, Gerbicz checking active, so the
  Gerbicz-subinterval discrimination the assert exists for was in play): finished correctly
  ("M216091 is a known MERSENNE PRIME"), entered the restored assert **43 times**;
* full production Pépin test of **F17** (`Fermat,Test=17`, forced 8K FFT): finished correctly
  ("F17 is not prime"), entered the restored assert **26 times**.

Every one of those 69 entries had `iter == ihi+1` exactly, and there were **zero** predicate
violations across all 698 `mod_square` returns in the two runs. The instrumentation was then removed;
the diff here is only the four one-line comparisons plus two explanatory comments.

**Not exercised:** site 4 (`Suyama_CF_PRP`, the Fermat cofactor-PRP path) was not run — it is the
provable no-op. No AVX-512, ARM, macOS or Windows testing was done; the change is
architecture-independent C, but I have not run those configurations.

## Not included

The same scan turned up two other items that are separate concerns and are deliberately **not** in
this PR: the `!`-should-be-`~` cluster in `mi64_md5()` (`mi64.c`, currently no reachable caller), and
the `RE_IM_STRIDE == 1` load-imbalance quirk in `modpow()` (`pm1.c`).
