### PR TITLE
Savefile integrity: detect write/read truncation, and replace savefiles atomically

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2241,7 +2241,7 @@ READ_RESTART_FILE:
 		fp = mlucas_fopen(RESTARTFILE, "wb");
 		if(fp) {		// In the non-PRP-test case, write_ppm1_savefiles() treats the latter 4 args as null:
 			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
-			fclose(fp); fp = 0x0;
+			close_savefile(RESTARTFILE,fp); fp = 0x0;
 			/* If we're on the primary restart file, set up for secondary: */
 			if(RESTARTFILE[0] != 'q') {
 				RESTARTFILE[0] = 'q';	goto WRITE_RESTART_FILE;
@@ -2267,7 +2267,7 @@ READ_RESTART_FILE:
 				fp = mlucas_fopen(g_cstr, "wb");
 				if(fp) {
 					write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
-					fclose(fp); fp = 0x0;
+					close_savefile(g_cstr,fp); fp = 0x0;
 				} else {
 					snprintf(cbuf,sizeof(cbuf), "ERROR: unable to open Gerbicz-check savefile %s for write of checkpoint data.\n",g_cstr);
 					mlucas_fprint(cbuf,1);
@@ -5066,6 +5066,77 @@ int test_types_compatible(uint32 t1, uint32 t2)
 		return t1 == t2;
 }
 
+/* v21: Write the [nbyte] low bytes of [val] to *fp, low byte first, returning 0 if any of the writes
+fails. Prior to v21 every fixed-width savefile field was written using unchecked fputc(), so a write
+error - a filesystem which has just filled up being the realistic case - silently truncated the
+savefile. And since the secondary savefile gets written immediately afterward from the same in-memory
+data, both copies ended up damaged in the same way, with nothing whatsoever printed to screen or
+logfile. Contrast the residue-body fwrite() in write_ppm1_residue(), whose return value has always
+been checked: that one fails loudly and leaves the secondary savefile holding the previous good
+checkpoint, from which the run then restarts cleanly. Same failure, same filesystem - the only
+difference is whether the return value gets looked at, so look at all of them:
+*/
+int write_savefile_field(FILE *fp, const uint64 val, const uint32 nbyte)
+{
+	uint32 i;
+	for(i = 0; i < nbyte; i++) {
+		if(fputc((int)((val >> (8*i)) & 0xff), fp) == EOF)
+			return 0;
+	}
+	return 1;
+}
+
+/* v21: A savefile is only as good as the bytes which actually made it out of the stdio buffer: a
+failed fclose() means buffered data was lost, i.e. exactly the silent-truncation case the checked
+writes above exist to prevent. Treat it the same way - abort while the *other* savefile copy still
+holds the previous good checkpoint, rather than proceed with two damaged copies on disk:
+*/
+void close_savefile(const char *fname, FILE *fp)
+{
+	if(fclose(fp) == EOF) {
+		snprintf(cbuf,sizeof(cbuf),"ERROR: close of savefile %s failed - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
+		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
+	}
+}
+
+/* v21: Several savefile fields were added in later program versions, so a savefile whose data simply
+stops where such a field would begin may be one written by an older version. But it may equally be a
+current-format savefile which a failed write truncated, and prior to v21 the two were conflated: the
+older-format reading was simply assumed, and since that makes read_ppm1_savefiles() return *success*,
+a truncated savefile got accepted and the still-valid backup copy sitting next to it was never even
+consulted. So sanity-check the older-format claim before accepting it - a savefile written by an older
+version ends *exactly* at a format boundary, thus:
+	[1] the EOF must have occurred on the very first byte of the missing field, not partway through it;
+	[2] the file length must exactly equal [expect_len], the length such an older-format savefile has
+	    for this exponent and test type;
+	[3] the run must not need any of the fields which are being skipped: if [need_gcheck] is set the
+	    Gerbicz-check residue is one of them, and no older-format savefile contains it - reading such a
+	    file would leave the G-check accumulator uninitialized.
+Returns 1 if the older-format reading holds up, 0 if the file is simply damaged. [nread] = number of
+bytes the caller's read loop consumed, the one which returned EOF included.
+*/
+int savefile_ends_at(const char *func, const char *fname, FILE *fp, uint32 nread, uint64 expect_len, int need_gcheck)
+{
+	long fsize;
+	if(need_gcheck) {
+		sprintf(cbuf,"%s: savefile %s lacks the Gerbicz-check residue this test type requires.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if(nread != 1) {	// EOF partway through a field: no version of the program ever wrote such a file
+		sprintf(cbuf,"%s: savefile %s ends in mid-field - truncated, not an older-format savefile.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if(fseek(fp,0L,SEEK_END) != 0 || (fsize = ftell(fp)) < 0L) {
+		sprintf(cbuf,"%s: Unable to determine length of savefile %s.\n",func,fname);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	if((uint64)fsize != expect_len) {
+		sprintf(cbuf,"%s: savefile %s is %ld bytes, but an older-format one would be %" PRIu64 " - truncated.\n",func,fname,fsize,expect_len);
+		fprintf(stderr,"%s", cbuf);	return 0;
+	}
+	return 1;
+}
+
 /*** READ: Assumes a valid file pointer has been gotten via a call of the form
 fp = mlucas_fopen(RESTARTFILE,"rb");
 ***/
@@ -5173,6 +5244,16 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 	const char func[] = "read_ppm1_savefiles";
 	uint32 i,j,k,len,nbytes = 0,nerr;
 	uint64 itmp64, nsquares = 0ull, *avec = (uint64 *)arr1, exp[4],pow[4],rem[4];
+	/* v21: Parse the savefile fields which live in globals into locals, and copy them to the globals
+	only once the read has fully succeeded. Formerly PRP_BASE, NERR_ROE and NERR_GCHECK were written
+	directly, so a *failed* read left them holding fgetc()-EOF garbage (0xFEFEFEFF) which nothing ever
+	restored: if the secondary savefile was unusable too, the ensuing start-from-scratch then ran as a
+	"4278124287-PRP test", and the poisoned error counters got written into every later savefile and
+	reported to the server as a maximal hardware-error code. Init from the globals so that fields which
+	the file does not contain (older formats) are left as-is, exactly as before:
+	*/
+	uint32 prp_base = PRP_BASE, nerr_roe = NERR_ROE, nerr_gcheck = NERR_GCHECK;
+	uint64 res_shift = 0ull, gcheck_shift = GCHECK_SHIFT, len_v17,len_v19;
 	uint128 ui128,vi128; uint192 ui192,vi192; uint256 ui256,vi256;	// Fixed-length 2/3/4-word ints for stashing results of multiword modexp.
 	*Res64 = 0ull;	// 0 value on return indicates failure of some kind
 	mi64_clear(pow,4); mi64_clear(rem,4);
@@ -5231,6 +5312,14 @@ int read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, 
 		nbytes = (p>>3) + 1;
 		TRANSFORM_TYPE = RIGHT_ANGLE;
 	}
+	/* v21: Exact lengths of the two historical savefile formats which end short of the current one, used
+	by savefile_ends_at() to tell a legitimately-shorter older-format savefile from a truncated current one:
+		pre-v18: t,m,s header (10 bytes) + residue and its S-H checksum triplet (nbytes+18);
+		    v19: the above + kblocks (3) + RES_SHIFT (8), and if a G-check test, + PRP_BASE (4)
+		         + G-check residue and its checksum triplet (nbytes+18) + GCHECK_SHIFT (8):
+	*/
+	len_v17 = (uint64)nbytes + 28;
+	len_v19 = len_v17 + 11 + (DO_GCHECK ? (uint64)nbytes + 30 : 0ull);
 
 	i = read_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 	if(!i) return 0;
@@ -5327,33 +5416,47 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	for(j = 0; j < 3 && i != EOF; j++) {
 		i = fgetc(fp);	*kblocks += (uint64)i << (8*j);
 	}
-	if(i == EOF) {
+	if(i == EOF) {	// v21: EOF here means either a pre-v18 savefile or a truncated current-format one - which?
 		*kblocks = 0;
-		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks ... assuming a pre-v18 savefile.\n",func); fprintf(stderr,"%s", cbuf); return 1;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17,DO_GCHECK)) return 0;
+		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
+		goto SAVEFILE_READ_DONE;
 	}
 	/* May 2018: 8 bytes for circular-shift to apply to the (unshifted) residue read from the file: */
-	i = 0; RES_SHIFT = 0ull;
+	i = 0;
 	for(j = 0; j < 8 && i != EOF; j++) {
-		i = fgetc(fp);	RES_SHIFT += (uint64)i << (8*j);
+		i = fgetc(fp);	res_shift += (uint64)i << (8*j);
 	}
 	if(i == EOF) {
-		RES_SHIFT = 0ull;
-		sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks ... assuming a pre-v18 savefile.\n",func); fprintf(stderr,"%s", cbuf); return 1;
+		res_shift = 0ull;
+		if(!savefile_ends_at(func,fname,fp,j,len_v17+3,DO_GCHECK)) return 0;
+		sprintf(cbuf,"%s: Hit EOF in read of residue-shift in savefile %s ... assuming a pre-v18 savefile.\n",func,fname); mlucas_fprint(cbuf,1);
+		goto SAVEFILE_READ_DONE;
 	}
 
   // v19: For PRP-tests, also read a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
   if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
 	ASSERT(arr2 != 0x0, "Null arr2 pointer!");
-	PRP_BASE = 0ull;
+	prp_base = 0;
 	for(j = 0; j < 4; j++) {
-		i = fgetc(fp);	PRP_BASE += i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: Formerly unchecked, leaving PRP_BASE = 0xFEFEFEFF on a failed read
+			sprintf(cbuf, "%s: Hit EOF in read of PRP-base in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		prp_base += i << (8*j);
 	}
 	i = read_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
 	if(!i) return 0;
 	// G-check residues all need to be clshifted by residue-shift count at the ITERS_BETWEEN_GCHECK_UPDATESth PRP-test iteration:
-	GCHECK_SHIFT = 0ull;
+	gcheck_shift = 0ull;
 	for(j = 0; j < 8; j++) {
-		i = fgetc(fp);	GCHECK_SHIFT += (uint64)i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: ditto for GCHECK_SHIFT
+			sprintf(cbuf, "%s: Hit EOF in read of G-check residue-shift in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		gcheck_shift += (uint64)i << (8*j);
 	}
   }
 
@@ -5363,25 +5466,39 @@ Thus if we use a negative-power algo, to recover 2^p (mod q = 2^k.qodd):
 	for(j = 0; j < 4; j++) {
 		i = fgetc(fp);
 		if(i == EOF) {
-			if(!j) {
-				sprintf(cbuf, "%s: Restart from v19 savefile - will start tracking #errors encountered at this point.\n",func);
-				fprintf(stderr,"%s", cbuf);
-				return 1;
+			if(!j) {	// v21: As above, only believe "older-format savefile" if the file length says so:
+				if(!savefile_ends_at(func,fname,fp,1,len_v19,FALSE)) return 0;
+				sprintf(cbuf, "%s: Restart from v19 savefile %s - will start tracking #errors encountered at this point.\n",func,fname);
+				mlucas_fprint(cbuf,1);
+				goto SAVEFILE_READ_DONE;
 			} else {	// If at least the first of the 3 bytes exists, all 3 had better be there:
-				sprintf(cbuf, "%s: Expected 4 nerr bytes!",func);
+				sprintf(cbuf, "%s: Expected 4 nerr bytes in savefile %s!\n",func,fname);
 				fprintf(stderr,"%s", cbuf);
 				return 0;
 			}
 		}
 		nerr += i << (8*j);
 	}
-	NERR_ROE = MAX(nerr,NERR_ROE);	// If restart-from-savefile as result of hitting an ROE, preserve the runtime-incremented value of NERR_ROE:
+	nerr_roe = MAX(nerr,nerr_roe);	// If restart-from-savefile as result of hitting an ROE, preserve the runtime-incremented value of NERR_ROE:
 	// Similar handling for G-check error count:
 	nerr = 0ull;
 	for(j = 0; j < 4; j++) {
-		i = fgetc(fp);	nerr += i << (8*j);
+		i = fgetc(fp);
+		if(i == EOF) {	// v21: This loop formerly had no EOF check at all, so a savefile truncated in its
+			// last 4 bytes read back as NERR_GCHECK = 0xFEFEFEFF = 4278124287 with the read still reporting
+			// success - which then got submitted to the server as error-code 0x00F00000 ("15 Gerbicz errors")
+			// plus a literal "gerbicz":4278124287, even for test types which have no Gerbicz check at all:
+			sprintf(cbuf, "%s: Expected 4 G-check-error-count bytes in savefile %s!\n",func,fname);
+			fprintf(stderr,"%s", cbuf);	return 0;
+		}
+		nerr += i << (8*j);
 	}
-	NERR_GCHECK = MAX(nerr,NERR_GCHECK);
+	nerr_gcheck = MAX(nerr,nerr_gcheck);
+
+SAVEFILE_READ_DONE:
+	// v21: Read succeeded - only now commit the parsed values to their globals:
+	RES_SHIFT = res_shift;	PRP_BASE = prp_base;	GCHECK_SHIFT = gcheck_shift;
+	NERR_ROE = nerr_roe;	NERR_GCHECK = nerr_gcheck;
 	/* Don't deallocate arr1 here, since we'll need it later for savefile writes. */
 	return 1;
 }
@@ -5402,16 +5519,13 @@ void write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], co
 		snprintf(cbuf,sizeof(cbuf),"%s: Error writing residue to restart file.\n",func);
 		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 	}
-	/* ...and checksums:	*/
-	/* Res64: */
-	for(i = 0; i < 64; i+=8)
-		fputc((int)(Res64 >> i) & 0xff, fp);
-	/* Res35m1: */
-	for(i = 0; i < 40; i+=8)
-		fputc((int)(Res35m1 >> i) & 0xff, fp);
-	/* Res36m1: */
-	for(i = 0; i < 40; i+=8)
-		fputc((int)(Res36m1 >> i) & 0xff, fp);
+	/* ...and checksums (Res64: 8 bytes, Res35m1 and Res36m1: 5 bytes each) - v21: check these writes
+	as well, since a savefile truncated here reads back as an older-format, i.e. valid, one: */
+	if(!write_savefile_field(fp,Res64,8) || !write_savefile_field(fp,Res35m1,5) || !write_savefile_field(fp,Res36m1,5)) {
+		fclose(fp); fp = 0x0;
+		snprintf(cbuf,sizeof(cbuf),"%s: Error writing residue checksums to restart file.\n",func);
+		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
+	}
 }
 
 // v20: E.g. distributed deep p-1 S2 may use B2 >= 2^32, so make ihi a uint64; add filename arg since S2 appends '.s2' to RESTARTFILE:
@@ -5425,14 +5539,12 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 	kblocks = (n >> 10);
 	ASSERT(n == (kblocks << 10),"Not a proper unpadded FFT length");
 
-	/* See the function read_ppm1_savefiles() for the file format here: */
-	/* t: */
-	fputc(TEST_TYPE, fp);
-	/* m: */
-	fputc(MODULUS_TYPE, fp);
-	/* s: */
-	for(i = 0; i < 64; i+=8)
-		fputc((ihi >> i) & 0xff, fp);
+	/* See the function read_ppm1_savefiles() for the file format here. v21: All the fixed-width fields
+	go out through write_savefile_field(), which checks its writes - see the comment on that function: */
+	/* t: */	i  = write_savefile_field(fp,TEST_TYPE   ,1);
+	/* m: */	i &= write_savefile_field(fp,MODULUS_TYPE,1);
+	/* s: */	i &= write_savefile_field(fp,ihi         ,8);
+	if(!i) goto SAVEFILE_WRITE_ERR;
 
 	/* Set the expected number of residue bytes, depending on the modulus: */
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
@@ -5446,27 +5558,31 @@ void write_ppm1_savefiles(const char *fname, uint64 p, int n, FILE *fp, uint64 i
 
 	write_ppm1_residue(nbytes, fp, arr1, Res64,Res35m1,Res36m1);
 
-	// v18: FFT length in K (3 bytes):
-	for(i = 0; i < 24; i+=8)
-		fputc((kblocks >> i) & 0xff, fp);
-	// v18: circular-shift to apply to the (unshifted) residue read from the file (8 bytes):
-	for(i = 0; i < 64; i+=8)
-		fputc((RES_SHIFT >> i) & 0xff, fp);
+	// v18: FFT length in K (3 bytes), then circular-shift to apply to the residue read from the file (8 bytes):
+	i  = write_savefile_field(fp,kblocks  ,3);
+	i &= write_savefile_field(fp,RES_SHIFT,8);
+	if(!i) goto SAVEFILE_WRITE_ERR;
 
   // v19: For PRP-tests, also write a second Gerbicz-check residue array [arr2] and associated S-H checksum triplet [i1,i2,i3]:
   if(DO_GCHECK) {	// v21: Change to key off DO_GCHECK, to allow Fermat-mod Pepin-tests to use the Gerbicz check, too
-	for(i = 0; i < 32; i+=8)
-		fputc((PRP_BASE >> i) & 0xff, fp);
+	if(!write_savefile_field(fp,PRP_BASE,4)) goto SAVEFILE_WRITE_ERR;
 	write_ppm1_residue(nbytes, fp, arr2, i1,i2,i3);
 	// G-check residues all need to be clshifted by residue-shift count at the ITERS_BETWEEN_GCHECK_UPDATESth PRP-test iteration:
-	for(i = 0; i < 64; i+=8)
-		fputc((GCHECK_SHIFT >> i) & 0xff, fp);
+	if(!write_savefile_field(fp,GCHECK_SHIFT,8)) goto SAVEFILE_WRITE_ERR;
   }
 	// v20: Write cumulative #errs for ROE >= 0.4375 (>= for LL, > for PRP) and Gerbicz-check for the test in question:
-	for(i = 0; i < 32; i+=8)
-		fputc((NERR_ROE >> i) & 0xff, fp);
-	for(i = 0; i < 32; i+=8)
-		fputc((NERR_GCHECK >> i) & 0xff, fp);
+	i  = write_savefile_field(fp,NERR_ROE   ,4);
+	i &= write_savefile_field(fp,NERR_GCHECK,4);
+	if(!i) goto SAVEFILE_WRITE_ERR;
+	return;
+
+SAVEFILE_WRITE_ERR:	// v21: Formerly these writes were unchecked, so a full filesystem silently truncated
+	// the savefile - and, the secondary copy being written straight afterward from the same data, both
+	// copies alike. Abort here instead, at which point the *other* copy still holds the previous good
+	// checkpoint, exactly as already happens when the residue-body write above fails:
+	fclose(fp);
+	snprintf(cbuf,sizeof(cbuf),"write_ppm1_savefiles: Error writing savefile %s - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
+	mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 }
 
 /*********************/
@@ -6646,7 +6762,9 @@ int restart_file_valid(const char *fname, const uint64 p, uint8 *arr1, uint8 *ar
 	int retval = 0;
 	uint32 j;
 	uint64 Res64,Res35m1,Res36m1, i1,i2,i3, itmp64;
-	FILE *fptr = mlucas_fopen(fname,"r");
+	// v21: "rb", not "r": read_ppm1_savefiles()'s contract requires binary mode, and on Windows text mode
+	// mangles \r\n pairs and treats an embedded 0x1A as EOF, both of which occur in a bytewise residue:
+	FILE *fptr = mlucas_fopen(fname,"rb");
 	if(fptr) {
 		retval = read_ppm1_savefiles(fname, p, &j, fptr, &itmp64,
 										arr1, &Res64,&Res35m1,&Res36m1,	// Primality-test residue

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2227,7 +2227,10 @@ READ_RESTART_FILE:
 			sprintf(cbuf, ".%dM", ilo/1000000);
 			strcpy(g_cstr, RESTARTFILE);
 			strcat(g_cstr, cbuf);
-			if(rename(RESTARTFILE, g_cstr)) {
+			// v21: mlucas_rename(), not rename(): the latter ignored MLUCAS_PATH (so under a nonempty prefix it
+			// renamed a nonexistent cwd-relative name and always failed) and cannot replace an existing
+			// destination on Windows. Same for the other rename() calls below:
+			if(mlucas_rename(RESTARTFILE, g_cstr)) {
 				snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename %s restart file ==> %s ... skipping every-10M-iteration restart file archiving\n",WORKFILE,g_cstr);
 				fprintf(stderr,"%s",cbuf);
 			}
@@ -2238,7 +2241,9 @@ READ_RESTART_FILE:
 		itmp64 = ihi;
 		// If Pepin test is at final iteration, change PRP base to 3 for final write to file (cf. earlier assignment at line 1214). More info: https://github.com/primesearch/Mlucas/pull/11
 		if (ihi == maxiter && TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT) PRP_BASE = 3;
-		fp = mlucas_fopen(RESTARTFILE, "wb");
+		// v21: _atomic: stage the new checkpoint in a scratch file and rename it over the savefile, so that
+		// a crash/kill/power-loss partway through the write cannot leave a truncated savefile behind:
+		fp = mlucas_fopen_atomic(RESTARTFILE, "wb");
 		if(fp) {		// In the non-PRP-test case, write_ppm1_savefiles() treats the latter 4 args as null:
 			write_ppm1_savefiles(RESTARTFILE,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 			close_savefile(RESTARTFILE,fp); fp = 0x0;
@@ -2264,7 +2269,7 @@ READ_RESTART_FILE:
 			if(ihi%ITERS_BETWEEN_GCHECKS == 0) {
 				strcpy(g_cstr, RESTARTFILE);
 				strcat(g_cstr, ".G");
-				fp = mlucas_fopen(g_cstr, "wb");
+				fp = mlucas_fopen_atomic(g_cstr, "wb");	// v21: atomic-replace, as for the p/q savefiles above
 				if(fp) {
 					write_ppm1_savefiles(g_cstr,p,n,fp, itmp64, (uint8 *)arrtmp,Res64,Res35m1,Res36m1, (uint8 *)e_uint64_ptr,i1,i2,i3);
 					close_savefile(g_cstr,fp); fp = 0x0;
@@ -2765,7 +2770,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			// If end of a regular (non-s2-continuation) p-1 run and primary good, rename it from [p|f][expo] ==> [p|f][expo].s1;
 			// if primary missing/corrupt, rename secondary q[expo] ==> [p|f][expo].s1:
 			if(TEST_TYPE == TEST_TYPE_PM1 && !s2_continuation) {
-				if(rename(RESTARTFILE, g_cstr)) {
+				if(mlucas_rename(RESTARTFILE, g_cstr)) {
 					snprintf(cbuf,sizeof(cbuf),"ERROR: unable to rename the p-1 stage 1 savefile %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 					mlucas_fprint(cbuf,1);
 				}
@@ -2773,7 +2778,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 				// If primary was missing/corrupt, i.e. we're on the secondary, rename secondary to primary-name
 				if(RESTARTFILE[0] == 'q') {
 					RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
-					if(rename(g_cstr, RESTARTFILE)) {
+					if(mlucas_rename(g_cstr, RESTARTFILE)) {
 						snprintf(cbuf,sizeof(cbuf),"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 						mlucas_fprint(cbuf,1);
 					}
@@ -2905,8 +2910,12 @@ GET_NEXT_ASSIGNMENT:
 		fclose(fq); fq = 0x0;
 
 		/* Now blow away the old worktodo file and rename WINI.TMP ==> worktodo.txt...	*/
-		remove(WORKFILE);
-		if(rename("WINI.TMP", WORKFILE))
+		// v21: A single atomic rename replaces the former remove()-then-rename() pair, which on POSIX left a
+		// window in which the worktodo file did not exist at all - a crash there lost the entire assignment
+		// list. mlucas_rename() also supplies the MLUCAS_PATH prefix which the bare rename() omitted (both files
+		// having been *created* through mlucas_fopen(), which prefixes) and the replace-existing semantics which
+		// the Windows CRT rename() lacks - the very reason the remove() was there in the first place:
+		if(mlucas_rename("WINI.TMP", WORKFILE))
 		{
 			sprintf(cbuf,"ERROR: unable to rename WINI.TMP file ==> %s ... attempting line-by-line copy instead.\n",WORKFILE);
 			fprintf(stderr,"%s",cbuf);
@@ -5093,7 +5102,7 @@ holds the previous good checkpoint, rather than proceed with two damaged copies 
 */
 void close_savefile(const char *fname, FILE *fp)
 {
-	if(fclose(fp) == EOF) {
+	if(mlucas_fclose_atomic(fname,fp)) {
 		snprintf(cbuf,sizeof(cbuf),"ERROR: close of savefile %s failed - filesystem full? Aborting rather than leave a silently-truncated savefile.\n",fname);
 		mlucas_fprint(cbuf,0);	ASSERT(0,cbuf);
 	}

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2755,7 +2755,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		re-using it would kibosh subsequent stage 2 continuation runs. Safer to start with s1 residue for those:
 		*/
 		strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".s2");
-		if(remove(g_cstr)) {
+		if(mlucas_remove(g_cstr)) {
 			snprintf(cbuf,sizeof(cbuf),"INFO: Unable to remove stage 2 savefile %s.\n",g_cstr);
 			mlucas_fprint(cbuf,1);
 		}
@@ -2782,7 +2782,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 						snprintf(cbuf,sizeof(cbuf),"ERROR: Primary savefile missing/corrupt, but unable to rename the secondary %s ==> %s ... any ensuing LL/PRP test will overwrite.\n",RESTARTFILE,g_cstr);
 						mlucas_fprint(cbuf,1);
 					}
-				} else if(remove(g_cstr))	// ...otherwise delete the secondary
+				} else if(mlucas_remove(g_cstr))	// ...otherwise delete the secondary
 					fprintf(stderr, "Unable to delete secondary restart file %s.\n",g_cstr);
 			}
 		} else
@@ -2793,7 +2793,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 	}
 	// If completion of LL/PRP run, or secondary was not used as a backup for p-1 stage 1 savefile rename, delete it now:
 	RESTARTFILE[0] = 'q';
-	if(remove(RESTARTFILE))
+	if(mlucas_remove(RESTARTFILE))
 		fprintf(stderr, "Unable to delete secondary restart file %s\n",RESTARTFILE);
 
 	RESTARTFILE[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
@@ -2823,7 +2823,7 @@ GET_NEXT_ASSIGNMENT:
 			ASSERT(0,cbuf);
 		}
 		/* Remove any WINI.TMP file that may be present: */
-		remove("WINI.TMP");
+		mlucas_remove("WINI.TMP");
 		fq = mlucas_fopen("WINI.TMP", "w");
 		if(!fq) {
 			sprintf(cbuf, "Unable to open WINI.TMP file for writing.\n");
@@ -2940,7 +2940,7 @@ GET_NEXT_ASSIGNMENT:
 
 			/*...Then remove the WINI.TMP file:	*/
 
-			remove("WINI.TMP");
+			mlucas_remove("WINI.TMP");
 		}
 		/* if one or more exponents left in rangefile, go back for more; otherwise exit. */
 		if (i > 0) {

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -91,6 +91,9 @@ uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 	int n, int scrnFlag, double *tdiff, char *const gcd_str);
 int		test_types_compatible(uint32 t1, uint32 t2);
+int		write_savefile_field(FILE *fp, const uint64 val, const uint32 nbyte);
+void	close_savefile(const char *fname, FILE *fp);
+int		savefile_ends_at(const char *func, const char *fname, FILE *fp, uint32 nread, uint64 expect_len, int need_gcheck);
 int		 read_ppm1_residue(const uint32 nbytes, FILE *fp,       uint8 arr_tmp[],       uint64 *Res64,       uint64 *Res35m1,       uint64 *Res36m1);
 void	write_ppm1_residue(const uint32 nbytes, FILE *fp, const uint8 arr_tmp[], const uint64 Res64, const uint64 Res35m1, const uint64 Res36m1);
 int		 read_ppm1_savefiles(const char *fname, uint64 p, uint32 *kblocks, FILE *fp, uint64 *ilo, uint8 arr1[], uint64 *Res64, uint64 *Res35m1, uint64 *Res36m1, uint8 arr2[], uint64 *i1, uint64 *i2, uint64 *i3);

--- a/src/factor.c
+++ b/src/factor.c
@@ -4040,7 +4040,9 @@ MFACTOR_HELP:
 			}
 			if(fp) { fclose(fp); fp = 0x0; }
 			fclose(fq); fq = 0x0;
-			if(rename(TMPFILE,RESTARTFILE)) {
+			// v21: mlucas_rename(), not rename(): supplies the MLUCAS_PATH prefix both files were created with,
+			// and replaces an existing destination on Windows, whose CRT rename() fails with EEXIST instead:
+			if(mlucas_rename(TMPFILE,RESTARTFILE)) {
 				sprintf(g_cstr,"ERROR: unable to rename %s file ==> %s.\n",TMPFILE,RESTARTFILE);
 				ASSERT(0,g_cstr);
 			}
@@ -4663,8 +4665,10 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 {
 	int itmp;
 	uint32 curr_line = 0, nerr = 0;
-	/* TF restart files are in HRF, not binary: */
-	fp = mlucas_fopen(fname,"w");	// Open in write mode
+	/* TF restart files are in HRF, not binary. v21: _atomic - stage the new contents in a scratch file and
+	rename it over the target, so that a crash partway through this write cannot leave a truncated savefile
+	where a complete one used to be: */
+	fp = mlucas_fopen_atomic(fname,"w");	// Open in write mode
 	if(!fp) {
 	#ifndef FACTOR_STANDALONE
 		fp = mlucas_fopen(STATFILE,"a");
@@ -4729,7 +4733,14 @@ uint64 kmin, uint64 know, uint64 kmax, uint32 passmin, uint32 passnow, uint32 pa
 		if(itmp <= 0) {
 			++nerr; fprintf(stderr,"ERROR: unable to write Line %d (#Q tried) of factoring restart file %s!\n",curr_line,fname);
 		}
-		fclose(fp); fp = 0x0;
+		// v21: If any of the above writes failed we have nothing worth publishing, so drop the scratch file and
+		// leave any pre-existing savefile alone; otherwise commit it, counting a failure to do so as one more error:
+		if(nerr) {
+			mlucas_discard_atomic(fname,fp);
+		} else if(mlucas_fclose_atomic(fname,fp)) {
+			++nerr; fprintf(stderr,"ERROR: unable to commit factoring restart file %s ... any previous savefile left in place.\n",fname);
+		}
+		fp = 0x0;
 		return (int)nerr;
 	}
 }

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -1465,7 +1465,7 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 		fp = mlucas_fopen(inv_file, "wb");
 		if(fp) {
 			write_ppm1_savefiles(inv_file,p,n,fp, 0ull, (uint8*)vec2,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
-			fclose(fp);	fp = 0x0;
+			close_savefile(inv_file,fp);	fp = 0x0;
 		} else {
 			snprintf(cbuf,STR_MAX_LEN*2, "ERROR: unable to open restart file %s for write of checkpoint data.\n",inv_file);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);
@@ -1720,7 +1720,7 @@ MME = 0;
 	savefile[0] = ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? 'p' : 'f');
 	strcat(savefile, ".s2");
 	// [From the above p-1 savefile schema] 3. On entry, S2 checks for existence of ".s2" savefile:
-	fp = mlucas_fopen(savefile,"r");
+	fp = mlucas_fopen(savefile,"rb");	// v21: the .s2 savefile is binary (written "wb"); text mode mangles it on Windows
 	// o If exists, read nsquares field into uint64 qlo, mask off high byte (which stores the value of any relocation-prime
 	// psmall used for stage 2), compare vs original-assignment B2_start read (or inferred, as B2_start = B1) from worktodo entry:
 	if(fp) {												// G-check residue fields all set NULL in this call:
@@ -2461,7 +2461,7 @@ MME = 0;
 				// q won't get += bigstep until we loop, so here, (q + bigstep) is the q-value corr. to just-incremented k.
 				// Also write any relocation-prime psmall into high bit of the resulting nsquares field:
 				write_ppm1_savefiles(savefile,p,n,fp, ((uint64)psmall<<56) + q + bigstep, (uint8*)arrtmp,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
-				fclose(fp);	fp = 0x0;
+				close_savefile(savefile,fp);	fp = 0x0;
 			} else {
 				snprintf(cbuf,STR_MAX_LEN*2, "ERROR: unable to open restart file %s for write of checkpoint data.\n",savefile);
 				mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0,cbuf);

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -532,7 +532,9 @@ PM1_S1P_READ_RETURN:
 		ASSERT(arr != 0x0, "Null arr pointer!");
 		ASSERT(strlen(fname) != 0, "Empty filename!");
 
-		FILE*fptr = mlucas_fopen(fname, "wb");
+		// v21: atomic-replace: a crash partway through this write formerly left a truncated primes-product
+		// file in place of the previous complete one, and the caller has no backup copy to fall back on:
+		FILE*fptr = mlucas_fopen_atomic(fname, "wb");
 		if(!fptr) {
 			sprintf(cbuf,"ERROR: Unable to open precomputed p-1 stage 1 primes-product file %s for writing.\n",fname);
 			mlucas_fprint(cbuf,pm1_standlone+1);	ASSERT(0, cbuf);
@@ -570,7 +572,17 @@ PM1_S1P_READ_RETURN:
 		retval = 1;
 
 	PM1_S1P_WRITE_RETURN:
-		if(fptr) { fclose(fptr); fptr = 0x0; }
+		// v21: On the checksum-mismatch path above retval is still 0, i.e. we are abandoning this write;
+		// commit the scratch file over the target only if the data we staged in it is actually good:
+		if(fptr) {
+			if(!retval)
+				mlucas_discard_atomic(fname,fptr);
+			else if(mlucas_fclose_atomic(fname,fptr)) {
+				sprintf(cbuf,"ERROR: Unable to commit precomputed p-1 stage 1 primes-product file %s.\n",fname);
+				mlucas_fprint(cbuf,pm1_standlone+1);	retval = 0;
+			}
+			fptr = 0x0;
+		}
 		return retval;
 	}
 #endif
@@ -1462,7 +1474,7 @@ fprintf(stderr,"#1: vec1 = A^+1 checksums = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ";
 		Res35m1 = mi64_div_by_scalar64(vec2,two35m1,nlimb,0x0);
 		Res36m1 = mi64_div_by_scalar64(vec2,two36m1,nlimb,0x0);
 		// Write inverse to savefile:
-		fp = mlucas_fopen(inv_file, "wb");
+		fp = mlucas_fopen_atomic(inv_file, "wb");	// v21: atomic-replace, as for the .s2 checkpoint below
 		if(fp) {
 			write_ppm1_savefiles(inv_file,p,n,fp, 0ull, (uint8*)vec2,Res64,Res35m1,Res36m1, 0x0,0x0,0x0,0x0);
 			close_savefile(inv_file,fp);	fp = 0x0;
@@ -2456,7 +2468,13 @@ MME = 0;
 				, 1000*get_time(*tdiff)/(nmodmul - nmodmul_save), Res64, AME, MME);
 			mlucas_fprint(cbuf,pm1_standlone+scrnFlag);
 			*tdiff = MME = 0.0;	// Reset timer and maxerr at end of each iteration interval
-			fp = mlucas_fopen(savefile, "wb");
+			// v21: _atomic: the .s2 checkpoint has no secondary copy standing behind it - unlike the p/q
+			// residue savefiles, where a corrupt primary is detected and the secondary used instead - so
+			// truncating it in place made every checkpoint write a window in which the *only* record of
+			// stage-2 progress on disk was a partially-written file. Killing a run in that window destroyed
+			// the last good checkpoint and cost the whole of stage 2 so far. Stage the write in a scratch
+			// file and rename it over the target, which is then never seen in a partial state:
+			fp = mlucas_fopen_atomic(savefile, "wb");
 			if(fp) {
 				// q won't get += bigstep until we loop, so here, (q + bigstep) is the q-value corr. to just-incremented k.
 				// Also write any relocation-prime psmall into high bit of the resulting nsquares field:

--- a/src/util.c
+++ b/src/util.c
@@ -36,6 +36,10 @@
 #endif
 #if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
 	#include <windows.h>
+	#include <io.h>		// v21: _commit(), _fileno() - the Windows spellings of fsync(), fileno()
+#else
+	#include <fcntl.h>	// v21: open() of the savefile's containing directory, to fsync() a rename
+	#include <unistd.h>	// v21: fsync(), fileno(), close()
 #endif
 
 #if 0
@@ -9553,6 +9557,172 @@ FILE *mlucas_fopen(const char *path, const char *mode)
 	strcpy(mlucas_path, MLUCAS_PATH);
 	strcat(mlucas_path, path);
 	return fopen(mlucas_path, mode);
+}
+
+/**************************************************************************************************/
+/*** v21: Crash-safe (atomic) savefile replacement - see the mlucas_fopen_atomic() comment below ***/
+/**************************************************************************************************/
+
+/* Suffix appended to a savefile name to form the name of the scratch file its replacement is
+staged in. Deliberately a fixed string rather than a mkstemp()-style random one: it keeps the
+scratch file next to its target in the same directory (a hard requirement, since rename() is only
+atomic *within* a filesystem), it is unique per target because savefile names already are, and a
+leftover from a previous crash is simply reused rather than accumulating as litter: */
+#define SAVEFILE_TMP_SUFFIX	".new"
+
+/* MLUCAS_PATH-prefix [path] (+ optional [suffix]) into caller-supplied buffer [dest], which must
+have room for MLUCAS_PATH_BUFSIZE chars. Same length reasoning as mlucas_fopen(): */
+#define MLUCAS_PATH_BUFSIZE	(2*STR_MAX_LEN + sizeof(SAVEFILE_TMP_SUFFIX) + 1)
+
+static void mlucas_path_cat(char dest[], const char *path, const char *suffix)
+{
+	strcpy(dest, MLUCAS_PATH);
+	strcat(dest, path);
+	if(suffix) strcat(dest, suffix);
+}
+
+/* Rename [oldpath] ==> [newpath], both MLUCAS_PATH-relative, replacing [newpath] if it exists.
+Returns 0 on success, nonzero on failure. Two things this does which a bare rename() call does not:
+
+	[1] It applies the MLUCAS_PATH prefix. Every Mlucas file is *created* through mlucas_fopen(),
+	    which prefixes; the bare rename() calls this replaces did not, so under a nonempty
+	    MLUCAS_PATH (the "$HOME/.mlucas.d/" packaging layout, or the MLUCAS_PATH env var) they
+	    named files which do not exist, and the renames simply failed.
+
+	[2] It replaces an existing destination on Windows as well as POSIX. rename(2) is required to
+	    atomically replace the destination on POSIX, but the Windows CRT rename() fails with EEXIST
+	    if the destination exists - which is exactly the case here, since the whole point is to
+	    overwrite the previous savefile. MoveFileEx(...,MOVEFILE_REPLACE_EXISTING) is the Windows
+	    equivalent; MOVEFILE_WRITE_THROUGH additionally asks that the rename be flushed before the
+	    call returns, which is what makes it durable rather than merely atomic.
+
+Note the preprocessor gate: platform.h routes MinGW builds down its OS_TYPE_LINUX branch on purpose
+(see the "MinGW builds use the Linux codepath" comment there), so a bare #ifdef OS_TYPE_WINDOWS would
+miss MinGW - whose rename() is the same replace-hostile msvcrt one. Test both, as platform.h itself
+does wherever it needs "is this a Windows target?" rather than "is this an MSVC build?".
+*/
+int mlucas_rename(const char *oldpath, const char *newpath)
+{
+	char obuf[MLUCAS_PATH_BUFSIZE], nbuf[MLUCAS_PATH_BUFSIZE];
+	mlucas_path_cat(obuf, oldpath, 0x0);
+	mlucas_path_cat(nbuf, newpath, 0x0);
+#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+	return !MoveFileEx(obuf, nbuf, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+#else
+	return rename(obuf, nbuf);
+#endif
+}
+
+/* Open the scratch file in which a crash-safe replacement of savefile [path] is staged. Use exactly
+as mlucas_fopen(path,"wb"), but close the result with mlucas_fclose_atomic(path,fp) rather than
+fclose(fp); [path] must be the same string in both calls.
+
+Why this exists: a savefile write of the form
+
+	fp = mlucas_fopen(savefile,"wb");  ...write...  fclose(fp);
+
+truncates the target *before* writing a single byte of the replacement, so from the instant the file
+is opened until the instant the last byte lands, there is no complete copy of that checkpoint on
+disk. A crash, kill -9, power loss or full filesystem in that window leaves a short or garbage
+savefile behind and takes the previous good checkpoint with it. Measured, not theoretical: killing a
+p-1 run partway through a .s2 stage-2 checkpoint write leaves a truncated .s2 where the previous
+complete checkpoint used to be, and the next run then discards that stage-2 progress entirely and
+redoes the stage from its start. The p/q residue-savefile pair survives the same treatment only
+because there are two copies of it - the corrupt primary is detected and the secondary used instead.
+The .s2 checkpoint has no second copy, so there is nothing to fall back to.
+
+Staging the new contents in a sibling scratch file and rename()-ing it over the target closes that
+window: the target is only ever replaced by a rename, which is atomic, so at every instant the file
+on disk is either the complete old checkpoint or the complete new one - never a prefix of either.
+The scratch file must live in the same directory as its target for this to work, since rename() is
+only atomic within a filesystem; appending a suffix to the full target path guarantees that.
+*/
+FILE *mlucas_fopen_atomic(const char *path, const char *mode)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE];
+	ASSERT(mode != 0x0 && mode[0] == 'w', "mlucas_fopen_atomic: only write ('w'/'wb') modes make sense here!");
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	return fopen(tmp_path, mode);
+}
+
+/* Abandon a crash-safe savefile write begun with mlucas_fopen_atomic(path,...): close the scratch
+file and delete it, leaving [path] untouched. For callers which discover partway through - or after
+finishing - that the data they staged is not fit to be published: */
+void mlucas_discard_atomic(const char *path, FILE *fp)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE];
+	if(fp) fclose(fp);
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	remove(tmp_path);
+}
+
+/* Finish a crash-safe savefile write begun with mlucas_fopen_atomic(path,...): flush the stdio
+buffer, push the data to stable storage, close, then atomically rename the scratch file over [path].
+Returns 0 on success; on any failure returns nonzero having deleted the scratch file, so that [path]
+still holds the previous good checkpoint. Callers must check the return value - it is the analogue of
+a failed write, not of a failed fclose() nobody looks at.
+
+The fsync() is the difference between "a crash cannot corrupt the savefile" and "a *power loss*
+cannot corrupt the savefile". Without it the rename can reach the disk ahead of the data it is
+supposed to be publishing, leaving the target name pointing at a file whose contents never made it
+out of the page cache. Its failure is treated as a write failure, since a deferred ENOSPC/EIO is
+exactly how a filesystem reports that the data did not make it.
+*/
+int mlucas_fclose_atomic(const char *path, FILE *fp)
+{
+	char tmp_path[MLUCAS_PATH_BUFSIZE], tmp_name[STR_MAX_LEN + sizeof(SAVEFILE_TMP_SUFFIX)];
+	int err = 0;
+	if(!fp) return -1;
+	mlucas_path_cat(tmp_path, path, SAVEFILE_TMP_SUFFIX);
+	strcpy(tmp_name, path);	strcat(tmp_name, SAVEFILE_TMP_SUFFIX);	// MLUCAS_PATH-relative, for mlucas_rename()
+	/* [1] stdio buffer ==> OS: */
+	if(fflush(fp) != 0)
+		err = 1;
+	/* [2] OS page cache ==> stable storage. EINVAL/ENOTSUP mean the fd is of a type which cannot be
+	synced (a pipe, or a filesystem lacking the operation) rather than that the data was lost, so do
+	not treat those as write failures: */
+	if(!err) {
+	#if defined(OS_TYPE_WINDOWS) || defined(__MINGW32__)
+		if(_commit(_fileno(fp)) != 0 && errno != EINVAL && errno != EBADF)
+			err = 1;
+	#else
+		if(fsync(fileno(fp)) != 0 && errno != EINVAL && errno != ENOTSUP)
+			err = 1;
+	#endif
+	}
+	/* [3] Close. A failed fclose() means buffered data was dropped, i.e. the file is short: */
+	if(fclose(fp) != 0)
+		err = 1;
+	if(err) {
+		remove(tmp_path);	// Leave [path] holding the previous good checkpoint
+		return 1;
+	}
+	/* [4] Publish, atomically: */
+	if(mlucas_rename(tmp_name, path)) {
+		remove(tmp_path);
+		return 1;
+	}
+	/* [5] Make the rename itself durable by syncing the containing directory. Best-effort: a
+	failure here means the *name change* might not survive a power loss, in which case the target
+	simply still holds the previous good checkpoint - no corruption either way - so unlike the data
+	fsync above this one does not fail the write. No Windows equivalent, and none needed: the
+	MOVEFILE_WRITE_THROUGH flag passed to MoveFileEx() already covers it. */
+#if !defined(OS_TYPE_WINDOWS) && !defined(__MINGW32__)
+	{
+		char *slash;	int dfd;
+		strcpy(tmp_path, MLUCAS_PATH);	strcat(tmp_path, path);
+		slash = strrchr(tmp_path,'/');
+		if(slash == tmp_path)	// Target sits in the root directory
+			tmp_path[1] = '\0';
+		else if(slash)
+			*slash = '\0';
+		else					// No directory component at all ==> current working directory
+			strcpy(tmp_path,".");
+		dfd = open(tmp_path, O_RDONLY);
+		if(dfd >= 0) { fsync(dfd); close(dfd); }
+	}
+#endif
+	return 0;
 }
 
 /*********************/

--- a/src/util.c
+++ b/src/util.c
@@ -9613,6 +9613,18 @@ int mlucas_rename(const char *oldpath, const char *newpath)
 #endif
 }
 
+/* remove() with the MLUCAS_PATH prefix applied, for the same reason mlucas_rename() exists: every
+savefile in the tree is created through mlucas_fopen(), which prepends MLUCAS_PATH, so a bare
+remove(name) under a nonempty prefix looks in the wrong directory. It does not fail loudly - it
+returns nonzero for "no such file", which the call sites then report as an inability to delete a
+file that was in fact never looked at. */
+int mlucas_remove(const char *path)
+{
+	char buf[MLUCAS_PATH_BUFSIZE];
+	mlucas_path_cat(buf, path, 0x0);
+	return remove(buf);
+}
+
 /* Open the scratch file in which a crash-safe replacement of savefile [path] is staged. Use exactly
 as mlucas_fopen(path,"wb"), but close the result with mlucas_fclose_atomic(path,fp) rather than
 fclose(fp); [path] must be the same string in both calls.

--- a/src/util.h
+++ b/src/util.h
@@ -198,6 +198,7 @@ int		mlucas_fclose_atomic(const char *path, FILE *fp);
 void	mlucas_discard_atomic(const char *path, FILE *fp);
 /* MLUCAS_PATH-aware, replace-existing-destination rename; 0 = success: */
 int		mlucas_rename(const char *oldpath, const char *newpath);
+int		mlucas_remove(const char *path);
 // v20: Add simple utility to print the input string to the current-assignment logfile and/or to stderr:
 void	mlucas_fprint(char*const p_cstr, uint32 echo_to_stderr);
 double	mlucas_getOptVal(const char*fname, char*optname);

--- a/src/util.h
+++ b/src/util.h
@@ -188,6 +188,16 @@ char	*quote_spaces(char *dest, char *src); /* Double-quote spaces in string  */
 int		mkdir_p(char *path); /* Emulate `mkdir -p path'  */
 char	*shell_quote(char *dest, char *src); /* Escape shell meta characters  */
 FILE	*mlucas_fopen(const char *path, const char *mode); /* fopen() wrapper  */
+/* v21: Crash-safe savefile replacement. mlucas_fopen_atomic() stages the new contents in a sibling
+scratch file; mlucas_fclose_atomic() syncs it and renames it over the target, which is thus replaced
+atomically rather than truncated in place. Both take the same MLUCAS_PATH-relative [path]; the close
+returns 0 on success and nonzero (target left holding the previous good checkpoint) on failure: */
+FILE	*mlucas_fopen_atomic(const char *path, const char *mode);
+int		mlucas_fclose_atomic(const char *path, FILE *fp);
+/* Abandon a staged write: close and delete the scratch file, leaving the target untouched: */
+void	mlucas_discard_atomic(const char *path, FILE *fp);
+/* MLUCAS_PATH-aware, replace-existing-destination rename; 0 = success: */
+int		mlucas_rename(const char *oldpath, const char *newpath);
 // v20: Add simple utility to print the input string to the current-assignment logfile and/or to stderr:
 void	mlucas_fprint(char*const p_cstr, uint32 echo_to_stderr);
 double	mlucas_getOptVal(const char*fname, char*optname);


### PR DESCRIPTION
## The one-line argument

Same run, same exponent, same filesystem condition. The only variable is whether the return value of the write is examined:

```
### PRP savefile, 35-byte shortfall (fails 1 byte inside the G-check residue body -> CHECKED fwrite)
    on-disk after the failed checkpoint: p=27674  q=27709   <<< secondary still holds the last good checkpoint
    Mlucas said: Assertion '0' failed: write_ppm1_residue: Error writing residue to restart file.
    restart:     Restarting M110527 ...
    results.txt: "res64":"E95075F756DD7BEB" "error-code":"00000000" "gerbicz":0   <<< FULLY CORRECT

### PRP savefile, 4-byte shortfall (fails inside NERR_GCHECK -> UNCHECKED fputc)
    on-disk after the failed checkpoint: p=27705  q=27705   <<< BOTH COPIES TRUNCATED
    Mlucas said:                                            <<< NOTHING AT ALL
    restart:     (no message at all)
    results.txt: "res64":"E95075F756DD7BEB" "error-code":"00F00000" "gerbicz":4278124287
```

A savefile has ~20 fields and exactly two of them — the residue bodies — had their write return value checked. Everything else went out through unchecked `fputc()`: the Res64/Res35m1/Res36m1 checksum triplet at the end of `write_ppm1_residue()`, and every fixed-width field in `write_ppm1_savefiles()` (`t`, `m`, `s`, `kblocks`, `RES_SHIFT`, `PRP_BASE`, `GCHECK_SHIFT`, `NERR_ROE`, `NERR_GCHECK`). The file was then closed with an unchecked `fclose()` at both `ernstMain()` savefile-write sites — the `p`/`q` checkpoint and the `.G` Gerbicz savefile. Because the secondary savefile is written immediately afterwards from the same in-memory data, both copies end up truncated at the same offset, and nothing appears in stdout, stderr or `p<exp>.stat`.

That unchecked tail is the last 34 bytes of a PRP savefile and the last 37 of an LL / P-1-stage-1 one — which is exactly where a gradually-filling filesystem lands. A run rewrites `p<exp>`/`q<exp>` in place at every checkpoint, each `"wb"` freeing its own space, so the deficit is only whatever *other* files consumed since the last checkpoint (the `.stat` log grows a few hundred bytes every single checkpoint). The realistic failure is a shortfall of a few bytes near the end of the file, in both copies, at the same offset.

## A 1-byte shortfall poisons an LL result

The `NERR_GCHECK` read loop in `read_ppm1_savefiles()` is one of three field-read loops in that function with no EOF test — the others being `PRP_BASE` and `GCHECK_SHIFT` — and the one whose garbage value reaches the server. `i` is `uint32`, so `EOF` becomes `0xFFFFFFFF` and the four shifted copies sum to `NERR_GCHECK = 0xFEFEFEFF = 4278124287`, and the function returns **success** with nothing printed. That value reaches the server twice, both in `generate_JSON_report()`: `const uint32 error_code = (MIN(NERR_ROE, 0x3F) << 8) | (MIN(NERR_GCHECK, 0xF) << 20);` pins bits 20-23 of the Prime95 error code to `0xF` ("15 Gerbicz errors"), and the PRP and PRP-CF result lines emit the raw counter unclamped in their `"gerbicz"` field.

Reproduced on an **LL** test — a test type that has no Gerbicz check at all, so the code is not merely wrong in magnitude, it is categorically impossible:

```
### LL savefile 13863 bytes, cap=13862, shortfall = 1 BYTE
    on-disk: p=13862 q=13862
    Mlucas said:                                    <<< NOTHING
    restart rc=0 -> (no message at all)
    results.txt: "res64":"DB43B1563828DEB6" "error-code":"00F00000"
```

The poisoned counter is also written back out by `write_ppm1_savefiles()` into every subsequent savefile, so it survives for the rest of the run even after space is freed.

## Truncation misread as an old file format

In `read_ppm1_savefiles()`, EOF in the `kblocks`/`RES_SHIFT` region was unconditionally interpreted as "this is a pre-v18 savefile" — both loops end in `sprintf(cbuf,"%s: Hit EOF in read of FFT-kblocks ... assuming a pre-v18 savefile.\n",func); ... return 1;` — success — without reading `PRP_BASE`, the entire Gerbicz-check residue, `GCHECK_SHIFT` or either error counter. A file written by the current version can only end there if it is truncated, and the code picked the benign reading. Because the read reported success, `ernstMain()`'s fallback to the secondary savefile (`else if(g_cstr[0] != 'q') { g_cstr[0] = 'q'; goto READ_RESTART_FILE; }`) was never reached: a primary truncated to 13844 bytes with a **valid `q` sitting next to it** still takes the truncated `p`.

`DO_GCHECK` is set from the test type in `ernstMain()` — `((TEST_TYPE == TEST_TYPE_PRIMALITY) && (MODULUS_TYPE == MODULUS_TYPE_FERMAT) && (use_lowmem < 2)) || (TEST_TYPE == TEST_TYPE_PRP)` — never from what was actually read, so for a PRP assignment the `if(DO_GCHECK)` arm of the post-read `convert_res_bytewise_FP()` block then converts the never-touched `e_uint64_ptr` into the Gerbicz accumulator `b[]`. Observed outcomes on the same corrupt input, depending on what is in that heap block: a run that completes and reports `"errors":{"Roundoff":0, "gerbicz":0}` for a check that was silently disabled for the rest of the test, or `SIGSEGV`/`SIGABRT` on every single restart with a perfectly good backup on disk. Under valgrind:

```
==986009== Conditional jump or move depends on uninitialised value(s)
==986009==    at 0x404E335: mi64_shlc (mi64.c:423)
==986009==    by 0x4070D16: convert_res_bytewise_FP (Mlucas.c:5517)
==986009==    by 0x4067805: ernstMain.constprop.0 (Mlucas.c:1574)   <<< the G-check residue
==986009==  Uninitialised value was created by a heap allocation
==986009==    by 0x4064631: ernstMain.constprop.0 (Mlucas.c:1419)
```

For LL the same window is reachable from an ordinary 17..19-byte ENOSPC shortfall, and `*kblocks` is forced to 0, which silently discards the FFT length recorded in the savefile — so `ernstMain()`'s FFT-length-reversion guard, `if((j && j > kblocks) && !fft_length && (NERR_ROE<<6)*ITERS_BETWEEN_CHECKPOINTS > ilo)`, cannot fire and a run that had been bumped to a larger FFT length because of excessive roundoff error silently reverts to the length already known to be too small for it. In this sweep the LL 13844/13846 rows crash outright (`dumped core`) on every restart.

## Globals clobbered by a failed read

`read_ppm1_savefiles()` parses `PRP_BASE`, `GCHECK_SHIFT` and `NERR_GCHECK` straight into their globals in loops with no EOF test, so a **failed** read leaves them holding `fgetc`-EOF garbage that nothing restores. (`NERR_ROE`'s loop does test EOF, and returns before assigning.) `PRP_BASE` was correctly parsed from the worktodo line before the call and is now destroyed. With both copies unusable the run reaches `ernstMain()`'s "INFO: no restart file found...starting run from scratch." branch, and the `if(ilo == 0)` seeding block below it sets `iseed = PRP_BASE`:

```
$ truncate -s 13855 p110527     # ends just before the 4 PRP_BASE bytes; no q present
ERROR: read_ppm1_savefiles Failed on savefile p110527!
INFO: no restart file found...starting run from scratch.
The test will be done in form of a 4278124287-PRP test.          <<< garbage PRP base
M110527 Roundoff warning on iteration        1, maxerr =   0.499850020977
 Switching to next-larger available FFT length 6K and restarting from last checkpoint file.
```

...and that last pair of lines repeats forever, since "next-larger" resolves to the same 6K. Measured: 36213 repetitions in 30 seconds, no progress, no output, no exit. With this change the same input gives `The test will be done in form of a 3-PRP test.` and zero FFT-switch messages.

## The fix

Detection only. The on-disk format is unchanged, and savefiles written by the old and new code were verified **byte-identical** for both LL and PRP.

* **`write_savefile_field()`** (new) emits the low `nbyte` bytes of a value with a checked `fputc()`. `write_ppm1_savefiles()` and the checksum triplet in `write_ppm1_residue()` route every fixed-width field through it and abort on failure — which is precisely the behaviour the residue-body `fwrite()` already had, and which the control row above shows to be correct: the run stops at the point of failure while the *other* copy still holds the previous good checkpoint.
* **`close_savefile()`** (new) checks `fclose()`, where a full filesystem most often surfaces because the tail fields sit in the stdio buffer until close. Used at all four savefile-write sites (`Mlucas.c` ×2, `pm1.c` ×2).
* **`savefile_ends_at()`** (new) vets the "older-format savefile" reading before accepting it: the EOF must fall on the *first* byte of the missing field rather than partway through one; the file length must exactly equal that of the older format for this exponent and test type; and a Gerbicz-check test — which needs a residue that no older format contains — must not take that path at all, since doing so is what feeds uninitialised heap into the computation.
* **`read_ppm1_savefiles()`** parses into locals and commits to `RES_SHIFT`, `PRP_BASE`, `GCHECK_SHIFT`, `NERR_ROE` and `NERR_GCHECK` only once the read has fully succeeded. The `PRP_BASE`, `GCHECK_SHIFT` and `NERR_GCHECK` loops gain the missing EOF tests.
* Savefile-acceptance messages now go to the logfile via `mlucas_fprint()` rather than only to stderr, so a legacy/short-format acceptance leaves a trace in `p<exp>.stat`.
* One extra one-character fix included because it is zero-risk and in the same function family: `restart_file_valid()` opened the savefile `"r"` rather than `"rb"`, though `read_ppm1_savefiles()`'s own contract comment — *"READ: Assumes a valid file pointer has been gotten via a call of the form `fp = mlucas_fopen(RESTARTFILE,"rb");`"* — requires `"rb"`. On Linux the two are identical, so this is a no-op here; on Windows/MinGW text mode collapses `\r\n` and treats an embedded `0x1A` as EOF, both near-certain in a binary residue, and `restart_file_valid()`'s verdict decides whether `q<exp>` gets promoted to `p<exp>` and which files get removed (the `for(ierr = 0; ; RESTARTFILE[0] = 'q')` loop in `ernstMain()`). **I have no Windows host and did not execute that path on one**, so the Windows benefit is by inspection only. One other *binary* savefile open is still in text mode and is deliberately **not** touched here: `pm1_stage2()` reads the stage-2 `.s2` savefile with `fp = mlucas_fopen(savefile,"r");` — the identical defect, on the very savefile the second commit below converts to atomic writes. Say the word and I will fold it in. (Mfactor's HRF restart files in `factor.c` are genuinely text and correctly use `"r"`.)

## Before/after: full shortfall sweep

Method: `LD_PRELOAD` shim interposing `fopen`/`fputc`/`fwrite`/`fclose`, which for `p110527`/`q110527` opened for writing accepts at most `NOSPC_CAP` bytes and thereafter short-writes from `fwrite`, returns `EOF` from `fputc` and returns `EOF` from `fclose` — the stdio-level symptoms of a full filesystem. Real production runs, not self-tests: `PRP=<aid>,1,2,110527,-1,75,0` and `Test=<aid>,110527,75,1`, FFT 6K, starting from a valid iteration-20000 checkpoint present in **both** `p` and `q`. Phase 1 runs with the cap in force; phase 2 re-runs with the space freed to see whether the run can recover and what it finally reports.

Uncorrupted reference results: PRP `"res64":"E95075F756DD7BEB" "error-code":"00000000" "gerbicz":0`, LL `"res64":"DB43B1563828DEB6" "error-code":"00000000"`.

| test | short by | fails inside | before: on disk | before: reported | before | after: on disk | after: reported | after |
|---|---|---|---|---|---|---|---|---|
| LL | 0 | *(control: no failure)* | p=13863 q=13863 | res64 ok, `00000000` | writes + restarts normally | p=13863 q=13863 | res64 ok, `00000000` | writes + restarts normally |
| LL | 1 | `NERR_GCHECK` | p=13862 **q=13862** | res64 ok, **`00F00000`** | **silent, poisoned result** | p=13862 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 4 | `NERR_GCHECK` | p=13859 **q=13859** | res64 ok, **`00F00000`** | **silent, poisoned result** | p=13859 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 7 | `NERR_ROE` | p=13856 **q=13856** | *(nothing)* | **silent, computation lost** | p=13856 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 8 | `NERR_ROE` | p=13855 **q=13855** | res64 ok, `00000000` | silent, corrupt file accepted | p=13855 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 9 | `RES_SHIFT` | p=13854 **q=13854** | res64 ok, `00000000` | silent, corrupt file accepted | p=13854 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 13 | `RES_SHIFT` | p=13850 **q=13850** | res64 ok, `00000000` | silent, corrupt file accepted | p=13850 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 16 | `RES_SHIFT` | p=13847 **q=13847** | res64 ok, `00000000` | silent, corrupt file accepted | p=13847 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 17 | `kblocks` | p=13846 **q=13846** | *(nothing)* | **silent, core dump every restart** | p=13846 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 19 | `kblocks` | p=13844 **q=13844** | *(nothing)* | **silent, core dump every restart** | p=13844 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 20 | `Res36m1` | p=13843 **q=13843** | *(nothing)* | **silent, computation lost** | p=13843 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 23 | `Res36m1` | p=13840 **q=13840** | *(nothing)* | **silent, computation lost** | p=13840 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| LL | 33 | `Res64` | p=13830 **q=13830** | *(nothing)* | **silent, computation lost** | p=13830 q=13863 | res64 ok, `00000000` | loud abort, recovered |
| PRP | 0 | *(control: no failure)* | p=27709 q=27709 | res64 ok, `00000000`, gerbicz 0 | writes + restarts normally | p=27709 q=27709 | res64 ok, `00000000`, gerbicz 0 | writes + restarts normally |
| PRP | 1 | `NERR_GCHECK` | p=27708 **q=27708** | res64 ok, **`00F00000`**, **gerbicz 4278190080** | **silent, poisoned result** | p=27708 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 4 | `NERR_GCHECK` | p=27705 **q=27705** | res64 ok, **`00F00000`**, **gerbicz 4278124287** | **silent, poisoned result** | p=27705 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 8 | `NERR_ROE` | p=27701 **q=27701** | res64 ok, `00000000`, gerbicz 0 | silent, corrupt file accepted | p=27701 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 9 | `GCHECK_SHIFT` | p=27700 **q=27700** | res64 ok, `00000000`, gerbicz 0 | silent, corrupt file accepted | p=27700 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 16 | `GCHECK_SHIFT` | p=27693 **q=27693** | res64 ok, `00000000`, gerbicz 0 | silent, corrupt file accepted | p=27693 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 19 | G-check `Res36m1` | p=27690 **q=27690** | *(nothing)* | **silent, computation lost** | p=27690 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 34 | G-check `Res64` | p=27675 **q=27675** | *(nothing)* | **silent, computation lost** | p=27675 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 35 | G-check residue **(checked `fwrite`)** | p=27674 q=27709 | res64 ok, `00000000`, gerbicz 0 | **loud abort, recovered** | p=27674 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 39 | G-check residue **(checked `fwrite`)** | p=27670 q=27709 | res64 ok, `00000000`, gerbicz 0 | **loud abort, recovered** | p=27670 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 13859 | `RES_SHIFT`, then reaches the checked `fwrite` | p=13850 q=27709 | res64 ok, `00000000`, gerbicz 0 | **loud abort, recovered** | p=13850 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 13862 | `RES_SHIFT`, then reaches the checked `fwrite` | p=13847 q=27709 | res64 ok, `00000000`, gerbicz 0 | **loud abort, recovered** | p=13847 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 13865 | `kblocks`, then reaches the checked `fwrite` | p=13844 q=27709 | res64 ok, `00000000`, gerbicz 0 | **loud abort, recovered** | p=13844 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |
| PRP | 13879 | residue 1 `Res64`, then reaches the checked `fwrite` | p=13830 q=27709 | res64 ok, `00000000`, gerbicz 0 | **loud abort, recovered** | p=13830 q=27709 | res64 ok, `00000000`, gerbicz 0 | loud abort, recovered |

**Before**, of 25 shortfall offsets: 4 silently submitted a result carrying a bogus maximal hardware-error code, 8 silently destroyed both copies and lost the run, 7 silently accepted a truncated savefile, and the only 6 that behaved correctly are exactly the 6 whose shortfall reaches a **checked** `fwrite`.

**After**, all 25 abort at the point of failure with the other copy still holding the previous good checkpoint, and every restart then completes with the correct residue and `"error-code":"00000000"`. Both defences fire independently — e.g. the 1-byte LL case:

```
write phase:  Assertion '0' failed: write_ppm1_savefiles: Error writing savefile p110527 -
              filesystem full? Aborting rather than leave a silently-truncated savefile.
              on-disk: p=13862 q=13863                       <<< secondary intact
restart:      read_ppm1_savefiles: Expected 4 G-check-error-count bytes in savefile p110527!
              ERROR: read_ppm1_savefiles Failed on savefile p110527!
              -> falls back to q110527, runs to completion
results.txt:  "res64":"DB43B1563828DEB6" "error-code":"00000000"
```

## Legitimate old savefiles are still accepted

Truncating a savefile to each real historical format length, no secondary present so acceptance/rejection is unambiguous:

| test | length | what it is | before | after |
|---|---|---|---|---|
| LL | 13844 | genuine pre-v18 (`nbytes+28`) | accepted | **accepted** |
| LL | 13847 | genuine v18-without-shift (`nbytes+31`) | accepted | **accepted** |
| LL | 13855 | genuine v19, no error counters (`nbytes+39`) | accepted | **accepted** |
| PRP | 27701 | genuine v19, no error counters (`2·nbytes+69`) | accepted | **accepted** |
| LL | 13845 / 13846 | truncated mid-`kblocks` | accepted | rejected (`ends in mid-field`) |
| LL | 13850 | truncated mid-`RES_SHIFT` | accepted | rejected (`ends in mid-field`) |
| LL | 13856 | truncated mid-`NERR_ROE` | rejected | rejected |
| LL | 13859 / 13862 | truncated mid-`NERR_GCHECK` | **accepted, no message** | rejected |
| PRP | 27705 / 27708 | truncated mid-`NERR_GCHECK` | **accepted, no message** | rejected |
| PRP | 13844 / 13847 | ends before the G-check residue | **accepted, runs on uninitialised heap** | rejected (`lacks the Gerbicz-check residue`) |

The genuine pre-v18 LL file was additionally run to completion under the fix and gives the correct `"res64":"DB43B1563828DEB6"`, `"error-code":"00000000"`, with the acceptance now recorded in `p110527.stat`.

Residual, stated plainly: a truncation landing *exactly* on a historical format boundary (e.g. an LL savefile exactly `nbytes+28` bytes long) is indistinguishable from a genuine old savefile by any length or content test, and is still read as legacy. What closes that hole is the write-side half of this change: such a file can no longer be produced silently — the write that would have created it now aborts, with the other copy intact. In the sweep, the LL 17- and 19-byte rows are exactly this case, and they are green in the "after" column for that reason.

## Verification performed

Linux x86_64, gcc 16.1.1, single-threaded, `bash makemake.sh avx2`:

* Full clean build, no new warnings.
* `obj_avx2/Mlucas -s tt`: 13K/14K/15K Res64 = `E3BC90B0E652C7C0` / `DB8E39C67F8CCA0A` / `B3C5A1C03E26BB17`, matching the expected values.
* The 27-row shortfall sweep above, before and after, both test types.
* Historical-format acceptance matrix above, before and after.
* Savefiles written by the old and new binaries from the same checkpoint are `cmp`-identical, `p` and `q`, for both LL and PRP.
* Both an LL and a PRP savefile round-trip (write checkpoint, restart from it, complete) since the error-code poisoning was on the LL path.
* `Test=<aid>,110527,75,0` P-1 run: same factor `22178240650613079833`, same `"status":"F"`, rc=0, before and after — the two `pm1.c` `close_savefile()` conversions do not disturb it.
* **Not tested:** Windows (the `"rb"` change), AVX-512, ARM, and the P-1 stage-2-continuation savefile path.

## Still outstanding — not in this PR

There is no crash-safe savefile update: no write-to-temp-then-`rename`, no `fsync`/`fdatasync` anywhere in the tree (`grep -rn "fsync\|fdatasync" src/` → zero hits), and the primary is truncated in place by `"wb"` before its replacement exists (`ernstMain()`'s `WRITE_RESTART_FILE` block; the every-10M-iteration `rename(RESTARTFILE, g_cstr)` archive step just above it widens the window further by removing `p<exp>` before the write). The primary-then-secondary write order does buy real protection — with `p` damaged and `q` intact the run restarts correctly from `q`, verified — but nothing forces `p`'s bytes to stable storage before `q`'s truncation lands, so under power loss the filesystem may commit an arbitrary prefix of either copy in either order.

This PR narrows the both-copies-simultaneously-invalid window to that case; it does not close it. The temp-file + `fsync` + `rename` redesign is a genuine design change and is deliberately left for a separate decision.

Also noted while investigating and deliberately left alone: at `READ_RESTART_FILE` in `ernstMain()` the filename for a P-1 stage-2 continuation is rebuilt unconditionally (`else if(s2_continuation) { strcpy(g_cstr, RESTARTFILE); strcat(g_cstr, ".s1"); }`), while both read-failure handlers — the one for `read_ppm1_savefiles()` and the one for `convert_res_bytewise_FP()` — "fall back to the secondary" by mutating only the first character and jumping back to that label (`g_cstr[0] = 'q'; goto READ_RESTART_FILE;`). On re-entry the `s2_continuation` branch overwrites the `'q'`, so the same unreadable file is read, fails and jumps again. Traced statically only — I did not build a stage-2-continuation fixture, and it is adjacent to other in-flight P-1 restart work, so it is not touched here.


---

# Second commit: atomic savefile replacement

The first commit makes a **failed** write loud. This one makes an **interrupted** write harmless. They are two halves of the same problem and meet in one place, so they are one PR rather than two that collide.

## The gap

Savefile writes open the target with `mlucas_fopen(savefile,"wb")`, which **truncates in place**. A crash, kill, power loss or full filesystem partway through leaves a short or corrupt savefile *and* destroys the only copy of the previous good checkpoint.

Not hypothetical: `pm1_stage2()`'s per-interval checkpoint does exactly this for the stage-2 `.s2` file (`fp = mlucas_fopen(savefile, "wb");`) — and a crash *during* a checkpoint write is itself a common cause of the very restart that then has to read it.

## How the two halves compose

The call sites introduced by the first commit are unchanged; only `close_savefile()`'s body changes:

```c
void close_savefile(const char *fname, FILE *fp)
{
    if(mlucas_fclose_atomic(fname,fp)) { ...diagnose and abort... }
```

New helpers in `util.c`, beside `mlucas_fopen()`: `mlucas_fopen_atomic()` stages the new contents in a sibling `<target>.new`; `mlucas_fclose_atomic()` does fflush → fsync → fclose → rename → directory fsync; `mlucas_discard_atomic()` drops the scratch file. Any failure deletes the scratch file and returns nonzero **with the target untouched**.

## Scope — 12 write sites surveyed

Converted, being the truncate-in-place ones: the p/q (and `f`) LL/PRP residue checkpoints, the `.G` Gerbicz savefile, p-1's `.s2` / `.inv` / `.s1_prod`, and Mfactor's `init_savefile()`. Only the p/q pair had any prior protection (two copies, reader falls back); **the `.s2` had none**.

Deliberately excluded: `mlucas.cfg`, written incrementally across a self-test and a rebuildable cache; `factor.c`'s `write_savefile()`, which patches in place with `"r+"` rather than truncating (leaving it alone means #114 composes for free); and append-mode logs.

Each site's close-failure policy mirrors its own pre-existing open-failure policy, so nothing changes from fatal to non-fatal or vice versa.

Also fixed in passing: `factor.c`'s periodic restart-file update called bare `rename(TMPFILE,RESTARTFILE)`, which omits the `MLUCAS_PATH` prefix both files were created with — and whose Windows CRT form fails with `EEXIST` when the destination exists. Now `mlucas_rename()`.

## Windows

The gate is `(OS_TYPE_WINDOWS || __MINGW32__)`, matching what `util.c` already uses for `<windows.h>` — `platform.h` routes MinGW down the *Linux* branch, so the plain macro would miss it. That path uses `MoveFileEx(MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH)` and `_commit(_fileno())`, since POSIX `rename()` fails on Windows when the destination exists. **Not compile-tested there** — no toolchain available here.

## Verification

An `LD_PRELOAD` injector that writes N bytes then `_exit(137)`, so the interruption is real rather than simulated:

| scenario | before | after |
|---|---|---|
| killed 5000 bytes into the 3rd `.s2` write | 5000-byte `.s2`; the good `q=51450` checkpoint **gone**; restart redoes stage 2 from `q0=27300` | `.s2` intact at 15049 bytes; run resumes at **`q0 = 51450`** |
| 9-byte truncation | same, and `psmall` lost too | unaffected |

Same experiment on the p-residue savefile. A full LL run gives `res64 = 87A4592CF0B50DCC` in every variant. `Mfactor init_savefile` output byte-identical before and after. `nosimd` warning counts match `main`; `avx2` clean.

`nosimd -s tt` on the combined tree shows a `nonzero exit carry in radix30_ditN_cy_dif1` at iteration 8 — **pre-existing**, reproduced identically on a control tree without either commit. It is the known nosimd scalar-radix defect that #152 fixes.

## One claim I could not reproduce, and am therefore not making

#165 reports that a truncated `.s2` leads to `"status":"NF"` being published for an interval that was never searched. What I measured on unfixed code was a total loss of stage-2 progress — the truncated `.s2` was caught on the second read and stage 2 restarted from scratch — not a false NF. #165's path presumably needs its own `s2_continuation` setup. I have removed that stronger claim from the code comments rather than repeat it.

---

# Third commit: apply the `MLUCAS_PATH` prefix to the savefile `remove()` calls too

The second commit routed every savefile `rename()` through a `MLUCAS_PATH`-aware helper, which left five bare `remove()` calls in `Mlucas.c` as the only savefile paths in the file not carrying the prefix. Every savefile in the tree is *created* through `mlucas_fopen()`, which prepends `MLUCAS_PATH`, so under a nonempty prefix those five look in the wrong directory. They do not fail silently in the sense of returning success — `remove()` returns nonzero for "no such file" and each site duly reports it — but what the user sees is a complaint about being unable to delete a file that was in fact never looked at, while the intended file stays where it is.

What each site fails to do under a nonempty prefix:

| site | consequence |
|---|---|
| `.s2` removal after a completed p-1 run | the stage-2 savefile survives — defeating the stated intent of the comment directly above it, that a possibly-corrupt S2 residue must not be reachable by a later stage-2 continuation run |
| secondary `q<exp>`, p-1 branch | never deleted |
| secondary `q<exp>`, LL/PRP completion path | never deleted |
| `WINI.TMP` after a failed workfile rewrite | left behind |
| `WINI.TMP` after a successful one | left behind |

Adds `mlucas_remove()` to `util.c` beside `mlucas_rename()`, sharing its `mlucas_path_cat()` helper, and routes all five through it. No bare `remove()` or `rename()` on a savefile path remains in `Mlucas.c`.

Premise checked rather than assumed: `WORKFILE`, `WINI.TMP` and `RESTARTFILE` are opened via `mlucas_fopen()` at 4, 2 and 3 sites respectively and via bare `fopen()` at none, and `MLUCAS_PATH` is a real, user-settable, `mkdir_p`'d prefix.

Scope of testing: builds clean at `nosimd` and `avx2`. I did **not** exercise these paths end-to-end under a nonempty `MLUCAS_PATH` — that needs a worktodo assignment run to completion, since the deletions only happen at the end. The change is mechanical routing through the same prefix helper the `rename()` calls in the second commit already use, and the completeness of the routing was checked by confirming zero bare `remove()`/`rename()` calls remain.

---

*Description corrections since the first revision: the `NERR_GCHECK` read loop was described as the only EOF-untested field-read loop in `read_ppm1_savefiles()` (there are three, all fixed here); "every other savefile open in the tree uses `"rb"`" overlooked `pm1_stage2()`'s `.s2` read, which has the same defect and is not fixed here; and the third commit above was previously undescribed. Line-number citations have been replaced with function names and quoted code so they survive rebases.*

