### PR TITLE
twopmmodq128/192/256: recompute qhalf after the even-modulus right-justify shift

### DIFF
--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -87,6 +87,7 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	if(nshift) {
 		x.d0 = (uint64)nshift; x.d1 = 0ull; SUB128(p,x,p);	// p >= nshift guaranteed here:
 		RSHIFT128(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+		RSHIFT_FAST128(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
 	#if FAC_DEBUG
 		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint128_base10_char(char_buf,q)]);
 	#endif

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -87,6 +87,7 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	if(nshift) {
 		x.d0 = (uint64)nshift; x.d1 = x.d2 = 0ull; SUB192(p,x,p);	// p >= nshift guaranteed here:
 		RSHIFT192(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+		RSHIFT_FAST192(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
 	#if FAC_DEBUG
 		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint192_base10_char(char_buf,q)]);
 	#endif

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -122,6 +122,7 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	if(nshift) {
 		x.d0 = (uint64)nshift; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,p);	// p >= nshift guaranteed here:
 		RSHIFT256(q,nshift,q);	// Right-shift dividend by (nshift) bits; for 2^p this means subtracting nshift from p
+		RSHIFT_FAST256(q, 1, qhalf);	// Must recompute (q-1)/2: the mod-doublings in the powering loop reduce (mod q'), not (mod q)
 	#if FAC_DEBUG
 		if(dbg) printf("Removed power-of-2 from q: q' = (q >> %u) = %s\n",nshift,&char_buf[convert_uint256_base10_char(char_buf,q)]);
 	#endif


### PR DESCRIPTION
## The bug

`twopmmodq128()`, `twopmmodq192()` and `twopmmodq256()` compute the mod-doubling comparison
threshold `qhalf = (q-1)/2` from the **original** modulus — `src/twopmodq128.c:67`,
`src/twopmodq192.c:68`, `src/twopmodq256.c:103` — i.e. *before* the right-justify step a few
lines further down that strips the trailing zero bits of an even modulus:

```c
 67:	RSHIFT_FAST128(q, 1, qhalf);	/* = (q-1)/2, since q odd. */    <-- original q
 ...
 86:	nshift = trailz128(q);
 87:	if(nshift) {
 88:		x.d0 = (uint64)nshift; ... SUB128(p,x,p);
 89:		RSHIFT128(q,nshift,q);	// q <- q' = q >> nshift
 90:	}
 ...
166:	if(curr_bit) {	// modular doubling, against the STALE threshold:
167:		if(CMPUGT128(x, qhalf)){ ADD128(x, x, x); SUB128(x, q, x); }else{ ADD128(x, x, x); }
168:	}
```

`qhalf` is never recomputed, so from that point on it holds
`q_orig/2 = 2^(nshift-1)·q' >= q'`, while the powering loop needs the threshold of the
*reduced* modulus `q'`. Since `x < q' <= qhalf`, the comparison is always false, the
conditional `SUB128(x,q,x)` never fires, and every set bit of the exponent leaves the running
residue un-reduced. The returned value is too large by a multiple of the original modulus.

### Contrast: the 64-bit sibling does it in the right order

`twopmmodq64()` (`src/twopmodq.c:1204-1213`) computes `qhalf` **after** the shift:

```c
	nshift = trailz64(q);
	if(nshift) {
		q >>= nshift; p -= nshift;
		...
	}
	qhalf  = q>>1;	/* = (q-1)/2, since q odd. */
```

So this is a copy-forward omission in the wide variants, not a deliberate difference.

## The fix

One line per file: recompute `qhalf` from `q'` inside the `if(nshift)` block. The pre-shift
value is still needed by the `p <= 128/192/256` early-return path above (which powers modulo
the unshifted `q`), so the original computation is left in place rather than moved.

**Checked and *not* affected** (per the task's "don't ship a partial fix" concern):

* The `_q4`/`_q8` batch variants in these same files build `q = 2·k·p+1`, which is always odd,
  and contain no right-justify step at all — each of the three files has exactly one `trailz`
  call, in the routine fixed here.
* The negative-power routines `twopmodq128/192/256`, `twopmodq128x2`, `twopmodq128x2B`,
  `twopmodq160` likewise never shift the modulus (Montgomery requires odd `q`).
* Nothing else derived from `q` before the shift is stale: `qinv`, `R^2 mod q`, `pshift`,
  `leadb` and `start_index` are all computed after it.

## Verification

Box is AVX2 (no AVX-512 hardware); gcc 15.2.1; everything below was actually run.

### 1. Python-oracle differential vs `pow(2,p,q)`

4000 random `(p,q)` pairs per width (12000 per seed × 3 seeds), moduli of 65..width bits, both
parities of `q`, exponents from `width+400` up to `10^7` and up to 200-bit random values:

| | upstream/main | with this fix |
|---|---|---|
| 128-bit, even q | 511/2043 wrong | **0/2043** |
| 192-bit, even q | 506/2044 wrong | 16/2044 |
| 256-bit, even q | 509/2050 wrong | **0/2050** |
| odd q, all widths | 43/5863 wrong | 43/5863 |
| **total** | **1569/12000** | **59/12000** |

(seeds 999 and 31337 give 1533→67 and 1523→69.) On main ~98% of the even-modulus failures
differ from the true value by an *exact multiple of q* — the signature of the missing
conditional subtraction. The residual 192-bit failures (even *and* odd) are PR #167's
`SQR_LOHI192` dropped carry; see the combination table below.

### 2. End-to-end, keyed to random primes

Per bit-length, 200 random primes `q`; test A = `twopmmodq_W(q-1, q)` must be 1 (Fermat's
little theorem, odd modulus); test B = `twopmmodq_W(8540000, q-1)` vs `pow(2,8540000,q-1)`
(even modulus — the shape used at `Mlucas.c:5287/5292/5297`):

| q bits | test | main | +this fix | +#167 only | +both |
|---|---|---|---|---|---|
| 66..128 (W=128) | B | 59-71/200 | **0/200** | 59-71/200 | **0/200** |
| 130,150,170 (W=192) | B | 61-76/200 | **0/200** | 61-76/200 | **0/200** |
| 185 / 191 / 192 (W=192) | B | 73 / 132 / 152 | 1 / 77 / 114 | 73 / 77 / 75 | **0 / 0 / 0** |
| 185 / 191 / 192 (W=192) | A | 38 / 200 / 200 | 38 / 200 / 200 | **0 / 0 / 0** | **0 / 0 / 0** |
| 200..256 (W=256) | B | 59-68/200 | **0/200** | 59-68/200 | **0/200** |

Note the middle rows: **#167 alone leaves every even-modulus failure in place, and this patch
alone leaves the 192-bit ones in place.** The two bugs are independent and both are needed.

### 3. Replica of the issue-#32 check, built from production code

`t2.c` reproduces `src/Mlucas.c:5280-5306` verbatim — the real `twopmmodq128/192/256`, the real
`mi64_scalar_modpow_lr`, the real `mi64_getlen`/`mi64_cmp_eq` comparison — with `nsquares =
8540000` and, as the "A" side, the independently-computed `3^(2^nsquares mod (q-1)) mod q`.
100 random prime known factors at each of 12 bit-lengths:

| build | spurious `Full-residue == 3^nsquares (mod q)` failures |
|---|---|
| upstream/main | **176/1200** — 25@128b, 3@185b, 47@191b, 78@192b, 23@256b |
| + this fix | 105/1200 — 3@185b, 40@191b, 62@192b (128b and 256b gone) |
| + this fix + #167 | 0/1200 |
| + this fix + #167 + #142 + #168 | **0/1200** |

Single-case witness for this patch: `q = 213436717037110123892305130799299763299` (prime, 128
bits), `nsquares = 8540000`. On main the check computes
`B = 129651509694665431084661069185007554462` and aborts; with the fix it computes the correct
`58371858236198304794354307346003388915` and passes.

Why the firings are confined to factors of *exactly* 128/192/256 bits: the stale threshold adds
a surplus multiple of `(q-1)` to the exponent, and `base^(E + (q-1)) == base^E (mod q)` by
Fermat's little theorem — so the error is *absorbed* and the check still passes, **unless**
`E + (q-1)` overflows the `uint128`/`uint192`/`uint256` return value, which requires
`q-1 > 2^127 / 2^191 / 2^255`. That matches the measured distribution exactly (0/100 at 127
bits, 25/100 at 128 bits).

### 4. Build / self-test

* Full clean `bash makemake.sh avx2`, no new warnings; `obj_avx2/Mlucas -s tt` residues
  unchanged from main: `13K=E3BC90B0E652C7C0`, `14K=DB8E39C67F8CCA0A`, `15K=B3C5A1C03E26BB17`.
  (The 1K/2K "excessive roundoff" notices are the known pre-existing ones, #101/#104.)
* The routines touched here have no callers in Mfactor — the only in-tree callers are
  `Mlucas.c:5287/5292/5297` and `Mlucas.c:6394` — but the Mfactor `test_fac()` startup
  self-test was run anyway, and reports *"Factoring self-tests completed successfully"* in the
  1-, 2-, 3- and 4-word builds. That required PRs #193 and #82 to be merged in, because
  **Mfactor does not build on current main with a modern GCC**: `1word`/`4word` die on
  `implicit declaration of twopmodq100_2WORD_DOUBLE_q4` (factor.c:3585) and `2word`/`3word` on
  `#error P2WORD may not be used together with USE_FMADD` — both reproduced on unmodified
  `main`, so pre-existing.
* Not tested: AVX-512 (no hardware here), Windows, ARM, non-GCC. The change is portable C in a
  scalar routine with no SIMD or asm involvement.

## Relationship to issue #32 — honest assessment

**I did not reproduce the specific failure reported in #32, and this patch does not explain it.**
The reporter's assignment is
`PRP=...,1,2,8546743,-1,99,0,3,5,"209104614239,2707424768671102639169"`, and the assertion
fires on the **first** factor, `209104614239` — 38 bits, so `j == 1` and the exponent is
computed by `twopmmodq64()`, which has the correct `qhalf` ordering and is not touched here.
I re-verified both reported factors genuinely divide `2^8546743-1`, so #168's bogus-factor path
does not explain that report either, and the earlier analysis in the issue thread (the check's
`B` side was mathematically correct, so the savefile residue was the corrupt one — an
`-flto=auto` ARM build, the #10/#24 class) still looks like the right diagnosis for it.

What this patch *does* establish is that **#32's assertion has at least three distinct
mechanisms**, and it would be useful for the maintainers to treat the issue that way rather
than looking for one root cause:

1. **This bug** — stale `qhalf` for the even modulus `q-1`. Fires on any PRP-CF run whose known
   factor is exactly 128, 192 or 256 bits: 25/100 of random 128-bit prime factors and 23/100 of
   random 256-bit ones, measured with production code in §3 above. Below those thresholds the
   error is real but silently absorbed by FLT.
2. **PR #167's `SQR_LOHI192`** — fires for known factors of roughly 185..192 bits
   (78/100 at 192 bits), reachable from the *default* Mlucas binary via `Mlucas.c:5292`.
3. **PR #168's unvalidated known factors** — a bogus 2nd/3rd factor in a worktodo entry, which
   ends up as a permanent crash loop on this same assertion. That one is user data, not
   arithmetic.

Deliberately **not** claiming `Resolves #32`: the complete fix set for the arithmetic half of
#32 appears to be **this PR + #167** (0/1200 with both, 176/1200 on main), with #168 covering
the data-validation half, but the one report we have in hand is none of the three.

## Other defects found while testing, filed separately, not fixed here

* **Small exponents near the routine width.** For `p` within 64 of the width — `p in [129,192]`
  for `twopmmodq128`, and the corresponding ranges for the 192-/256-bit versions — the
  "leftmost 8 bits of `p - width`" extraction yields `leadb != pshift` and `start_index`
  underflows (`uint32`), so the powering loop executes zero iterations and the routine returns
  its seed. `twopmmodq64()` has the identical defect for `p in [65,128]`. Reachable if a
  savefile is read at a very small iteration count.
* **`MULH128`'s dropped carry** (`imul_macro1.h:4771`/`:4774`, the `__w3 += (__w2 < __b);`
  idiom). `twopmmodq128` returns a wrong result *deterministically* whenever its Montgomery
  loop reaches `x == 1` — e.g. `p = q-1` for prime `q` just above `2^64`, where it returns 0
  instead of 1 (34/236 of random 65-bit primes). A Python model of the macro bodies reproduces
  the exact wrong value, and patching only `MULH128`'s carry test in that model fixes it. This
  is a concrete reachability witness for a defect previously believed to need a 1-in-2^64
  operand coincidence.

