### PR TITLE
imul_macro1.h: propagate the dropped word-2 carry in the 128-bit SQR/MUL/MULH macros (twopmmodq128 returns 0 instead of 1)

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -2368,18 +2368,19 @@ for the 127-bit version.
 
     #define SQR_LOHI128(__x, __lo, __hi)\
     {\
-		uint64 __w0,__w1,__w2,__w3,__a,__b;\
+		uint64 __w0,__w1,__w2,__w3,__a,__b,__cy2,__cy3;\
 		\
 		SQR_LOHI64(__x.d0,       &__w0,&__w1);\
 		MUL_LOHI64(__x.d0,__x.d1,&__a ,&__b );\
 		SQR_LOHI64(__x.d1,       &__w2,&__w3);\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
+		__w1 += __a;	__cy2  = (__w1 < __a);\
+		__w2 += __b;	__cy3  = (__w2 < __b);\
+		__w1 += __a;	__cy2 += (__w1 < __a);\
+		__w2 += __b;	__cy3 += (__w2 < __b);\
+		/* Now process carries: */\
+		__w2 += __cy2;	__cy3 += (__w2 < __cy2);\
+		__w3 += __cy3;\
 		/* Now split the result between __lo and __hi: */\
 		__lo.d0 =  __w0;	__lo.d1 = __w1;\
 		__hi.d0 =  __w2;	__hi.d1 = __w3;\
@@ -2387,15 +2388,17 @@ for the 127-bit version.
 
     #define SQR_LOHI127(__x, __lo, __hi)\
     {\
-		uint64 __w0,__w1,__w2,__w3,__a,__b;\
+		uint64 __w0,__w1,__w2,__w3,__a,__b,__cy2,__cy3;\
 		\
 		SQR_LOHI64(__x.d0,            &__w0,&__w1);\
 		MUL_LOHI64(__x.d0,__x.d1 << 1,&__a ,&__b );\
 		SQR_LOHI64(__x.d1,            &__w2,&__w3);\
 		/* __a + 2^64*__b now stores 2*a*b, so only need to add once: */\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
+		__w1 += __a;	__cy2  = (__w1 < __a);\
+		__w2 += __b;	__cy3  = (__w2 < __b);\
+		/* Now process carries: */\
+		__w2 += __cy2;	__cy3 += (__w2 < __cy2);\
+		__w3 += __cy3;\
 		/* Now split the result between __lo and __hi: */\
 		__lo.d0 =  __w0;	__lo.d1 = __w1;\
 		__hi.d0 =  __w2;	__hi.d1 = __w3;\
@@ -2471,18 +2474,19 @@ for the 127-bit version.
 
     #define SQR_LOHI128(__x, __lo, __hi)\
     {\
-		uint64 __w0,__w1,__w2,__w3,__a,__b;\
+		uint64 __w0,__w1,__w2,__w3,__a,__b,__cy2,__cy3;\
 		\
 		SQR_LOHI64(__x.d0,        __w0, __w1);\
 		MUL_LOHI64(__x.d0,__x.d1, __a , __b );\
 		SQR_LOHI64(__x.d1,        __w2, __w3);\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
+		__w1 += __a;	__cy2  = (__w1 < __a);\
+		__w2 += __b;	__cy3  = (__w2 < __b);\
+		__w1 += __a;	__cy2 += (__w1 < __a);\
+		__w2 += __b;	__cy3 += (__w2 < __b);\
+		/* Now process carries: */\
+		__w2 += __cy2;	__cy3 += (__w2 < __cy2);\
+		__w3 += __cy3;\
 		/* Now split the result between __lo and __hi: */\
 		__lo.d0 =  __w0;	__lo.d1 = __w1;\
 		__hi.d0 =  __w2;	__hi.d1 = __w3;\
@@ -2504,15 +2508,17 @@ for the 127-bit version.
   #else
     #define SQR_LOHI127(__x, __lo, __hi)\
     {\
-		uint64 __w0,__w1,__w2,__w3,__a,__b;\
+		uint64 __w0,__w1,__w2,__w3,__a,__b,__cy2,__cy3;\
 		\
 		SQR_LOHI64(__x.d0,             __w0, __w1);\
 		MUL_LOHI64(__x.d0,__x.d1 << 1, __a , __b );\
 		SQR_LOHI64(__x.d1,             __w2, __w3);\
 		/* __a + 2^64*__b now stores 2*a*b, so only need to add once: */\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
+		__w1 += __a;	__cy2  = (__w1 < __a);\
+		__w2 += __b;	__cy3  = (__w2 < __b);\
+		/* Now process carries: */\
+		__w2 += __cy2;	__cy3 += (__w2 < __cy2);\
+		__w3 += __cy3;\
 		/* Now split the result between __lo and __hi: */\
 		__lo.d0 =  __w0;	__lo.d1 = __w1;\
 		__hi.d0 =  __w2;	__hi.d1 = __w3;\
@@ -2583,7 +2589,9 @@ for the 127-bit version.
 				__wa0,__wa1,__wa2,__wa3,\
 				__wb0,__wb1,__wb2,__wb3,\
 				__wc0,__wc1,__wc2,__wc3,\
-				__wd0,__wd1,__wd2,__wd3;\
+				__wd0,__wd1,__wd2,__wd3,\
+				__cy0,__cy1,__cy2,__cy3,\
+				__cz0,__cz1,__cz2,__cz3;\
 		\
 		SQR_LOHI64(__x0.d0,        __wa0, __wb0);\
 		SQR_LOHI64(__x1.d0,        __wa1, __wb1);\
@@ -2601,10 +2609,10 @@ for the 127-bit version.
 		SQR_LOHI64(__x3.d1,        __wc3, __wd3);\
 		\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__wb0 += __a0; __wc0 += __b0 + (__wb0 < __a0); __wd0 += (__wc0 < __b0); __wb0 += __a0; __wc0 += __b0 + (__wb0 < __a0); __wd0 += (__wc0 < __b0);\
-		__wb1 += __a1; __wc1 += __b1 + (__wb1 < __a1); __wd1 += (__wc1 < __b1); __wb1 += __a1; __wc1 += __b1 + (__wb1 < __a1); __wd1 += (__wc1 < __b1);\
-		__wb2 += __a2; __wc2 += __b2 + (__wb2 < __a2); __wd2 += (__wc2 < __b2); __wb2 += __a2; __wc2 += __b2 + (__wb2 < __a2); __wd2 += (__wc2 < __b2);\
-		__wb3 += __a3; __wc3 += __b3 + (__wb3 < __a3); __wd3 += (__wc3 < __b3); __wb3 += __a3; __wc3 += __b3 + (__wb3 < __a3); __wd3 += (__wc3 < __b3);\
+		__wb0 += __a0; __cy0  = (__wb0 < __a0); __wc0 += __b0; __cz0  = (__wc0 < __b0); __wb0 += __a0; __cy0 += (__wb0 < __a0); __wc0 += __b0; __cz0 += (__wc0 < __b0); __wc0 += __cy0; __cz0 += (__wc0 < __cy0); __wd0 += __cz0;\
+		__wb1 += __a1; __cy1  = (__wb1 < __a1); __wc1 += __b1; __cz1  = (__wc1 < __b1); __wb1 += __a1; __cy1 += (__wb1 < __a1); __wc1 += __b1; __cz1 += (__wc1 < __b1); __wc1 += __cy1; __cz1 += (__wc1 < __cy1); __wd1 += __cz1;\
+		__wb2 += __a2; __cy2  = (__wb2 < __a2); __wc2 += __b2; __cz2  = (__wc2 < __b2); __wb2 += __a2; __cy2 += (__wb2 < __a2); __wc2 += __b2; __cz2 += (__wc2 < __b2); __wc2 += __cy2; __cz2 += (__wc2 < __cy2); __wd2 += __cz2;\
+		__wb3 += __a3; __cy3  = (__wb3 < __a3); __wc3 += __b3; __cz3  = (__wc3 < __b3); __wb3 += __a3; __cy3 += (__wb3 < __a3); __wc3 += __b3; __cz3 += (__wc3 < __b3); __wc3 += __cy3; __cz3 += (__wc3 < __cy3); __wd3 += __cz3;\
 		\
 		/* Now split the result between __lo and __hi: */\
 		__lo0.d0 = __wa0;	__lo0.d1 = __wb0;	__hi0.d0 =  __wc0;	__hi0.d1 = __wd0;\
@@ -2660,7 +2668,9 @@ for the 127-bit version.
 		uint64	__a0,__a1,__a2,__a3,\
 				__b0,__b1,__b2,__b3,\
 				__s0,__s1,__s2,__s3,\
-				__t0,__t1,__t2,__t3;\
+				__t0,__t1,__t2,__t3,\
+				__cy0,__cy1,__cy2,__cy3,\
+				__cz0,__cz1,__cz2,__cz3;\
 		\
 		SQR_LOHI64(__x0.d0,                   __a0 ,     __b0 );\
 		SQR_LOHI64(__x1.d0,                   __a1 ,     __b1 );\
@@ -2683,10 +2693,10 @@ for the 127-bit version.
 		SQR_LOHI64(__x3.d1,               __hi3.d0 , __hi3.d1 );\
 		\
 		/* __a + 2^64*__b now stores 2*a*b, so only need to add once: */\
-		__lo0.d1 = __b0 + __s0;	__hi0.d0 += __t0 + (__lo0.d1 < __b0);	__hi0.d1 += (__hi0.d0 < __t0);\
-		__lo1.d1 = __b1 + __s1;	__hi1.d0 += __t1 + (__lo1.d1 < __b1);	__hi1.d1 += (__hi1.d0 < __t1);\
-		__lo2.d1 = __b2 + __s2;	__hi2.d0 += __t2 + (__lo2.d1 < __b2);	__hi2.d1 += (__hi2.d0 < __t2);\
-		__lo3.d1 = __b3 + __s3;	__hi3.d0 += __t3 + (__lo3.d1 < __b3);	__hi3.d1 += (__hi3.d0 < __t3);\
+		__lo0.d1 = __b0 + __s0;	__cy0  = (__lo0.d1 < __b0);	__hi0.d0 += __t0;	__cz0  = (__hi0.d0 < __t0);	__hi0.d0 += __cy0;	__cz0 += (__hi0.d0 < __cy0);	__hi0.d1 += __cz0;\
+		__lo1.d1 = __b1 + __s1;	__cy1  = (__lo1.d1 < __b1);	__hi1.d0 += __t1;	__cz1  = (__hi1.d0 < __t1);	__hi1.d0 += __cy1;	__cz1 += (__hi1.d0 < __cy1);	__hi1.d1 += __cz1;\
+		__lo2.d1 = __b2 + __s2;	__cy2  = (__lo2.d1 < __b2);	__hi2.d0 += __t2;	__cz2  = (__hi2.d0 < __t2);	__hi2.d0 += __cy2;	__cz2 += (__hi2.d0 < __cy2);	__hi2.d1 += __cz2;\
+		__lo3.d1 = __b3 + __s3;	__cy3  = (__lo3.d1 < __b3);	__hi3.d0 += __t3;	__cz3  = (__hi3.d0 < __t3);	__hi3.d0 += __cy3;	__cz3 += (__hi3.d0 < __cy3);	__hi3.d1 += __cz3;\
     }
   #endif	/* #endif(ia64) */
 
@@ -2786,7 +2796,9 @@ for the 127-bit version.
 				__wa0,__wa1,__wa2,__wa3,__wa4,__wa5,__wa6,__wa7,\
 				__wb0,__wb1,__wb2,__wb3,__wb4,__wb5,__wb6,__wb7,\
 				__wc0,__wc1,__wc2,__wc3,__wc4,__wc5,__wc6,__wc7,\
-				__wd0,__wd1,__wd2,__wd3,__wd4,__wd5,__wd6,__wd7;\
+				__wd0,__wd1,__wd2,__wd3,__wd4,__wd5,__wd6,__wd7,\
+				__cy0,__cy1,__cy2,__cy3,__cy4,__cy5,__cy6,__cy7,\
+				__cz0,__cz1,__cz2,__cz3,__cz4,__cz5,__cz6,__cz7;\
 		\
 		SQR_LOHI64(__x0.d0,        __wa0, __wb0);\
 		SQR_LOHI64(__x1.d0,        __wa1, __wb1);\
@@ -2816,14 +2828,14 @@ for the 127-bit version.
 		SQR_LOHI64(__x7.d1,        __wc7, __wd7);\
 		\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__wb0 += __a0; __wc0 += __b0 + (__wb0 < __a0); __wd0 += (__wc0 < __b0); __wb0 += __a0; __wc0 += __b0 + (__wb0 < __a0); __wd0 += (__wc0 < __b0);\
-		__wb1 += __a1; __wc1 += __b1 + (__wb1 < __a1); __wd1 += (__wc1 < __b1); __wb1 += __a1; __wc1 += __b1 + (__wb1 < __a1); __wd1 += (__wc1 < __b1);\
-		__wb2 += __a2; __wc2 += __b2 + (__wb2 < __a2); __wd2 += (__wc2 < __b2); __wb2 += __a2; __wc2 += __b2 + (__wb2 < __a2); __wd2 += (__wc2 < __b2);\
-		__wb3 += __a3; __wc3 += __b3 + (__wb3 < __a3); __wd3 += (__wc3 < __b3); __wb3 += __a3; __wc3 += __b3 + (__wb3 < __a3); __wd3 += (__wc3 < __b3);\
-		__wb4 += __a4; __wc4 += __b4 + (__wb4 < __a4); __wd4 += (__wc4 < __b4); __wb4 += __a4; __wc4 += __b4 + (__wb4 < __a4); __wd4 += (__wc4 < __b4);\
-		__wb5 += __a5; __wc5 += __b5 + (__wb5 < __a5); __wd5 += (__wc5 < __b5); __wb5 += __a5; __wc5 += __b5 + (__wb5 < __a5); __wd5 += (__wc5 < __b5);\
-		__wb6 += __a6; __wc6 += __b6 + (__wb6 < __a6); __wd6 += (__wc6 < __b6); __wb6 += __a6; __wc6 += __b6 + (__wb6 < __a6); __wd6 += (__wc6 < __b6);\
-		__wb7 += __a7; __wc7 += __b7 + (__wb7 < __a7); __wd7 += (__wc7 < __b7); __wb7 += __a7; __wc7 += __b7 + (__wb7 < __a7); __wd7 += (__wc7 < __b7);\
+		__wb0 += __a0; __cy0  = (__wb0 < __a0); __wc0 += __b0; __cz0  = (__wc0 < __b0); __wb0 += __a0; __cy0 += (__wb0 < __a0); __wc0 += __b0; __cz0 += (__wc0 < __b0); __wc0 += __cy0; __cz0 += (__wc0 < __cy0); __wd0 += __cz0;\
+		__wb1 += __a1; __cy1  = (__wb1 < __a1); __wc1 += __b1; __cz1  = (__wc1 < __b1); __wb1 += __a1; __cy1 += (__wb1 < __a1); __wc1 += __b1; __cz1 += (__wc1 < __b1); __wc1 += __cy1; __cz1 += (__wc1 < __cy1); __wd1 += __cz1;\
+		__wb2 += __a2; __cy2  = (__wb2 < __a2); __wc2 += __b2; __cz2  = (__wc2 < __b2); __wb2 += __a2; __cy2 += (__wb2 < __a2); __wc2 += __b2; __cz2 += (__wc2 < __b2); __wc2 += __cy2; __cz2 += (__wc2 < __cy2); __wd2 += __cz2;\
+		__wb3 += __a3; __cy3  = (__wb3 < __a3); __wc3 += __b3; __cz3  = (__wc3 < __b3); __wb3 += __a3; __cy3 += (__wb3 < __a3); __wc3 += __b3; __cz3 += (__wc3 < __b3); __wc3 += __cy3; __cz3 += (__wc3 < __cy3); __wd3 += __cz3;\
+		__wb4 += __a4; __cy4  = (__wb4 < __a4); __wc4 += __b4; __cz4  = (__wc4 < __b4); __wb4 += __a4; __cy4 += (__wb4 < __a4); __wc4 += __b4; __cz4 += (__wc4 < __b4); __wc4 += __cy4; __cz4 += (__wc4 < __cy4); __wd4 += __cz4;\
+		__wb5 += __a5; __cy5  = (__wb5 < __a5); __wc5 += __b5; __cz5  = (__wc5 < __b5); __wb5 += __a5; __cy5 += (__wb5 < __a5); __wc5 += __b5; __cz5 += (__wc5 < __b5); __wc5 += __cy5; __cz5 += (__wc5 < __cy5); __wd5 += __cz5;\
+		__wb6 += __a6; __cy6  = (__wb6 < __a6); __wc6 += __b6; __cz6  = (__wc6 < __b6); __wb6 += __a6; __cy6 += (__wb6 < __a6); __wc6 += __b6; __cz6 += (__wc6 < __b6); __wc6 += __cy6; __cz6 += (__wc6 < __cy6); __wd6 += __cz6;\
+		__wb7 += __a7; __cy7  = (__wb7 < __a7); __wc7 += __b7; __cz7  = (__wc7 < __b7); __wb7 += __a7; __cy7 += (__wb7 < __a7); __wc7 += __b7; __cz7 += (__wc7 < __b7); __wc7 += __cy7; __cz7 += (__wc7 < __cy7); __wd7 += __cz7;\
 		\
 		/* Now split the result between __lo and __hi: */\
 		__lo0.d0 = __wa0;	__lo0.d1 = __wb0;	__hi0.d0 =  __wc0;	__hi0.d1 = __wd0;\
@@ -2911,7 +2923,9 @@ for the 127-bit version.
 		uint64	__a0,__a1,__a2,__a3,__a4,__a5,__a6,__a7,\
 				__b0,__b1,__b2,__b3,__b4,__b5,__b6,__b7,\
 				__s0,__s1,__s2,__s3,__s4,__s5,__s6,__s7,\
-				__t0,__t1,__t2,__t3,__t4,__t5,__t6,__t7;\
+				__t0,__t1,__t2,__t3,__t4,__t5,__t6,__t7,\
+				__cy0,__cy1,__cy2,__cy3,__cy4,__cy5,__cy6,__cy7,\
+				__cz0,__cz1,__cz2,__cz3,__cz4,__cz5,__cz6,__cz7;\
 		\
 		SQR_LOHI64(__x0.d0,                   __a0 ,     __b0 );\
 		SQR_LOHI64(__x1.d0,                   __a1 ,     __b1 );\
@@ -2950,14 +2964,14 @@ for the 127-bit version.
 		SQR_LOHI64(__x7.d1,               __hi7.d0 , __hi7.d1 );\
 		\
 		/* __a + 2^64*__b now stores 2*a*b, so only need to add once: */\
-		__lo0.d1 = __b0 + __s0;	__hi0.d0 += __t0 + (__lo0.d1 < __b0);	__hi0.d1 += (__hi0.d0 < __t0);\
-		__lo1.d1 = __b1 + __s1;	__hi1.d0 += __t1 + (__lo1.d1 < __b1);	__hi1.d1 += (__hi1.d0 < __t1);\
-		__lo2.d1 = __b2 + __s2;	__hi2.d0 += __t2 + (__lo2.d1 < __b2);	__hi2.d1 += (__hi2.d0 < __t2);\
-		__lo3.d1 = __b3 + __s3;	__hi3.d0 += __t3 + (__lo3.d1 < __b3);	__hi3.d1 += (__hi3.d0 < __t3);\
-		__lo4.d1 = __b4 + __s4;	__hi4.d0 += __t4 + (__lo4.d1 < __b4);	__hi4.d1 += (__hi4.d0 < __t4);\
-		__lo5.d1 = __b5 + __s5;	__hi5.d0 += __t5 + (__lo5.d1 < __b5);	__hi5.d1 += (__hi5.d0 < __t5);\
-		__lo6.d1 = __b6 + __s6;	__hi6.d0 += __t6 + (__lo6.d1 < __b6);	__hi6.d1 += (__hi6.d0 < __t6);\
-		__lo7.d1 = __b7 + __s7;	__hi7.d0 += __t7 + (__lo7.d1 < __b7);	__hi7.d1 += (__hi7.d0 < __t7);\
+		__lo0.d1 = __b0 + __s0;	__cy0  = (__lo0.d1 < __b0);	__hi0.d0 += __t0;	__cz0  = (__hi0.d0 < __t0);	__hi0.d0 += __cy0;	__cz0 += (__hi0.d0 < __cy0);	__hi0.d1 += __cz0;\
+		__lo1.d1 = __b1 + __s1;	__cy1  = (__lo1.d1 < __b1);	__hi1.d0 += __t1;	__cz1  = (__hi1.d0 < __t1);	__hi1.d0 += __cy1;	__cz1 += (__hi1.d0 < __cy1);	__hi1.d1 += __cz1;\
+		__lo2.d1 = __b2 + __s2;	__cy2  = (__lo2.d1 < __b2);	__hi2.d0 += __t2;	__cz2  = (__hi2.d0 < __t2);	__hi2.d0 += __cy2;	__cz2 += (__hi2.d0 < __cy2);	__hi2.d1 += __cz2;\
+		__lo3.d1 = __b3 + __s3;	__cy3  = (__lo3.d1 < __b3);	__hi3.d0 += __t3;	__cz3  = (__hi3.d0 < __t3);	__hi3.d0 += __cy3;	__cz3 += (__hi3.d0 < __cy3);	__hi3.d1 += __cz3;\
+		__lo4.d1 = __b4 + __s4;	__cy4  = (__lo4.d1 < __b4);	__hi4.d0 += __t4;	__cz4  = (__hi4.d0 < __t4);	__hi4.d0 += __cy4;	__cz4 += (__hi4.d0 < __cy4);	__hi4.d1 += __cz4;\
+		__lo5.d1 = __b5 + __s5;	__cy5  = (__lo5.d1 < __b5);	__hi5.d0 += __t5;	__cz5  = (__hi5.d0 < __t5);	__hi5.d0 += __cy5;	__cz5 += (__hi5.d0 < __cy5);	__hi5.d1 += __cz5;\
+		__lo6.d1 = __b6 + __s6;	__cy6  = (__lo6.d1 < __b6);	__hi6.d0 += __t6;	__cz6  = (__hi6.d0 < __t6);	__hi6.d0 += __cy6;	__cz6 += (__hi6.d0 < __cy6);	__hi6.d1 += __cz6;\
+		__lo7.d1 = __b7 + __s7;	__cy7  = (__lo7.d1 < __b7);	__hi7.d0 += __t7;	__cz7  = (__hi7.d0 < __t7);	__hi7.d0 += __cy7;	__cz7 += (__hi7.d0 < __cy7);	__hi7.d1 += __cz7;\
     }
   #endif	/* #endif(ia64) */
 
@@ -3980,18 +3994,19 @@ On Alpha, this needs a total of 8 MUL instructions.
 
     #define MUL_LOHI128(__x, __y, __lo, __hi)\
     {\
-		uint64 __w0,__w1,__w2,__w3,__a,__b,__c,__d;\
+		uint64 __w0,__w1,__w2,__w3,__a,__b,__c,__d,__cy2,__cy3;\
 		\
 		MUL_LOHI64(__x.d0,__y.d0,&__w0,&__w1);\
 		MUL_LOHI64(__x.d0,__y.d1,&__a ,&__b );\
 		MUL_LOHI64(__y.d0,__x.d1,&__c ,&__d );\
 		MUL_LOHI64(__x.d1,__y.d1,&__w2,&__w3);\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
-		__w1 += __c;\
-		__w2 += __d + (__w1 < __c); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __d); /* Overflow into word3 is checked here. */\
+		__w1 += __a;	__cy2  = (__w1 < __a);\
+		__w2 += __b;	__cy3  = (__w2 < __b);\
+		__w1 += __c;	__cy2 += (__w1 < __c);\
+		__w2 += __d;	__cy3 += (__w2 < __d);\
+		/* Now process carries: */\
+		__w2 += __cy2;	__cy3 += (__w2 < __cy2);\
+		__w3 += __cy3;\
 		/* Now store the result: */\
 		__lo.d0 =  __w0;	__lo.d1 = __w1;\
 		__hi.d0 =  __w2;	__hi.d1 = __w3;\
@@ -4001,18 +4016,19 @@ On Alpha, this needs a total of 8 MUL instructions.
 
     #define MUL_LOHI128(__x, __y, __lo, __hi)\
     {\
-		uint64 __w0,__w1,__w2,__w3,__a,__b,__c,__d;\
+		uint64 __w0,__w1,__w2,__w3,__a,__b,__c,__d,__cy2,__cy3;\
 		\
 		MUL_LOHI64(__x.d0,__y.d0, __w0, __w1);\
 		MUL_LOHI64(__x.d0,__y.d1, __a , __b );\
 		MUL_LOHI64(__y.d0,__x.d1, __c , __d );\
 		MUL_LOHI64(__x.d1,__y.d1, __w2, __w3);\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
-		__w1 += __c;\
-		__w2 += __d + (__w1 < __c); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __d); /* Overflow into word3 is checked here. */\
+		__w1 += __a;	__cy2  = (__w1 < __a);\
+		__w2 += __b;	__cy3  = (__w2 < __b);\
+		__w1 += __c;	__cy2 += (__w1 < __c);\
+		__w2 += __d;	__cy3 += (__w2 < __d);\
+		/* Now process carries: */\
+		__w2 += __cy2;	__cy3 += (__w2 < __cy2);\
+		__w3 += __cy3;\
 		/* Now store the result: */\
 		/* Now store the result: */\
 		__lo.d0 =  __w0;	__lo.d1 = __w1;\
@@ -4417,10 +4433,10 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
     , __x2, __qinv2, __q2, __lo2, __hi2\
     , __x3, __qinv3, __q3, __lo3, __hi3)\
     {\
-		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0;\
-		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1;\
-		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2;\
-		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3;\
+		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0,__cz0;\
+		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1,__cz1;\
+		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2,__cz2;\
+		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3,__cz3;\
 		\
 		/* SQR_LOHI128(x,lo,hi) IS HERE: */\
 		SQR_LOHI64(__x0.d0,        &__wa0,&__wb0);\
@@ -4439,10 +4455,10 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 		SQR_LOHI64(__x3.d1,        &__wc3,&__wd3);\
 		\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);	__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);\
-		__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);	__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);\
-		__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);	__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);\
-		__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);	__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);\
+		__wb0 += __a0;	__cy0  = (__wb0 < __a0);	__wc0 += __b0;	__cz0  = (__wc0 < __b0);	__wb0 += __a0;	__cy0 += (__wb0 < __a0);	__wc0 += __b0;	__cz0 += (__wc0 < __b0);	__wc0 += __cy0;	__cz0 += (__wc0 < __cy0);	__wd0 += __cz0;\
+		__wb1 += __a1;	__cy1  = (__wb1 < __a1);	__wc1 += __b1;	__cz1  = (__wc1 < __b1);	__wb1 += __a1;	__cy1 += (__wb1 < __a1);	__wc1 += __b1;	__cz1 += (__wc1 < __b1);	__wc1 += __cy1;	__cz1 += (__wc1 < __cy1);	__wd1 += __cz1;\
+		__wb2 += __a2;	__cy2  = (__wb2 < __a2);	__wc2 += __b2;	__cz2  = (__wc2 < __b2);	__wb2 += __a2;	__cy2 += (__wb2 < __a2);	__wc2 += __b2;	__cz2 += (__wc2 < __b2);	__wc2 += __cy2;	__cz2 += (__wc2 < __cy2);	__wd2 += __cz2;\
+		__wb3 += __a3;	__cy3  = (__wb3 < __a3);	__wc3 += __b3;	__cz3  = (__wc3 < __b3);	__wb3 += __a3;	__cy3 += (__wb3 < __a3);	__wc3 += __b3;	__cz3 += (__wc3 < __b3);	__wc3 += __cy3;	__cz3 += (__wc3 < __cy3);	__wd3 += __cz3;\
 		\
 		/* Now store the high 128 bits of the result in __hi: */\
 		__hi0.d0 =  __wc0;	__hi0.d1 = __wd0;\
@@ -4548,14 +4564,14 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
     , __x6, __qinv6, __q6, __lo6, __hi6\
     , __x7, __qinv7, __q7, __lo7, __hi7)\
     {\
-		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0;\
-		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1;\
-		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2;\
-		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3;\
-		uint64	__a4,__b4,__t4,__wa4,__wb4,__wc4,__wd4,__cy4;\
-		uint64	__a5,__b5,__t5,__wa5,__wb5,__wc5,__wd5,__cy5;\
-		uint64	__a6,__b6,__t6,__wa6,__wb6,__wc6,__wd6,__cy6;\
-		uint64	__a7,__b7,__t7,__wa7,__wb7,__wc7,__wd7,__cy7;\
+		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0,__cz0;\
+		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1,__cz1;\
+		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2,__cz2;\
+		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3,__cz3;\
+		uint64	__a4,__b4,__t4,__wa4,__wb4,__wc4,__wd4,__cy4,__cz4;\
+		uint64	__a5,__b5,__t5,__wa5,__wb5,__wc5,__wd5,__cy5,__cz5;\
+		uint64	__a6,__b6,__t6,__wa6,__wb6,__wc6,__wd6,__cy6,__cz6;\
+		uint64	__a7,__b7,__t7,__wa7,__wb7,__wc7,__wd7,__cy7,__cz7;\
 		\
 		/* SQR_LOHI128(x,lo,hi) IS HERE: */\
 		SQR_LOHI64(__x0.d0,        &__wa0,&__wb0);\
@@ -4586,14 +4602,14 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 		SQR_LOHI64(__x7.d1,        &__wc7,&__wd7);\
 		\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);	__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);\
-		__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);	__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);\
-		__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);	__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);\
-		__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);	__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);\
-		__wb4 += __a4;	__wc4 += __b4 + (__wb4 < __a4);	__wd4 += (__wc4 < __b4);	__wb4 += __a4;	__wc4 += __b4 + (__wb4 < __a4);	__wd4 += (__wc4 < __b4);\
-		__wb5 += __a5;	__wc5 += __b5 + (__wb5 < __a5);	__wd5 += (__wc5 < __b5);	__wb5 += __a5;	__wc5 += __b5 + (__wb5 < __a5);	__wd5 += (__wc5 < __b5);\
-		__wb6 += __a6;	__wc6 += __b6 + (__wb6 < __a6);	__wd6 += (__wc6 < __b6);	__wb6 += __a6;	__wc6 += __b6 + (__wb6 < __a6);	__wd6 += (__wc6 < __b6);\
-		__wb7 += __a7;	__wc7 += __b7 + (__wb7 < __a7);	__wd7 += (__wc7 < __b7);	__wb7 += __a7;	__wc7 += __b7 + (__wb7 < __a7);	__wd7 += (__wc7 < __b7);\
+		__wb0 += __a0;	__cy0  = (__wb0 < __a0);	__wc0 += __b0;	__cz0  = (__wc0 < __b0);	__wb0 += __a0;	__cy0 += (__wb0 < __a0);	__wc0 += __b0;	__cz0 += (__wc0 < __b0);	__wc0 += __cy0;	__cz0 += (__wc0 < __cy0);	__wd0 += __cz0;\
+		__wb1 += __a1;	__cy1  = (__wb1 < __a1);	__wc1 += __b1;	__cz1  = (__wc1 < __b1);	__wb1 += __a1;	__cy1 += (__wb1 < __a1);	__wc1 += __b1;	__cz1 += (__wc1 < __b1);	__wc1 += __cy1;	__cz1 += (__wc1 < __cy1);	__wd1 += __cz1;\
+		__wb2 += __a2;	__cy2  = (__wb2 < __a2);	__wc2 += __b2;	__cz2  = (__wc2 < __b2);	__wb2 += __a2;	__cy2 += (__wb2 < __a2);	__wc2 += __b2;	__cz2 += (__wc2 < __b2);	__wc2 += __cy2;	__cz2 += (__wc2 < __cy2);	__wd2 += __cz2;\
+		__wb3 += __a3;	__cy3  = (__wb3 < __a3);	__wc3 += __b3;	__cz3  = (__wc3 < __b3);	__wb3 += __a3;	__cy3 += (__wb3 < __a3);	__wc3 += __b3;	__cz3 += (__wc3 < __b3);	__wc3 += __cy3;	__cz3 += (__wc3 < __cy3);	__wd3 += __cz3;\
+		__wb4 += __a4;	__cy4  = (__wb4 < __a4);	__wc4 += __b4;	__cz4  = (__wc4 < __b4);	__wb4 += __a4;	__cy4 += (__wb4 < __a4);	__wc4 += __b4;	__cz4 += (__wc4 < __b4);	__wc4 += __cy4;	__cz4 += (__wc4 < __cy4);	__wd4 += __cz4;\
+		__wb5 += __a5;	__cy5  = (__wb5 < __a5);	__wc5 += __b5;	__cz5  = (__wc5 < __b5);	__wb5 += __a5;	__cy5 += (__wb5 < __a5);	__wc5 += __b5;	__cz5 += (__wc5 < __b5);	__wc5 += __cy5;	__cz5 += (__wc5 < __cy5);	__wd5 += __cz5;\
+		__wb6 += __a6;	__cy6  = (__wb6 < __a6);	__wc6 += __b6;	__cz6  = (__wc6 < __b6);	__wb6 += __a6;	__cy6 += (__wb6 < __a6);	__wc6 += __b6;	__cz6 += (__wc6 < __b6);	__wc6 += __cy6;	__cz6 += (__wc6 < __cy6);	__wd6 += __cz6;\
+		__wb7 += __a7;	__cy7  = (__wb7 < __a7);	__wc7 += __b7;	__cz7  = (__wc7 < __b7);	__wb7 += __a7;	__cy7 += (__wb7 < __a7);	__wc7 += __b7;	__cz7 += (__wc7 < __b7);	__wc7 += __cy7;	__cz7 += (__wc7 < __cy7);	__wd7 += __cz7;\
 		\
 		/* Now store the high 128 bits of the result in __hi: */\
 		__hi0.d0 =  __wc0;	__hi0.d1 = __wd0;\
@@ -4760,18 +4776,19 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 
     #define MULH128(__x, __y, __hi)\
     {\
-		uint64 __w1,__w2,__w3,__a,__b,__c,__d;\
+		uint64 __w1,__w2,__w3,__a,__b,__c,__d,__cy2,__cy3;\
 		\
 		MULH64(__x.d0,__y.d0,       __w1);\
 		MUL_LOHI64(__x.d0,__y.d1, __a , __b );\
 		MUL_LOHI64(__y.d0,__x.d1, __c , __d );\
 		MUL_LOHI64(__x.d1,__y.d1, __w2, __w3);\
-		__w1 += __a;\
-		__w2 += __b + (__w1 < __a); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __b); /* Overflow into word3 is checked here. */\
-		__w1 += __c;\
-		__w2 += __d + (__w1 < __c); /* Overflow into word2 is checked here. */\
-		__w3 +=       (__w2 < __d); /* Overflow into word3 is checked here. */\
+		__w1 += __a;	__cy2  = (__w1 < __a);\
+		__w2 += __b;	__cy3  = (__w2 < __b);\
+		__w1 += __c;	__cy2 += (__w1 < __c);\
+		__w2 += __d;	__cy3 += (__w2 < __d);\
+		/* Now process carries: */\
+		__w2 += __cy2;	__cy3 += (__w2 < __cy2);\
+		__w3 += __cy3;\
 		__hi.d0 =  __w2;	__hi.d1 = __w3;\
     }
 
@@ -4786,7 +4803,9 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 				__b0,__b1,__b2,__b3,\
 				__c0,__c1,__c2,__c3,\
 				__d0,__d1,__d2,__d3,\
-				__t0,__t1,__t2,__t3;\
+				__t0,__t1,__t2,__t3,\
+				__cy0,__cy1,__cy2,__cy3,\
+				__cz0,__cz1,__cz2,__cz3;\
 		\
 		MULH64(__x0.d0,__y0.d0, __t0);\
 		MULH64(__x1.d0,__y1.d0, __t1);\
@@ -4808,35 +4827,36 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 		MUL_LOHI64(__x2.d1,__y2.d1, __hi2.d0, __hi2.d1);\
 		MUL_LOHI64(__x3.d1,__y3.d1, __hi3.d0, __hi3.d1);\
 		\
-		__t0 += __a0;\
-		__t1 += __a1;\
-		__t2 += __a2;\
-		__t3 += __a3;\
+		__t0 += __a0;	__cy0  = (__t0 < __a0);\
+		__t1 += __a1;	__cy1  = (__t1 < __a1);\
+		__t2 += __a2;	__cy2  = (__t2 < __a2);\
+		__t3 += __a3;	__cy3  = (__t3 < __a3);\
 		\
-		__hi0.d0 += __b0 + (__t0 < __a0);\
-		__hi1.d0 += __b1 + (__t1 < __a1);\
-		__hi2.d0 += __b2 + (__t2 < __a2);\
-		__hi3.d0 += __b3 + (__t3 < __a3);\
+		__hi0.d0 += __b0;	__cz0  = (__hi0.d0 < __b0);\
+		__hi1.d0 += __b1;	__cz1  = (__hi1.d0 < __b1);\
+		__hi2.d0 += __b2;	__cz2  = (__hi2.d0 < __b2);\
+		__hi3.d0 += __b3;	__cz3  = (__hi3.d0 < __b3);\
 		\
-		__hi0.d1 +=        (__hi0.d0 < __b0);\
-		__hi1.d1 +=        (__hi1.d0 < __b1);\
-		__hi2.d1 +=        (__hi2.d0 < __b2);\
-		__hi3.d1 +=        (__hi3.d0 < __b3);\
+		__t0 += __c0;	__cy0 += (__t0 < __c0);\
+		__t1 += __c1;	__cy1 += (__t1 < __c1);\
+		__t2 += __c2;	__cy2 += (__t2 < __c2);\
+		__t3 += __c3;	__cy3 += (__t3 < __c3);\
 		\
-		__t0 += __c0;\
-		__t1 += __c1;\
-		__t2 += __c2;\
-		__t3 += __c3;\
+		__hi0.d0 += __d0;	__cz0 += (__hi0.d0 < __d0);\
+		__hi1.d0 += __d1;	__cz1 += (__hi1.d0 < __d1);\
+		__hi2.d0 += __d2;	__cz2 += (__hi2.d0 < __d2);\
+		__hi3.d0 += __d3;	__cz3 += (__hi3.d0 < __d3);\
 		\
-		__hi0.d0 += __d0 + (__t0 < __c0);\
-		__hi1.d0 += __d1 + (__t1 < __c1);\
-		__hi2.d0 += __d2 + (__t2 < __c2);\
-		__hi3.d0 += __d3 + (__t3 < __c3);\
+		/* Now process carries: */\
+		__hi0.d0 += __cy0;	__cz0 += (__hi0.d0 < __cy0);\
+		__hi1.d0 += __cy1;	__cz1 += (__hi1.d0 < __cy1);\
+		__hi2.d0 += __cy2;	__cz2 += (__hi2.d0 < __cy2);\
+		__hi3.d0 += __cy3;	__cz3 += (__hi3.d0 < __cy3);\
 		\
-		__hi0.d1 +=        (__hi0.d0 < __d0);\
-		__hi1.d1 +=        (__hi1.d0 < __d1);\
-		__hi2.d1 +=        (__hi2.d0 < __d2);\
-		__hi3.d1 +=        (__hi3.d0 < __d3);\
+		__hi0.d1 += __cz0;\
+		__hi1.d1 += __cz1;\
+		__hi2.d1 += __cz2;\
+		__hi3.d1 += __cz3;\
     }
 
 /************* TODO: OK with y == hi, but not with x == hi! *************/
@@ -4855,7 +4875,9 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 				__b0,__b1,__b2,__b3,__b4,__b5,__b6,__b7,\
 				__c0,__c1,__c2,__c3,__c4,__c5,__c6,__c7,\
 				__d0,__d1,__d2,__d3,__d4,__d5,__d6,__d7,\
-				__t0,__t1,__t2,__t3,__t4,__t5,__t6,__t7;\
+				__t0,__t1,__t2,__t3,__t4,__t5,__t6,__t7,\
+				__cy0,__cy1,__cy2,__cy3,__cy4,__cy5,__cy6,__cy7,\
+				__cz0,__cz1,__cz2,__cz3,__cz4,__cz5,__cz6,__cz7;\
 		\
 		MULH64(__x0.d0,__y0.d0, __t0);\
 		MULH64(__x1.d0,__y1.d0, __t1);\
@@ -4893,59 +4915,60 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 		MUL_LOHI64(__x6.d1,__y6.d1, __hi6.d0, __hi6.d1);\
 		MUL_LOHI64(__x7.d1,__y7.d1, __hi7.d0, __hi7.d1);\
 		\
-		__t0 += __a0;\
-		__t1 += __a1;\
-		__t2 += __a2;\
-		__t3 += __a3;\
-		__t4 += __a4;\
-		__t5 += __a5;\
-		__t6 += __a6;\
-		__t7 += __a7;\
+		__t0 += __a0;	__cy0  = (__t0 < __a0);\
+		__t1 += __a1;	__cy1  = (__t1 < __a1);\
+		__t2 += __a2;	__cy2  = (__t2 < __a2);\
+		__t3 += __a3;	__cy3  = (__t3 < __a3);\
+		__t4 += __a4;	__cy4  = (__t4 < __a4);\
+		__t5 += __a5;	__cy5  = (__t5 < __a5);\
+		__t6 += __a6;	__cy6  = (__t6 < __a6);\
+		__t7 += __a7;	__cy7  = (__t7 < __a7);\
 		\
-		__hi0.d0 += __b0 + (__t0 < __a0);\
-		__hi1.d0 += __b1 + (__t1 < __a1);\
-		__hi2.d0 += __b2 + (__t2 < __a2);\
-		__hi3.d0 += __b3 + (__t3 < __a3);\
-		__hi4.d0 += __b4 + (__t4 < __a4);\
-		__hi5.d0 += __b5 + (__t5 < __a5);\
-		__hi6.d0 += __b6 + (__t6 < __a6);\
-		__hi7.d0 += __b7 + (__t7 < __a7);\
+		__hi0.d0 += __b0;	__cz0  = (__hi0.d0 < __b0);\
+		__hi1.d0 += __b1;	__cz1  = (__hi1.d0 < __b1);\
+		__hi2.d0 += __b2;	__cz2  = (__hi2.d0 < __b2);\
+		__hi3.d0 += __b3;	__cz3  = (__hi3.d0 < __b3);\
+		__hi4.d0 += __b4;	__cz4  = (__hi4.d0 < __b4);\
+		__hi5.d0 += __b5;	__cz5  = (__hi5.d0 < __b5);\
+		__hi6.d0 += __b6;	__cz6  = (__hi6.d0 < __b6);\
+		__hi7.d0 += __b7;	__cz7  = (__hi7.d0 < __b7);\
 		\
-		__hi0.d1 +=        (__hi0.d0 < __b0);\
-		__hi1.d1 +=        (__hi1.d0 < __b1);\
-		__hi2.d1 +=        (__hi2.d0 < __b2);\
-		__hi3.d1 +=        (__hi3.d0 < __b3);\
-		__hi4.d1 +=        (__hi4.d0 < __b4);\
-		__hi5.d1 +=        (__hi5.d0 < __b5);\
-		__hi6.d1 +=        (__hi6.d0 < __b6);\
-		__hi7.d1 +=        (__hi7.d0 < __b7);\
+		__t0 += __c0;	__cy0 += (__t0 < __c0);\
+		__t1 += __c1;	__cy1 += (__t1 < __c1);\
+		__t2 += __c2;	__cy2 += (__t2 < __c2);\
+		__t3 += __c3;	__cy3 += (__t3 < __c3);\
+		__t4 += __c4;	__cy4 += (__t4 < __c4);\
+		__t5 += __c5;	__cy5 += (__t5 < __c5);\
+		__t6 += __c6;	__cy6 += (__t6 < __c6);\
+		__t7 += __c7;	__cy7 += (__t7 < __c7);\
 		\
-		__t0 += __c0;\
-		__t1 += __c1;\
-		__t2 += __c2;\
-		__t3 += __c3;\
-		__t4 += __c4;\
-		__t5 += __c5;\
-		__t6 += __c6;\
-		__t7 += __c7;\
+		__hi0.d0 += __d0;	__cz0 += (__hi0.d0 < __d0);\
+		__hi1.d0 += __d1;	__cz1 += (__hi1.d0 < __d1);\
+		__hi2.d0 += __d2;	__cz2 += (__hi2.d0 < __d2);\
+		__hi3.d0 += __d3;	__cz3 += (__hi3.d0 < __d3);\
+		__hi4.d0 += __d4;	__cz4 += (__hi4.d0 < __d4);\
+		__hi5.d0 += __d5;	__cz5 += (__hi5.d0 < __d5);\
+		__hi6.d0 += __d6;	__cz6 += (__hi6.d0 < __d6);\
+		__hi7.d0 += __d7;	__cz7 += (__hi7.d0 < __d7);\
 		\
-		__hi0.d0 += __d0 + (__t0 < __c0);\
-		__hi1.d0 += __d1 + (__t1 < __c1);\
-		__hi2.d0 += __d2 + (__t2 < __c2);\
-		__hi3.d0 += __d3 + (__t3 < __c3);\
-		__hi4.d0 += __d4 + (__t4 < __c4);\
-		__hi5.d0 += __d5 + (__t5 < __c5);\
-		__hi6.d0 += __d6 + (__t6 < __c6);\
-		__hi7.d0 += __d7 + (__t7 < __c7);\
+		/* Now process carries: */\
+		__hi0.d0 += __cy0;	__cz0 += (__hi0.d0 < __cy0);\
+		__hi1.d0 += __cy1;	__cz1 += (__hi1.d0 < __cy1);\
+		__hi2.d0 += __cy2;	__cz2 += (__hi2.d0 < __cy2);\
+		__hi3.d0 += __cy3;	__cz3 += (__hi3.d0 < __cy3);\
+		__hi4.d0 += __cy4;	__cz4 += (__hi4.d0 < __cy4);\
+		__hi5.d0 += __cy5;	__cz5 += (__hi5.d0 < __cy5);\
+		__hi6.d0 += __cy6;	__cz6 += (__hi6.d0 < __cy6);\
+		__hi7.d0 += __cy7;	__cz7 += (__hi7.d0 < __cy7);\
 		\
-		__hi0.d1 +=        (__hi0.d0 < __d0);\
-		__hi1.d1 +=        (__hi1.d0 < __d1);\
-		__hi2.d1 +=        (__hi2.d0 < __d2);\
-		__hi3.d1 +=        (__hi3.d0 < __d3);\
-		__hi4.d1 +=        (__hi4.d0 < __d4);\
-		__hi5.d1 +=        (__hi5.d0 < __d5);\
-		__hi6.d1 +=        (__hi6.d0 < __d6);\
-		__hi7.d1 +=        (__hi7.d0 < __d7);\
+		__hi0.d1 += __cz0;\
+		__hi1.d1 += __cz1;\
+		__hi2.d1 += __cz2;\
+		__hi3.d1 += __cz3;\
+		__hi4.d1 += __cz4;\
+		__hi5.d1 += __cz5;\
+		__hi6.d1 += __cz6;\
+		__hi7.d1 += __cz7;\
     }
 
 /* Routine to perform fused version of key 3-operation sequence in 128-bit modmul:
@@ -4961,10 +4984,10 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
     , __x2, __qinv2, __q2, __lo2, __hi2\
     , __x3, __qinv3, __q3, __lo3, __hi3)\
     {\
-		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0;\
-		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1;\
-		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2;\
-		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3;\
+		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0,__cz0;\
+		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1,__cz1;\
+		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2,__cz2;\
+		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3,__cz3;\
 		\
 		/* SQR_LOHI128(x,lo,hi) IS HERE: */\
 		SQR_LOHI64(__x0.d0,         __wa0, __wb0);\
@@ -4983,10 +5006,10 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 		SQR_LOHI64(__x3.d1,         __wc3, __wd3);\
 		\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);	__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);\
-		__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);	__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);\
-		__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);	__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);\
-		__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);	__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);\
+		__wb0 += __a0;	__cy0  = (__wb0 < __a0);	__wc0 += __b0;	__cz0  = (__wc0 < __b0);	__wb0 += __a0;	__cy0 += (__wb0 < __a0);	__wc0 += __b0;	__cz0 += (__wc0 < __b0);	__wc0 += __cy0;	__cz0 += (__wc0 < __cy0);	__wd0 += __cz0;\
+		__wb1 += __a1;	__cy1  = (__wb1 < __a1);	__wc1 += __b1;	__cz1  = (__wc1 < __b1);	__wb1 += __a1;	__cy1 += (__wb1 < __a1);	__wc1 += __b1;	__cz1 += (__wc1 < __b1);	__wc1 += __cy1;	__cz1 += (__wc1 < __cy1);	__wd1 += __cz1;\
+		__wb2 += __a2;	__cy2  = (__wb2 < __a2);	__wc2 += __b2;	__cz2  = (__wc2 < __b2);	__wb2 += __a2;	__cy2 += (__wb2 < __a2);	__wc2 += __b2;	__cz2 += (__wc2 < __b2);	__wc2 += __cy2;	__cz2 += (__wc2 < __cy2);	__wd2 += __cz2;\
+		__wb3 += __a3;	__cy3  = (__wb3 < __a3);	__wc3 += __b3;	__cz3  = (__wc3 < __b3);	__wb3 += __a3;	__cy3 += (__wb3 < __a3);	__wc3 += __b3;	__cz3 += (__wc3 < __b3);	__wc3 += __cy3;	__cz3 += (__wc3 < __cy3);	__wd3 += __cz3;\
 		\
 		/* Now store the high 128 bits of the result in __hi: */\
 		__hi0.d0 =  __wc0;	__hi0.d1 = __wd0;\
@@ -5092,14 +5115,14 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
     , __x6, __qinv6, __q6, __lo6, __hi6\
     , __x7, __qinv7, __q7, __lo7, __hi7)\
     {\
-		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0;\
-		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1;\
-		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2;\
-		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3;\
-		uint64	__a4,__b4,__t4,__wa4,__wb4,__wc4,__wd4,__cy4;\
-		uint64	__a5,__b5,__t5,__wa5,__wb5,__wc5,__wd5,__cy5;\
-		uint64	__a6,__b6,__t6,__wa6,__wb6,__wc6,__wd6,__cy6;\
-		uint64	__a7,__b7,__t7,__wa7,__wb7,__wc7,__wd7,__cy7;\
+		uint64	__a0,__b0,__t0,__wa0,__wb0,__wc0,__wd0,__cy0,__cz0;\
+		uint64	__a1,__b1,__t1,__wa1,__wb1,__wc1,__wd1,__cy1,__cz1;\
+		uint64	__a2,__b2,__t2,__wa2,__wb2,__wc2,__wd2,__cy2,__cz2;\
+		uint64	__a3,__b3,__t3,__wa3,__wb3,__wc3,__wd3,__cy3,__cz3;\
+		uint64	__a4,__b4,__t4,__wa4,__wb4,__wc4,__wd4,__cy4,__cz4;\
+		uint64	__a5,__b5,__t5,__wa5,__wb5,__wc5,__wd5,__cy5,__cz5;\
+		uint64	__a6,__b6,__t6,__wa6,__wb6,__wc6,__wd6,__cy6,__cz6;\
+		uint64	__a7,__b7,__t7,__wa7,__wb7,__wc7,__wd7,__cy7,__cz7;\
 		\
 		/* SQR_LOHI128(x,lo,hi) IS HERE: */\
 		SQR_LOHI64(__x0.d0,        __wa0, __wb0);\
@@ -5130,14 +5153,14 @@ On Alpha, this needs a total of 7 MUL instructions and 12 ALU ops.
 		SQR_LOHI64(__x7.d1,        __wc7, __wd7);\
 		\
 		/* Need to add 2*a*b, so add a*b twice: */\
-		__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);	__wb0 += __a0;	__wc0 += __b0 + (__wb0 < __a0);	__wd0 += (__wc0 < __b0);\
-		__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);	__wb1 += __a1;	__wc1 += __b1 + (__wb1 < __a1);	__wd1 += (__wc1 < __b1);\
-		__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);	__wb2 += __a2;	__wc2 += __b2 + (__wb2 < __a2);	__wd2 += (__wc2 < __b2);\
-		__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);	__wb3 += __a3;	__wc3 += __b3 + (__wb3 < __a3);	__wd3 += (__wc3 < __b3);\
-		__wb4 += __a4;	__wc4 += __b4 + (__wb4 < __a4);	__wd4 += (__wc4 < __b4);	__wb4 += __a4;	__wc4 += __b4 + (__wb4 < __a4);	__wd4 += (__wc4 < __b4);\
-		__wb5 += __a5;	__wc5 += __b5 + (__wb5 < __a5);	__wd5 += (__wc5 < __b5);	__wb5 += __a5;	__wc5 += __b5 + (__wb5 < __a5);	__wd5 += (__wc5 < __b5);\
-		__wb6 += __a6;	__wc6 += __b6 + (__wb6 < __a6);	__wd6 += (__wc6 < __b6);	__wb6 += __a6;	__wc6 += __b6 + (__wb6 < __a6);	__wd6 += (__wc6 < __b6);\
-		__wb7 += __a7;	__wc7 += __b7 + (__wb7 < __a7);	__wd7 += (__wc7 < __b7);	__wb7 += __a7;	__wc7 += __b7 + (__wb7 < __a7);	__wd7 += (__wc7 < __b7);\
+		__wb0 += __a0;	__cy0  = (__wb0 < __a0);	__wc0 += __b0;	__cz0  = (__wc0 < __b0);	__wb0 += __a0;	__cy0 += (__wb0 < __a0);	__wc0 += __b0;	__cz0 += (__wc0 < __b0);	__wc0 += __cy0;	__cz0 += (__wc0 < __cy0);	__wd0 += __cz0;\
+		__wb1 += __a1;	__cy1  = (__wb1 < __a1);	__wc1 += __b1;	__cz1  = (__wc1 < __b1);	__wb1 += __a1;	__cy1 += (__wb1 < __a1);	__wc1 += __b1;	__cz1 += (__wc1 < __b1);	__wc1 += __cy1;	__cz1 += (__wc1 < __cy1);	__wd1 += __cz1;\
+		__wb2 += __a2;	__cy2  = (__wb2 < __a2);	__wc2 += __b2;	__cz2  = (__wc2 < __b2);	__wb2 += __a2;	__cy2 += (__wb2 < __a2);	__wc2 += __b2;	__cz2 += (__wc2 < __b2);	__wc2 += __cy2;	__cz2 += (__wc2 < __cy2);	__wd2 += __cz2;\
+		__wb3 += __a3;	__cy3  = (__wb3 < __a3);	__wc3 += __b3;	__cz3  = (__wc3 < __b3);	__wb3 += __a3;	__cy3 += (__wb3 < __a3);	__wc3 += __b3;	__cz3 += (__wc3 < __b3);	__wc3 += __cy3;	__cz3 += (__wc3 < __cy3);	__wd3 += __cz3;\
+		__wb4 += __a4;	__cy4  = (__wb4 < __a4);	__wc4 += __b4;	__cz4  = (__wc4 < __b4);	__wb4 += __a4;	__cy4 += (__wb4 < __a4);	__wc4 += __b4;	__cz4 += (__wc4 < __b4);	__wc4 += __cy4;	__cz4 += (__wc4 < __cy4);	__wd4 += __cz4;\
+		__wb5 += __a5;	__cy5  = (__wb5 < __a5);	__wc5 += __b5;	__cz5  = (__wc5 < __b5);	__wb5 += __a5;	__cy5 += (__wb5 < __a5);	__wc5 += __b5;	__cz5 += (__wc5 < __b5);	__wc5 += __cy5;	__cz5 += (__wc5 < __cy5);	__wd5 += __cz5;\
+		__wb6 += __a6;	__cy6  = (__wb6 < __a6);	__wc6 += __b6;	__cz6  = (__wc6 < __b6);	__wb6 += __a6;	__cy6 += (__wb6 < __a6);	__wc6 += __b6;	__cz6 += (__wc6 < __b6);	__wc6 += __cy6;	__cz6 += (__wc6 < __cy6);	__wd6 += __cz6;\
+		__wb7 += __a7;	__cy7  = (__wb7 < __a7);	__wc7 += __b7;	__cz7  = (__wc7 < __b7);	__wb7 += __a7;	__cy7 += (__wb7 < __a7);	__wc7 += __b7;	__cz7 += (__wc7 < __b7);	__wc7 += __cy7;	__cz7 += (__wc7 < __cy7);	__wd7 += __cz7;\
 		\
 		/* Now store the high 128 bits of the result in __hi: */\
 		__hi0.d0 =  __wc0;	__hi0.d1 = __wd0;\


### PR DESCRIPTION
## The bug

Every 128-bit multiply macro in `src/imul_macro1.h` folds a 128-bit cross-term `(a,b)` into
the 4-word accumulator `(w0,w1,w2,w3)` with this three-statement idiom:

```c
	__w1 += __a;
	__w2 += __b + (__w1 < __a);	/* Overflow into word2 is checked here. */
	__w3 +=       (__w2 < __b);	/* Overflow into word3 is checked here. */
```

The third line is the carry-out test for the second, but it compares the *new* `__w2` against
`__b` **alone**, ignoring the carry-in that was added along with it. The correct predicate is
`__w2_new < __b + carry_in`. When `carry_in == 1` and the pre-addition `__w2` was exactly
`2^64-1`, the sum lands on `__b + 2^64`, i.e. on `__b` after truncation — so `__w2 < __b` is
false even though the addition really did overflow, and **a carry into `__w3` is dropped**.
The high output word comes back one too small.

Reported instances, on `main` (590a1a6):

| macro | line(s) |
|---|---|
| `SQR_LOHI128` | `:2482`, `:2485` (and `:2379`, `:2382` in the `MUL_LOHI64_SUBROUTINE` branch) |
| `SQR_LOHI127` | `:2515` (`:2398`) |
| `SQR_LOHI128_q4` / `_q8` | `:2604-2607` / `:2819-2826`, 2 per lane |
| `SQR_LOHI127_q4` / `_q8` | `:2686-2689` / `:2953-2960` |
| `MUL_LOHI128` | `:4012`, `:4015` (`:3991`, `:3994`) |
| `MULH128` | `:4771`, `:4774` |
| `MULH128_q4` / `_q8` | `:4816`+`:4821`, `:4831`+`:4836` / `:4905`+`:4914`, `:4932`+`:4941` |
| `THREE_OP128_q4` / `_q8` | `:4986-4989` / `:5133-5140` (and `:4442-4445` / `:4589-4596`) |

An exhaustive scan for the shape (regex over the whole header, allowing the statement pair to be
split across up to 20 lines, which is how `MULH128_q4/_q8` write it) finds **120 sites in 17
macro bodies** — the five sites in the original report plus their `_q4`/`_q8` inlinings, the
`SQR_LOHI127` siblings, the fused `THREE_OP128_q4/_q8`, and the `MUL_LOHI64_SUBROUTINE`
duplicates of all of the above. After this patch the same scan reports **0**.

## Why it is not a 1-in-2^64 curiosity: `twopmmodq128` returns 0 instead of 1

The trigger needs an exact 64-bit coincidence, so uniform-random operands essentially never hit
it (0 mismatches in the 20 M uniform-random invocations measured below). But there is a live path where the coincidence is *structural*:

`twopmmodq128()` (`src/twopmodq128.c:53`) runs `SQR_LOHI128` / `MULL128` / `MULH128` in its
Montgomery powering loop (`:160-162`). The `MULH128(q, lo)` step multiplies `q` by a value
derived from `qinv`, and `q*qinv == 1 (mod 2^128)` **by construction** — the low half of that
product is exactly 1, which is precisely the total cancellation that drives `__w2` to `2^64-1`
with a carry pending. So whenever the loop's running residue reaches `x == 1`, the dropped carry
fires deterministically and the routine **returns 0 where it must return 1**.

The cleanest witness is Fermat's little theorem: for prime `q`, `2^(q-1) == 1 (mod q)`.

Measured with an oracle test (`pow(2,p,q)` in Python) over random primes `q` just above `2^64`
with `p = q-1`, linking the real `twopmmodq128` out of a production `makemake.sh avx2` build:

| sample | `main` | with this patch |
|---|---|---|
| 236 random 65-bit primes | **41 wrong (17.4 %)** | **0 wrong** |
| 1000 random 65-bit primes | **157 wrong (15.7 %)** | **0 wrong** |

First failing case in the 236-sample: `q = 0x1000070213498f7f5` (prime),
`p = q-1 = 0x1000070213498f7f4` (q = 18446867361628223477)
-> returns `0`, must be `1`.

`twopmmodq128` is reached from the PRP-cofactor known-factor check at `src/Mlucas.c:5287`
(the `j == 2` arm, i.e. any known factor of 65..128 bits), which is the check behind issue #32.

### One-line reproducers

```
SQR_LOHI128(2^128-1)          main hi = {fffffffffffffffe,fffffffffffffffe}
                             fixed hi = {ffffffffffffffff,fffffffffffffffe}   <- exact
MULH128({00000000ffffffff,00000000fffffffe}, {0000000100000001,aaaaaaaaaaaaaaaa})
                              main hi.d1 = 0        fixed hi.d1 = 1           <- exact
MUL_LOHI128({ffffffffffffffff,0333126e1f536922}, {0000000000000001,00001c1962ef6469})
                              main hi.d1 = 0        fixed hi.d1 = 1           <- exact
```

`x = 2^128-1` is thus a single-expression demonstration that `SQR_LOHI128` is wrong on `main`.

## The fix

Adopt the deferred-carry-accumulator idiom the file already uses correctly for the wider
widths — `MULH192` at `:7219-7222` and `MULH256` at `imul256_macro.h:159-163`: accumulate the
per-word carries in `__cy2`/`__cy3` and ripple them in once at the end, so no carry-out is ever
tested against the wrong addend.

```c
	__w1 += __a;	__cy2  = (__w1 < __a);
	__w2 += __b;	__cy3  = (__w2 < __b);
	__w1 += __c;	__cy2 += (__w1 < __c);
	__w2 += __d;	__cy3 += (__w2 < __d);
	/* Now process carries: */
	__w2 += __cy2;	__cy3 += (__w2 < __cy2);
	__w3 += __cy3;
```

In the pipelined macros the two accumulators are per-lane `__cyN`/`__czN`; `THREE_OP128_q4/_q8`
already declare `__cyN` (reused further down as a scratch carry), so only `__czN` is added there.
No other statement is reordered and no operand read is moved, so the documented
overwrite-safety contracts (`x` and `lo` may alias; `y` may alias `hi`) are preserved.

**Deliberately including the provably-immune sites.** In the squaring macros the *first* of the
two adds cannot lose a carry: `__w2` starts as `low64(x.d1^2)`, and a perfect square is 0 or 1
mod 4, so it can never be `2^64-1` (which is 3 mod 4). Same argument makes all of
`SQR_LOHI127`/`_q4`/`_q8` immune. Those 52 sites are converted anyway rather than leaving the
family half-fixed and resting on a subtle number-theoretic invariant that a future edit could
silently invalidate. Cost is ~2 extra ALU ops per cross-term add on a path dominated by 64-bit
`mulq`s.

## Verification

Box is AVX2 x86-64 only, gcc 15.2.1. Everything below was actually run.

### 1. Macro-level differential harness (4 build variants, `__int128` oracle)

Each macro is wrapped and compared against an independent `unsigned __int128` schoolbook
oracle, with the wrappers compiled **four times** over the same headers so that the
`YES_ASM` / `MULH64_FAST` configuration matrix is covered — variant A = the shipping x86-64
config, B = `MULH64_FAST` off, C = all-portable-C bodies (exactly the preprocessor state
ARM/aarch64, RISC-V, PPC, s390x and 32-bit x86 see), D = both. The four variant objects are
pairwise distinct by md5 in both the before and the after build.

Per 200000 iterations per macro per variant, interleaved generators
(uniform / 20-element boundary pool / mixed / runs-of-set-bits, plus forced-equal operands):

| macro | `main` | with patch |
|---|---|---|
| `sqr_lohi128` | 187 | **0** |
| `sqr_lohi128_q4` | 738 | **0** |
| `sqr_lohi128_q8` | 1479 | **0** |
| `mul_lohi128` | 939 | **0** |
| `mulh128` | 961 | **0** |
| `mulh128_q4` | 3695 | **0** |
| `mulh128_q8` | 7086 | **0** |

**Unchanged neighbours.** Every other macro in the sweep reports a bit-identical count before
and after — `mulh128x96` 2983, `_q4` 11172, `_q8` 21200; `sqr_lohi160` 526, `_q4` 2009,
`_q8` 200000; `mulh160` 1115, `_q4` 4634, `_q8` 9164; `sqr_lohi192` 41042; `mulh192_q4` 1186,
`_q8` 2306; `cmp128b` 57250 — and the ~96 macros that were exact stay exact. Totals:
369672 -> 354587 mismatches, a delta of exactly 15085 = the sum of the seven rows above.
(All of those residual counts are the separately-reported findings: `SQR_LOHI192` = #167,
`SQR_LOHI160_q8` / `MULH128x96` / `MULH160` / `MULH192_q4`+`_q8` / `CMPULT128B` = their own PRs.)

Re-run once per generator instead of interleaved — same picture in all four, and the
unchanged-neighbour counts are again identical in every mode:

| generator | affected macros, `main` | with patch | all other macros, main -> patched |
|---|---|---|---|
| interleaved (all four) | 15085 | **0** | 354587 -> 354587 |
| 0 uniform random | 0 | 0 | 335501 -> 335501 |
| 1 boundary pool | 45349 | **0** | 386735 -> 386735 |
| 2 mixed random/boundary | 10611 | **0** | 329429 -> 329429 |
| 3 runs of set/clear bits | 4736 | **0** | 368074 -> 368074 |

High-volume targeted re-run of the ten affected macros (`ONLYOP` filter), 2000000 iterations
per macro per variant in each of the five generator settings — **0 mismatches out of
100000000 macro evaluations**, against 752356 on `main`.

`THREE_OP128_q4`/`_q8` are not in that harness (they fuse three macros and take 5 operands per
lane), so they got a dedicated oracle test: the `hi` output, which is the `SQR_LOHI128`
inlining this patch fixes, goes from 377 / 1005 / 243 / 223 bad lanes per 400000 (interleaved /
boundary-pool / mixed / bit-runs) to **0 in all four**. See the honest note below about their `lo` output.

### 2. End-to-end, oracle-checked against Python `pow(2,p,q)`

The real `twopmmodq64/128/192/256` linked out of a production build, 2024 (p,q) pairs per run
with the identical input set across all builds:

| set | `main` | + this patch | + this patch + #172 | + this + #172 + #167 |
|---|---|---|---|---|
| A128 — 236 primes just above 2^64, `p = q-1` | **41** | **0** | 0 | 0 |
| A64 / A192 / A256 — same (p,q), wider routines | 0 | 0 | 0 | 0 |
| B128 — 200 random odd q, random p | 0 | 0 | 0 | 0 |
| B192 — 200 random odd q | 95 | 95 | 95 | **0** |
| B64 / B256 | 0 | 0 | 0 | 0 |
| C128 / C192 / C256 — 40 even q each (right-justify path) | 11 / 9 / 8 | 11 / 9 / 8 | **0 / 0 / 0** | 0 / 0 / 0 |
| D128 / D192 / D256 — small p, direct mod-doubling path | 0 | 0 | 0 | 0 |
| **total** | **164 / 2024** | **123 / 2024** | 95 / 2024 | **0 / 2024** |

So: this patch fixes exactly the A128 column and touches nothing else; the residual even-modulus
failures are PR #172's stale `qhalf`, and the residual 192-bit ones are PR #167's `SQR_LOHI192`.
The three are independent and all three are needed for a clean sheet.

`MULH128` is also used outside the 128-bit routines, at `src/twopmodq256.c:332`, to extend
`qinv` from 128 to 256 bits — the same `q*qinv == 1` structure. `twopmmodq256` measured 0 wrong
before and after here, so that use is not currently mis-firing in this sample, but the fix can
only help it.

### 3. The real Mfactor 128-bit modpow path

`twopmodq128_q4` / `_q8` (which is where `SQR_LOHI128_q4/_q8` and `MULH128_q4/_q8` are actually
consumed, via `src/factor.c:3579`/`:3654`) were run over the 46 usable known-factor vectors in
`src/fac_test_dat128.h` (the `fac128x2[]` table, i.e. the ones whose `k = (q-1)/2p` fits in 64
bits), each with the true `k` in lane 0 and deliberately wrong `k+1..k+7` in the other lanes.
All 46 factors are found and there are no false positives on the 7 bogus lanes, **before and
after** the patch; the scalar `twopmodq128` agrees on all 46 as well. Expected — those inputs do
not hit the coincidence — but it rules out a regression on the hot path.

Mfactor's own `test_fac()` self-test could not be used: `make Mfactor` does not build on `main`
with gcc 15 (`implicit declaration of twopmodq100_2WORD_DOUBLE_q4`, `src/factor.c:3585`), which
reproduces without any of my changes and needs PRs #193/#82.

### 4. Build and self-test

* Full clean `bash makemake.sh avx2`, exit 0. The warning section of the build log is
  **byte-identical** to the pre-patch build (only the wall-clock lines differ).
* `obj_avx2/Mlucas -s tt` residues match `main`: `13K=E3BC90B0E652C7C0`,
  `14K=DB8E39C67F8CCA0A`, `15K=B3C5A1C03E26BB17`. (The 1K/2K "excessive roundoff" notices are
  the known pre-existing ones, #101/#104.)

## Overlap with PR #167 — merge order does not matter

#167 (`fix-sqr-lohi192-carry`) edits the same file, but `SQR_LOHI192` only: pre-image lines
**6405** and **6436-6440**. This patch's last hunk ends at pre-image line **5140** — a gap of
**1265 lines**, far outside any diff context window.

Confirmed mechanically rather than by eyeball: `git merge-tree --write-tree` of this branch
against `origin/fix-sqr-lohi192-carry` succeeds with exit 0 and no conflict messages
("Auto-merging src/imul_macro1.h"), and the resulting tree contains both changes intact. The
same test against `origin/fix-twopmodq-qhalf-after-shift` (#172, different files entirely) is
also clean. **Either merge order works; no rebase needed.** The last column of the §2 table was
produced by building that auto-merged tree.

#172's changes are *not* included in this commit.

The branch is based on 590a1a6, which was `upstream/main` when the work started; main has since
moved to 47d75d3 (#132, #133). `src/imul_macro1.h` is **byte-identical** between those two
commits, so every line number quoted above still holds against current main, and the only
changes to `src/twopmodq128|192|256.c` in between are `cstr` -> `g_cstr` renames inside
`#if FAC_DEBUG` blocks, so all the measurements above are unaffected. GitHub reports the PR
`MERGEABLE`; I did not rebase, to avoid re-queueing 64 CI jobs for a no-op.

## What I could not test, and one thing I found but did not fix

* **Not tested:** AVX-512 (no hardware on this box; and these are scalar-integer macros with no
  SIMD involvement anyway), Windows/MinGW, real ARM/aarch64/RISC-V/PPC hardware, and the
  `MUL_LOHI64_SUBROUTINE` branch *at runtime*. That branch is auto-selected only for x86-64 +
  SunStudio/ICC and cannot be compiled here at all (it hits a pre-existing `MULH96_PTR_q4` /
  `MUL64x32` macro-vs-function mismatch on `main`, reported separately). Its four affected macro
  bodies were patched identically to their default-branch twins and reviewed by hand, but carry
  no runtime evidence. They do at least *compile*: `src/twopmodq128.c` (which instantiates all of
  `SQR_LOHI128`, `SQR_LOHI127`, `MUL_LOHI128`, `MULH128` and their `_q4`/`_q8` forms) builds
  warning-clean with `-DMUL_LOHI64_SUBROUTINE -Wall -Wextra` under both gcc 15.2.1 and clang 22.1.8,
  before and after the patch, with the same single pre-existing informational `#warning`. The
  portable-C bodies that non-x86 platforms compile *are* covered at runtime, by harness variants
  C and D.
* **`THREE_OP128_q4`/`_q8` are still wrong, for a different reason.** Their hand-fused
  `MULH128` section uses the *other* buggy shape — `__b0 += __wd0 + (__a0 < __wc0);` with the
  carry-out of `__b0` simply discarded, the same "since b and d <= 2^64 - 2, can add carryout of
  a+c sans ripple-carry check" pattern as the separately-reported `MULH128x96` defect. Both
  addends there are full 128-bit products, so it fires on ~7 % of uniform-random inputs: the
  `lo` output measures 28784 bad lanes per 400000 both before and after this patch, while the
  `hi` output goes to 0. I left it alone because it is a different defect belonging to that
  other report, and because these macros are opt-in — the call sites at
  `src/twopmodq128.c:863`/`:1168` are behind `#if THREE_OP128`, which is undefined by default.
  Flagging it so nobody reads "THREE_OP128 touched by the carry fix" as "THREE_OP128 is now
  correct". (Cross-check that the oracle used for that measurement is right: the un-fused
  `SQR_LOHI128` + `MULL128` + `MULH128` sequence matches it 500000/500000 in both builds.)

