### PR TITLE
Reject the AVX-512 Mersenne radix1008/4032 cells that have no carry; count only runnable radix sets in the self-test

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3945,7 +3945,7 @@ int 	main(int argc, char *argv[])
 	uint32 numrad = 0, rad_prod = 0, rvec[10], rvec2[10];	/* Temporary storage for FFT radices */
 	double	runtime,/* wruntime, */ runtime_best,wruntime_best, tdiff;	// v20: w-prefixed are weighted by associated ROEs
 	double	roerr_avg = 0, roerr_max = 0;
-	int		radix_set, radix_best, nradix_set_succeed;
+	int		radix_set, radix_best, nradix_set_succeed, nradix_set_skipped, nradix_set_tried;
 
 	uint32 mvec_res_t_idx = 0;	/* Lookup index into the res_triplet table */
 	uint32 new_data;
@@ -4662,6 +4662,7 @@ TIMING_TEST_LOOP:
 		runtime_best = wruntime_best = 0.0;
 		radix_best = -1;
 		nradix_set_succeed = 0;
+		nradix_set_skipped = 0;	// #radix-sets this build has no implementation for - not failures, see below
 
 		/* If user-specified radix set, do only that one: */
 		if(radset >= 0)
@@ -4718,7 +4719,19 @@ TIMING_TEST_LOOP:
 			else if(retVal)	// Bzzzzzzzzzzzt!!! That answer is incorrect. The penalty is death:
 			{
 				printMlucasErrCode(retVal);
-				if( !userSetExponent && ((iters == 100) || (iters == 1000) || (iters == 10000)) )
+				// ERR_RADIX0_UNAVAILABLE means "this build has no working implementation of this leading radix"
+				// - e.g. the many radixNN_ditN_cy_dif1.c "No AVX-512 support; Skipping this leading radix."
+				// self-rejections, and the mers|fermat_mod_square guards on known-broken leading radices. That is
+				// "not applicable", not "computed the wrong answer", so it must not count against this FFT length
+				// in the pass-fraction test below: a length whose remaining radix sets are all correct should still
+				// get a cfg-file entry. Note we deliberately do NOT extend this to ERR_ASSERT, which the mod_square
+				// routines also return for the genuine "max_fp < 0.01 during DWT-unweighting" numerical failure -
+				// that one is a wrong-answer signal and must keep counting as a failure.
+				if(retVal == ERR_RADIX0_UNAVAILABLE) {
+					nradix_set_skipped++;
+					if( !userSetExponent && ((iters == 100) || (iters == 1000) || (iters == 10000)) )
+						fprintf(stderr, "This radix set is not available in this build - skipping it (not counted as a failure).\n");
+				} else if( !userSetExponent && ((iters == 100) || (iters == 1000) || (iters == 10000)) )
 					fprintf(stderr, "Error detected - this radix set will not be used.\n");
 				if(radset >= 0)	// If user-specified radix set, do only that one:
 					goto DONE;
@@ -4781,15 +4794,20 @@ TIMING_TEST_LOOP:
 		}
 
 		// If get no successful reference-Res64-matching results, or less than half of results @this FFT length match, skip it:
-		if(radix_best < 0 || runtime_best == 0.0 || nradix_set_succeed < (radix_set+1)/2)
+		// The denominator counts only the radix sets this build can actually run: ones which self-rejected with
+		// ERR_RADIX0_UNAVAILABLE are unimplemented here, not wrong, so counting them as failures would discard an
+		// FFT length whose remaining radix sets all produce the correct residue. When every set was skipped the
+		// (radix_best < 0) test still catches the length, so no cfg entry gets written on a vacuous 0-of-0.
+		nradix_set_tried = radix_set - nradix_set_skipped;	// #radix-sets actually attempted by this build
+		if(radix_best < 0 || runtime_best == 0.0 || nradix_set_succeed < (nradix_set_tried+1)/2)
 		{
-			sprintf(cbuf, "WARNING: %d of %d radix-sets at FFT length %u K passed - skipping it. PLEASE CHECK YOUR BUILD OPTIONS.\n",nradix_set_succeed,radix_set,iarg);
+			sprintf(cbuf, "WARNING: %d of %d radix-sets at FFT length %u K passed (%d skipped as unavailable in this build) - skipping it. PLEASE CHECK YOUR BUILD OPTIONS.\n",nradix_set_succeed,nradix_set_tried,iarg,nradix_set_skipped);
 			fprintf(stderr,"%s", cbuf);
 		}
 		/* If get a nonzero best-runtime, write the corresponding radix set index to the .cfg file: */
 		else
 		{
-			sprintf(cbuf, "INFO: %d of %d radix-sets at FFT length %u K passed - writing cfg-file entry.\n",nradix_set_succeed,radix_set,iarg);
+			sprintf(cbuf, "INFO: %d of %d radix-sets at FFT length %u K passed (%d skipped as unavailable in this build) - writing cfg-file entry.\n",nradix_set_succeed,nradix_set_tried,iarg,nradix_set_skipped);
 			fprintf(stderr,"%s", cbuf);
 
 			/* Divide by the number of iterations done in the self-test: */

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -338,6 +338,25 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			}
 		}
 
+	#ifdef USE_AVX512
+		/* radix1008 (= 63*16) and radix4032 (= 63*64) have no AVX-512 Mersenne-mod carry:
+		radix{1008,4032}_main_carry_loop.h carry the '#warning No avx-512 mers-mod carry support yet!',
+		and under USE_AVX512 + Mersenne the carry step emits no code whatsoever.
+
+		Without this check the run still fails, but further downstream and less clearly: the
+		thread-local half_arr memcheck reads '#ifdef USE_AVX', so in an AVX-512 build it probes the
+		4-lane AVX offsets +40/+56 and asserts. radix960, which does support AVX-512 Mersenne, carries
+		a no-op '#ifdef USE_AVX512' arm that silences exactly that assert. Do NOT add that arm here
+		while the carry is still missing: it would turn a loud failure into a silently wrong residue.
+
+		Remove this check when the AVX-512 Mersenne carry is implemented, not before. */
+		if(radix0 == 1008 || radix0 == 4032)
+		{
+			sprintf(cbuf  ,"Leading radix %u has no AVX-512 Mersenne-mod carry implementation; Skipping this leading radix.\n", (uint32)radix0);
+			WARN(HERE, cbuf, "", 1); return(ERR_RADIX0_UNAVAILABLE);
+		}
+	#endif
+
 		sprintf(cbuf,"Using complex FFT radices*");
 		char_addr = strstr(cbuf,"*");
 		for(i = 0; i < NRADICES; i++)


### PR DESCRIPTION
## Summary

Two changes, both in the path that selects and validates a leading FFT radix.

**1. Reject the two AVX-512 Mersenne cells that have no carry implementation.**

`radix1008` (= 63·16) and `radix4032` (= 63·64) have no AVX-512 Mersenne-mod carry. Both
`radix{1008,4032}_main_carry_loop.h` carry

```
#warning No avx-512 mers-mod carry support yet!
```

and under `USE_AVX512` + Mersenne the carry step emits no code at all. This rejects those two leading
radices up front, with a message saying why:

```c
#ifdef USE_AVX512
    if(radix0 == 1008 || radix0 == 4032) { WARN(...); return ERR_RADIX0_UNAVAILABLE; }
#endif
```

Without the check the run still fails, but further downstream and less clearly: the thread-local
`half_arr` memcheck reads `#ifdef USE_AVX`, so an AVX-512 build probes the 4-lane AVX offsets
`+40/+56` and asserts.

**Do not "fix" that assert as a tidy-up.** radix960, which does support AVX-512 Mersenne, carries a
no-op `#ifdef USE_AVX512` arm that silences exactly it. Adding that arm here while the carry is still
missing would convert a loud failure into a silently wrong residue. The rejection should stay until
the carry exists — see #205, which implements it; if that merges, this check can be deleted.

**2. Count only radix sets that actually ran, in the self-test pass fraction.**

A leading radix that declines the job returned `ERR_ASSERT`, which the self-test counted as an
attempted-and-failed radix set. That covers the check above and the pre-existing
`"No AVX-512 support; Skipping this leading radix"` self-rejections in radix12/20/28 and others. They
now return `ERR_RADIX0_UNAVAILABLE`, and the sweep excludes such sets from the denominator, so
`"N of M radix-sets passed"` describes the sets that were actually run.

## Scope

`radix0 == 63` is **not** rejected here, and neither is anything outside AVX-512. Those cells were
broken when this PR was first opened and are fixed elsewhere; see the merge order below.

## Verification

Compiles clean in `nosimd`, `sse2`, `avx`, `avx2` and `avx512`.

The rejection itself is exercised by running any 63·2^k FFT length in an AVX-512 build — 1008K,
2016K, 4032K and up — which now reports the skip and moves on, instead of asserting inside the
memcheck.

## Merge order

This PR must land **after** the three that fix the cells it no longer rejects. Merging it earlier
does not break anything by itself, but the guard would be narrower than the code warrants:

| dependency | what it fixes |
|---|---|
| **#204** | radix1008/4032 carry — the AVX/AVX2 silent all-zero-residue cells |
| **#210** | radix63's lane-0 carry loop, and its wraparound pass length hardcoded to 7 rather than `2*RE_IM_STRIDE-1` |
| **#152** | `nchunks = radix0>>1` drops the last work chunk for **every odd `radix0`** (5, 7, 9, 11, 13, 15, 63) in any build with `MULTITHREAD` compiled in, including at `-cpu 0`. This is what made radix63's *scalar* Mersenne failure look like a radix63 problem; it never was. |

**#205** implements the missing AVX-512 Mersenne carry. If it lands, the remaining check here becomes
unnecessary and should be removed.
