### PR TITLE
Respect an externally-imposed CPU-affinity mask when choosing the default core set

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -421,7 +421,7 @@ numbering conventions used by the leading x86-CPU manufacturers Intel and AMD.
  -nthread {int}
 	For multithread-enabled builds, run with this many threads.
 	If the user does not specify a thread count, the default is to run single-threaded
-	with that thread's affinity set to logical core 0.
+	with that thread's affinity set to the first logical core available to the process.
 
 	AFFINITY: The code will attempt to set the affinity of the resulting threads
 	0:n-1 to the same-indexed processor cores - whether this means distinct physical
@@ -429,6 +429,16 @@ numbering conventions used by the leading x86-CPU manufacturers Intel and AMD.
 	but AMD does not. For this reason as of v17 this option is deprecated in favor of
 	the -cpu flag, whose usage is detailed below, with the online README page providing
 	guidance for the core-numbering schemes of popular CPU vendors.
+
+	EXTERNALLY-IMPOSED AFFINITY: On Linux, "available" above means "within the CPU-affinity
+	mask this process inherited". If the process was launched under a restricted mask - via
+	taskset, numactl, systemd 'CPUAffinity=', a batch scheduler such as SLURM, or a container
+	cpuset - then -nthread n uses the first n logical cores of *that* mask rather than cores
+	0:n-1, so that several instances pinned to disjoint core groups do not all pile onto the
+	same low-numbered cores. With an unrestricted mask this is exactly cores 0:n-1, as before.
+	An explicit -cpu/-core core set always wins, but naming a core outside the inherited mask
+	now draws a warning, since pinning a thread there overrides the operator's placement (and
+	fails outright under a cgroup cpuset).
 
 	If n exceeds the available number of logical processor cores (call it #cpu), the
 	program will halt with an error message.

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -474,7 +474,8 @@ RANGE_BEG:
 	}
 
 /*  ...If multithreading enabled, set max. # of threads based on # of available (logical) processors,
-with the default #threads = 1 and affinity set to logical core 0, unless user overrides those via -nthread or -cpu:
+with the default #threads = 1 and affinity set to the first logical core this process is permitted to
+use, unless user overrides those via -nthread or -cpu:
 */
 #ifdef MULTITHREAD
 
@@ -494,9 +495,10 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 	if(!NTHREADS) {
 		NTHREADS = 1;
 		fprintf(stderr,"No CPU set or threadcount specified ... running single-threaded.\n");
-		// Use the same affinity-setting code here as for the -cpu option, but simply for cores [0:NTHREADS-1]:
-		sprintf(cbuf,"0:%d",NTHREADS-1);
-		parseAffinityString(cbuf);
+		// Use the same affinity-setting code here as for the -cpu option, but simply for the first
+		// NTHREADS cores of this process's inherited CPU-affinity mask (= cores [0:NTHREADS-1] unless
+		// that mask has been restricted by taskset/numactl/systemd/a batch scheduler):
+		setDefaultAffinity(NTHREADS);
 	} else if(NTHREADS > MAX_CORES) {
 		sprintf(cbuf,"ERROR: NTHREADS = %d exceeds the MAX_CORES setting in Mdata.h = %d\n", NTHREADS, MAX_CORES);
 		ASSERT(0, cbuf);
@@ -4238,9 +4240,10 @@ just below the upper limit for each FFT lengh in some subrange of the self-tests
 			ASSERT(!(i64arg>>32), "nthread argument must be < 2^32 ... halting.");
 			NTHREADS = (uint32)i64arg;
 			nthread = TRUE;
-			// Use the same affinity-setting code here as for the -cpu option, but simply for cores [0:NTHREADS-1]:
-			sprintf(cbuf,"0:%d",NTHREADS-1);
-			parseAffinityString(cbuf);
+			// Use the same affinity-setting code here as for the -cpu option, but simply for the first
+			// NTHREADS cores of this process's inherited CPU-affinity mask (= cores [0:NTHREADS-1] unless
+			// that mask has been restricted by taskset/numactl/systemd/a batch scheduler):
+			setDefaultAffinity(NTHREADS);
 		#endif
 		}
 

--- a/src/util.c
+++ b/src/util.c
@@ -20,6 +20,16 @@
 *                                                                              *
 *******************************************************************************/
 
+/* sched_getaffinity() and the CPU_* macros are GNU extensions: <sched.h> only declares them when
+_GNU_SOURCE is defined, and it must be defined before *any* libc header is pulled in - defining it
+just above '#include <sched.h>', as platform.h does, is too late once <pthread.h> has already
+included sched.h and left its include guard set. makemake.sh passes -D_GNU_SOURCE so ordinary
+builds are fine, but this file should not depend on that: the Clang-Tidy and GCC-analyzer CI jobs
+compile it with their own flag sets, where it failed with 'CPU_SETSIZE undeclared'. */
+#ifndef _GNU_SOURCE
+	#define _GNU_SOURCE
+#endif
+
 #include "align.h"
 #include "util.h"
 #include "factor.h"	// Needed for twopmodq64() prototype

--- a/src/util.c
+++ b/src/util.c
@@ -1817,6 +1817,16 @@ exit(0);
 	ASSERT(MAX_THREADS > 0,"Mlucas.c: MAX_THREADS must be > 0");
 
 	printf("INFO: System has %d available processor cores.\n", MAX_THREADS);
+	/* If some external agency (taskset/numactl/systemd/batch scheduler/container cpuset) has restricted
+	this process's CPU-affinity mask, say so: the default core set is then taken from that mask rather
+	than from the system-wide core count, so the user needs to see which of the two is in play. Note we
+	deliberately leave MAX_THREADS as the system-wide logical-CPU count, since it doubles as the upper
+	bound on legal -cpu core *indices* - which remain OS-wide indices, not offsets into the mask:
+	*/
+	uint64 avail_cores[MAX_CORES>>6];
+	int navail_cores = get_avail_cores(avail_cores,MAX_CORES>>6);
+	if(navail_cores > 0 && navail_cores < MAX_THREADS)
+		printf("INFO: Inherited CPU-affinity mask permits use of only %d of those cores.\n", navail_cores);
 
 	/* Test Multithreading via simple pthreading self-test: */
   #if 0
@@ -8910,6 +8920,65 @@ exit(0);
 
   #endif
 
+	/* Does this platform give us a way to ask which CPUs the process is actually *allowed* to use?
+	sched_getaffinity() is Linux-specific, so the guard here deliberately mirrors the one around the
+	sched_setaffinity() call in threadpool.c::worker_thr_routine(), ensuring the two always agree
+	about which builds do OS-level thread pinning by logical-CPU index:
+	*/
+  #if defined(OS_TYPE_LINUX) && !defined(OS_TYPE_WINDOWS) && !defined(__MINGW32__)
+	#define MLUCAS_HAVE_GETAFFINITY	1
+  #else
+	#define MLUCAS_HAVE_GETAFFINITY	0
+  #endif
+
+	/* Snapshot the set of logical CPUs this process is *permitted* to run on, i.e. the CPU-affinity
+	mask it inherited from its parent. A user or job scheduler may have restricted that mask - via
+	taskset, numactl, systemd 'CPUAffinity=', SLURM, a container runtime - in which case the
+	system-wide online-CPU count returned by get_num_cores() says nothing about where we may run.
+
+	Fills avail[0:nword-1], a bitmap indexed exactly as the global CORE_SET is, and returns the number
+	of permitted CPUs. A return value of 0 (avail[] all-zero) means the mask could not be determined,
+	and must be treated by callers as "no information", *not* as "no CPUs".
+	*/
+	int get_avail_cores(uint64 avail[], int nword)
+	{
+		int i, nset = 0;
+		for(i = 0; i < nword; i++) { avail[i] = 0ull; }
+	#if MLUCAS_HAVE_GETAFFINITY
+		cpu_set_t cpu_set;
+		CPU_ZERO(&cpu_set);
+		// Fails e.g. on a machine with more CPUs than CPU_SETSIZE, or under a libc/sandbox lacking the
+		// syscall; in that case fall back to the legacy whole-machine behavior rather than guessing:
+		if(sched_getaffinity(0, sizeof(cpu_set), &cpu_set) != 0)
+			return 0;
+		for(i = 0; i < CPU_SETSIZE && i < (nword<<6); i++) {
+			if(CPU_ISSET(i, &cpu_set)) { avail[i>>6] |= 1ull<<(i&63);	++nset; }
+		}
+	  #if INCLUDE_HWLOC
+		/* The above is in OS logical-CPU indices, but in an hwloc build with per-thread binding support
+		threadpool.c consumes CORE_SET bit indices as hwloc *logical* PU indices
+		(hwloc_get_obj_by_type(...,HWLOC_OBJ_PU,i)) - an ordering which differs from the OS one on any
+		SMT machine. Translate, so this bitmap is always in the same index space as CORE_SET:
+		*/
+		if(HWLOC_AFFINITY && nset) {
+			uint64 lmap[nword];
+			int nl = 0;
+			for(i = 0; i < nword; i++) { lmap[i] = 0ull; }
+			for(i = 0; i < (nword<<6); i++) {
+				if(!(avail[i>>6] & (1ull<<(i&63)))) continue;
+				hwloc_obj_t obj = hwloc_get_pu_obj_by_os_index(hw_topology, (unsigned)i);
+				if(obj && obj->logical_index < (unsigned)(nword<<6)) {
+					lmap[obj->logical_index>>6] |= 1ull<<(obj->logical_index&63);	++nl;
+				}
+			}
+			// Only adopt the translated map if every permitted CPU mapped to a PU in the loaded topology:
+			if(nl == nset) { for(i = 0; i < nword; i++) { avail[i] = lmap[i]; } }
+		}
+	  #endif
+	#endif
+		return nset;
+	}
+
 	// Simple struct to pass multiple args to the loop/join-test thread function:
 	struct do_loop_test_thread_data{
 		int tid;
@@ -9146,21 +9215,34 @@ exit(0);
 	{
 		int ncpu = 0, lo = -1,hi = lo,incr = 1, i,bit,word;
 		char *char_addr = istr, *endp;
+		unsigned long utmp;
 		ASSERT(char_addr != 0x0, "Null input-string pointer!");
 		size_t len = strlen(istr);
 		if(len == 0) return 0;	// Allow 0-length input, resulting in no-op
 		ASSERT(len <= STR_MAX_LEN, "Excessive input-substring length!");
-		lo = strtoul(char_addr, &endp, 10);	ASSERT(lo >= 0, "lo-substring not a valid nonnegative number!");
+		/* NB: strtoul() returns an unsigned long, so assigning its result straight into an int silently
+		truncates any value >= 2^32 - '-cpu 4294967299' used to quietly bind to core 3, the truncated
+		index also sliding past the range check in parseAffinityString() below. And strtoul() converting
+		no digits at all is not an error, it just leaves endp == the input pointer - which is how '-cpu 0:'
+		used to be silently taken to mean '-cpu 0'. So for each field of the triplet, require that some
+		digits were actually consumed and that the value is a legal core index, *before* narrowing to int:
+		*/
+		utmp = strtoul(char_addr, &endp, 10);
+		ASSERT(endp != char_addr && utmp < MAX_CORES, "lo-substring of core-affinity-triplet not a valid core index in [0,MAX_CORES)!");
+		lo = (int)utmp;
 		if(*endp) {
 			ASSERT(*endp == ':', "Non-colon separator in core-affinity-triplet substring!");
 			char_addr = endp+1;
-			hi = strtoul(char_addr, &endp, 10);
+			utmp = strtoul(char_addr, &endp, 10);
+			ASSERT(endp != char_addr && utmp < MAX_CORES, "hi-substring of core-affinity-triplet not a valid core index in [0,MAX_CORES)!");
+			hi = (int)utmp;
 			ASSERT(hi >= lo, "hi-substring not a valid number >= lo!");
 			if(*endp) {
 				ASSERT(*endp == ':', "Non-colon separator in core-affinity-triplet substring!");
 				char_addr = endp+1;
-				incr = strtoul(char_addr, &endp, 10);
-				ASSERT(incr > 0, "incr-substring not a valid positive number!");
+				utmp = strtoul(char_addr, &endp, 10);
+				ASSERT(endp != char_addr && utmp > 0 && utmp < MAX_CORES, "incr-substring of core-affinity-triplet not a valid positive number < MAX_CORES!");
+				incr = (int)utmp;
 				ASSERT(*endp == 0x0, "Non-numeric increment substring in core-affinity-triplet substring!");
 			} else {
 				// If increment (third) argument of triplet omitted, default to incr = 1.
@@ -9265,6 +9347,80 @@ exit(0);
 			fprintf(stderr,"ERROR: %d cores in user-specified core set have index exceeding those of available logical cores = 0-%d!\n",core_count_oflow,MAX_THREADS-1);
 			exit(EXIT_FAILURE);
 		}
+		/* Lastly, warn about any specified core lying outside the CPU-affinity mask this process inherited
+		(taskset, numactl, systemd 'CPUAffinity=', SLURM, container cpuset). An explicit user-specified core
+		set still wins - overriding the inherited placement is the documented point of the -cpu flag - but
+		the resulting per-worker sched_setaffinity() will then either widen the process's mask back out,
+		silently defeating the operator's placement, or (under a cgroup cpuset) fail with EINVAL and leave
+		that worker unpinned. Neither outcome is otherwise apparent from the run's output:
+		*/
+		uint64 avail[MAX_CORES>>6];
+		if(get_avail_cores(avail,MAX_CORES>>6) > 0) {
+			nc = 0;
+			for(i = 0; i < MAX_CORES; i++) {
+				word = i>>6; bit = i & 63;
+				if((CORE_SET[word] & (1ull<<bit)) && !(avail[word] & (1ull<<bit))) {
+					if(!nc++) { fprintf(stderr,"WARN: Specified core set includes logical CPUs outside this process's inherited CPU-affinity mask: "); }
+					fprintf(stderr,"%u.",i);
+				}
+			}
+			if(nc) { fprintf(stderr,"\n      Pinning threads there overrides the externally-imposed affinity, or fails outright under a cgroup cpuset.\n"); }
+		}
+	}
+
+	/******************/
+	/* Set the default thread-affinity core set, i.e. the one used when the user specified no explicit
+	core set: either no affinity-related command-line flag at all, or just '-nthread [ncore]'.
+
+	This used to simply pin to logical CPUs [0:ncore-1], which silently discards any externally-imposed
+	CPU-affinity mask: the worker threads sched_setaffinity() themselves onto CPUs 0,1,...,ncore-1 no
+	matter where the operator placed the process, so the standard practice of running several instances
+	pinned to disjoint core groups ('taskset -c 0-3', 'taskset -c 4-7', ...) collapses every instance
+	onto the same low-numbered CPUs, with full contention and no diagnostic. Take the core set from the
+	first [ncore] CPUs of the process's *inherited* affinity mask instead. For a process whose mask is
+	unrestricted - the overwhelming majority of runs - those are exactly CPUs [0:ncore-1], hence the
+	resulting CORE_SET bitmap, the printed core list and NTHREADS are all unchanged.
+	*/
+	void setDefaultAffinity(uint32 ncore)
+	{
+		char ostr[STR_MAX_LEN+1];
+		uint64 avail[MAX_CORES>>6];
+		int i,j,lo,hi, nchar = 0, navail = get_avail_cores(avail,MAX_CORES>>6);
+		int use_mask = (navail > 0);
+		uint32 nc = 0;
+		ASSERT((int)ncore > 0, "#threads must be > 0!");
+		if(use_mask && ncore > (uint32)navail) {
+			if(navail < MAX_THREADS) {
+				// Oversubscribing an externally-restricted mask needs its own diagnostic, since the generic
+				// "exceeds #available logical cores" error issued by parseAffinityString() cites the
+				// machine-wide core count and so reads as a non sequitur here:
+				fprintf(stderr,"ERROR: #threads [ = %u] exceeds the %d logical CPUs permitted by this process's inherited CPU-affinity mask!\n",ncore,navail);
+				exit(EXIT_FAILURE);
+			}
+			// Mask unrestricted, user simply asked for more threads than the machine has cores: fall back to
+			// the legacy [0:ncore-1] core set so parseAffinityString() issues its usual error, unchanged:
+			use_mask = FALSE;
+		}
+		// Emit the first [ncore] permitted CPU indices as a comma-separated list of lo[:hi] triplets,
+		// collapsing runs of consecutive indices so the common cases stay well within STR_MAX_LEN:
+		for(i = 0; use_mask && i < MAX_CORES && nc < ncore; i++) {
+			if(!(avail[i>>6] & (1ull<<(i&63)))) continue;
+			lo = hi = i;	++nc;
+			while(nc < ncore && (hi+1) < MAX_CORES && (avail[(hi+1)>>6] & (1ull<<((hi+1)&63)))) { ++hi;	++nc; }
+			if(lo == hi)
+				j = snprintf(ostr+nchar,sizeof(ostr)-nchar,"%s%d"   ,(nchar ? "," : ""),lo);
+			else
+				j = snprintf(ostr+nchar,sizeof(ostr)-nchar,"%s%d:%d",(nchar ? "," : ""),lo,hi);
+			if(j < 0 || (size_t)(nchar+j) >= sizeof(ostr)) {
+				fprintf(stderr,"ERROR: Inherited CPU-affinity mask is too fragmented to encode as an affinity string ... use the -cpu flag to specify a core set explicitly.\n");
+				exit(EXIT_FAILURE);
+			}
+			nchar += j;	i = hi;
+		}
+		// nc = 0, i.e. no usable mask info (non-Linux build, or sched_getaffinity failed, or the
+		// unrestricted-mask-oversubscribed case above): legacy [0:ncore-1] core set
+		if(!nc) { snprintf(ostr,sizeof(ostr),"0:%u",ncore-1); }
+		parseAffinityString(ostr);
 	}
 
 #endif	// MULTITHREAD ?

--- a/src/util.h
+++ b/src/util.h
@@ -205,6 +205,7 @@ double	mlucas_getOptVal(const char*fname, char*optname);
 #ifdef MULTITHREAD
 
 	int		get_num_cores(void);
+	int		get_avail_cores(uint64 avail[], int nword);
 	int		test_pthreads(int ncpu, int verbose);
 	void* 	ex_loop(void* data);
 	void*	PrintHello(void *threadid);
@@ -215,6 +216,7 @@ double	mlucas_getOptVal(const char*fname, char*optname);
   #endif
 	uint32	parseAffinityTriplet(char*istr, int hwloc_topo);
 	void	parseAffinityString(char*istr);
+	void	setDefaultAffinity(uint32 ncore);
 
 #endif	// MULTITHREAD ?
 


### PR DESCRIPTION
## The bug

Mlucas silently discards any externally-imposed CPU-affinity mask, so several instances pinned to disjoint core groups all collapse onto the same low-numbered CPUs and fight each other.

Measured on unmodified `main` (`590a1a6`) via `/proc/<pid>/task/*/status`:

```
$ taskset -c 9 ./Mlucas -fft 3072 -iters 100000        # no affinity flag at all
  tid 1131824  Cpus_allowed_list: 9        <- main thread (does no FFT work)
  tid 1131866  Cpus_allowed_list: 0        <- worker
  tid 1131872  Cpus_allowed_list: 0        <- worker

$ taskset -c 8-11 ./Mlucas -fft 3072 -iters 100000 -nthread 4
  tid 1132059  Cpus_allowed_list: 8-11     <- main
  workers:     0, 1, 2, 3, 0, 1, 2, 3
```

Two concurrent instances, `taskset -c 0-3` and `taskset -c 8-11`, both `-nthread 4`:

```
BEFORE: instance A worker cpus: 0 1 2 3
        instance B worker cpus: 0 1 2 3     <- complete overlap
```

Note the main thread *is* correctly placed, so `ps`/`top`/`taskset -p` show the process where the operator put it while the actual FFT work runs elsewhere.

## Root cause

- `src/Mlucas.c:494-499` — with no affinity flag: `NTHREADS = 1`, then `sprintf(cbuf,"0:%d",NTHREADS-1); parseAffinityString(cbuf)` — the core set is hardcoded to logical CPUs `[0:NTHREADS-1]`.
- `src/Mlucas.c:4241-4243` — `-nthread N` synthesises the same `"0:N-1"` string. `help.txt` documents `-nthread` only as a thread count.
- `src/threadpool.c:337-381` — each worker then unconditionally `sched_setaffinity()`es itself to one of those raw CPU indices. An unprivileged process may *widen* its own mask, so that call **succeeds** and the worker escapes whatever mask `taskset`/`numactl`/systemd `CPUAffinity=`/SLURM/a container imposed. (Under a cgroup cpuset it instead fails `EINVAL` and the worker runs unpinned — plus a `perror` per worker.)
- `src/util.c:8875-8908` — `get_num_cores()` returns `sysconf(_SC_NPROCESSORS_ONLN)`, the machine-wide online-CPU count, and never consults `sched_getaffinity()`, so nothing in the startup path knows the mask was restricted. `-nthread 16` inside a 4-CPU cpuset was accepted without comment.

For an explicit `-cpu`/`-core` flag, overriding the inherited placement is the documented point of the flag. The two paths above are the *implicit* ones, which is what makes this a defect rather than a feature.

## The fix

- New `get_avail_cores()` (`src/util.c`) snapshots the process's inherited affinity mask via `sched_getaffinity()` into a `CORE_SET`-indexed bitmap, returning its population count — or `0`, meaning "could not determine", which every caller treats as "no information" and falls back to today's behaviour.
- New `setDefaultAffinity(ncore)` builds the default core set from the **first `ncore` CPUs of that mask** rather than from `[0:ncore-1]`, emitting them as a run-length-compressed affinity string so the existing `parseAffinityString()` validation, printing and `NTHREADS` assignment are all reused unchanged. Both implicit paths now call it.
- An explicit `-cpu`/`-core` core set still wins, but naming a core outside the inherited mask now draws a warning rather than silently widening the mask or silently failing.
- `MAX_THREADS` is deliberately **left** as the machine-wide count, because it doubles as the upper bound on legal `-cpu` core *indices*; narrowing it to the mask's popcount would make `taskset -c 8-11 ./Mlucas -cpu 8:11` fail its own range check. The restriction is instead surfaced as an extra startup `INFO` line and as a distinct error when `-nthread` oversubscribes the mask.

### Also fixed: two smaller `-cpu` parse defects (`src/util.c:9147-9165`)

`strtoul()`'s `unsigned long` return was assigned straight into `int lo,hi,incr`, so indices >= 2^32 truncated and slipped past both the `ASSERT(lo>=0)`/`ASSERT(hi>=lo)` checks and `parseAffinityString()`'s `MAX_THREADS` range check:

| spec | before | after |
|---|---|---|
| `-cpu 4294967299` | `Set affinity for the following 1 cores: 3.` | rejected |
| `-cpu 4294967296` | `... 1 cores: 0.` | rejected |
| `-cpu 8589934595` | `... 1 cores: 3.` | rejected |
| `-cpu 0:7:4294967297` | `... 8 cores: 0.1.2.3.4.5.6.7.` (incr truncated to 1) | rejected |
| `-cpu 0:` | `... 1 cores: 0.` (silently meant `-cpu 0`) | rejected |

And a field converting no digits at all was not treated as an error, hence `-cpu 0:` silently meaning `-cpu 0`. Each field is now range-checked as an `unsigned long`, and required to actually contain digits, before being narrowed to `int`.

## Verification

Host: 8c/16t Comet Lake, gcc 16.1.1, AVX2 (no AVX-512 hardware).

### After the fix — `Cpus_allowed_list`

```
taskset -c 9 ./Mlucas                    -> main 9    ; workers 9, 9
taskset -c 8-11 ./Mlucas -nthread 4      -> main 8-11 ; workers 8, 9, 10, 11
taskset -c 1,3,5,7 ./Mlucas -nthread 4   -> main 1,3,5,7 ; workers 1, 3, 5, 7
```

Two concurrent instances, `taskset -c 0-3` and `taskset -c 8-11`, both `-nthread 4`:

```
AFTER:  instance A worker cpus: 0 1 2 3
        instance B worker cpus: 8 9 10 11    <- disjoint
```

`-cpu` inside the mask (`taskset -c 8-11 ... -cpu 8:11`) is honoured, workers on 8-11, no warning. `-cpu` outside the mask (`taskset -c 8-11 ... -cpu 0:3`) is still honoured — the user asked for it — but now says so:

```
WARN: Specified core set includes logical CPUs outside this process's inherited CPU-affinity mask: 0.1.2.3.
      Pinning threads there overrides the externally-imposed affinity, or fails outright under a cgroup cpuset.
```

### No external mask: byte-identical to unmodified main

This is the regression that matters, since it is what every existing user sees. Full stdout+stderr compared against a `590a1a6` build, only the `free system RAM` line filtered out (it varies between any two runs of the *same* binary):

```
IDENTICAL  args=''                     (84 lines)   Set affinity for the following 1 cores: 0.
IDENTICAL  args='-nthread 4'           (84 lines)   ... 4 cores: 0.1.2.3.
IDENTICAL  args='-nthread 16'          (85 lines)   ... 16 cores: 0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.
IDENTICAL  args='-nthread 17'          (16 lines)   [same ERROR text as before]
IDENTICAL  args='-nthread 1'           (84 lines)
IDENTICAL  args='-cpu 0:3'             (84 lines)
IDENTICAL  args='-cpu 0:6:2'           (84 lines)   ... 4 cores: 0.2.4.6.
IDENTICAL  args='-cpu 0:3,8:11'        (85 lines)   ... 8 cores: 0.1.2.3.8.9.10.11.
IDENTICAL  args='-cpu 15'              (84 lines)
IDENTICAL  args='-cpu 16'              (16 lines)   [same ERROR text as before]
IDENTICAL  args='-cpu 0:14:2,1:15:2'   (85 lines)
```

Same core set, same `NTHREADS`, same error messages. The same sweep is also byte-identical in a `use_hwloc` build.

The one intentional difference on an unrestricted machine is `-nthread 0`, previously an incidental `Assertion 'hi >= lo' failed: hi-substring not a valid number >= lo!` (from the synthesised string `"0:-1"`), now `Assertion '(int)ncore > 0' failed: #threads must be > 0!`. Both abort; the new message names the actual problem.

### Builds and self-test

- Clean `bash makemake.sh avx2` and `bash makemake.sh nosimd`: zero errors. No new compiler warnings — `-Wall -Wextra` on `util.c`/`Mlucas.c`/`threadpool.c` produces the same set as baseline (the `Mlucas.c:999` `-Wstringop-truncation` and the `util.c` `-Wsign-compare`/`-Wunused-parameter` hits are all pre-existing).
- `obj_avx2/Mlucas -s tt`: Res64s match reference values, including 13K=`E3BC90B0E652C7C0`, 14K=`DB8E39C67F8CCA0A`, 15K=`B3C5A1C03E26BB17`.

### Portability guarding

`sched_getaffinity()` is Linux-specific, so it sits behind `MLUCAS_HAVE_GETAFFINITY`, whose guard deliberately mirrors the one around the `sched_setaffinity()` call in `threadpool.c::worker_thr_routine()` — the two therefore always agree about which builds do OS-level pinning by CPU index. On macOS, Windows/MinGW, FreeBSD and OpenBSD, `get_avail_cores()` returns 0 and every caller falls back to the pre-existing `[0:ncore-1]` behaviour, exactly as today. I compile-checked that non-Linux arm by forcing the guard off (clean, no new warnings), but **I have not run** macOS, Windows, FreeBSD or OpenBSD builds.

In a `use_hwloc` build, `threadpool.c:344-367` consumes `CORE_SET` bit indices as hwloc *logical* PU indices rather than OS indices, so `get_avail_cores()` translates the mask into that index space via `hwloc_get_pu_obj_by_os_index()`. Verified on a real `makemake.sh avx2 use_hwloc` build: `taskset -c 8-11 ./Mlucas -nthread 4` went from workers on OS CPUs 0,8,1,9 (hwloc logical 0-3, i.e. escaping the mask) to workers on 8,9,10,11. This deliberately leaves the separate, pre-existing question of which index space `-cpu` itself denotes completely untouched and unresolved.

### Not tested

macOS/Windows/FreeBSD/OpenBSD runtime (compile-guarded, see above), and the cgroup-cpuset sub-case — where `sched_setaffinity()` to an out-of-cpuset CPU returns `EINVAL` — which I could not create unprivileged on this host.

## Relation to existing work

- **Does not overlap PR #140.** I checked with `gh pr diff 140`: that bounds the `CORE_SET` *bitmap* word index (`ASSERT(word < (MAX_CORES>>6))` at what is `util.c:9259` there) plus two asm clobber lists. This PR touches `util.c:9147-9165` (the `strtoul` field parsing) and adds new functions; no shared lines, and the two land cleanly in either order. As a side effect the new parse-time `< MAX_CORES` bound also rejects `-cpu 0:2147483647` before the bitmap write, so the two fixes are complementary — #140 remains the correct defence-in-depth fix at the write site.
- **Not issue #59 / PR #110.** Those are about *adding* affinity-setting support on Windows and macOS; this is about Linux affinity being set too aggressively. No claim to resolve them.
- **Plausibly relevant to issue #117** ("Improve scaling performance/throughput with multiple threads"). If any of the reported poor multi-worker throughput came from `taskset`-pinned instances, they were in fact all sharing CPUs `0..N-1`. I have not tried to reproduce #117's specific numbers, so this is a hypothesis, not a claimed fix — but it is a mechanism that would produce exactly that symptom.

No GitHub issue covers the main defect, so this PR intentionally has no `Resolves #N`.
