### PR TITLE
Make Fermat-mod cofactor-PRP runs work end-to-end

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1219,6 +1219,11 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 							// offsets used to prevent the shift count from modding to 0 as a result of repeated doublings (mod 2^m)
 		} else if(TEST_TYPE == TEST_TYPE_PRP) {
 			ASSERT(KNOWN_FACTORS[0] != 0, "Fermat-mod PRP test implies a PRP-CF run, but no known-factors provided!");
+			maxiter -= 1;	// Fermat-mod PRP means PRP-CF, whose full-modulus phase is just a Pepin test, i.e. p-1
+							// mod-squarings of the seed. The single further mod-squaring which converts that
+							// Euler/Pepin residue into the base-3 Fermat-PRP residue [A] needed by the Suyama
+							// test is done inside Suyama_CF_PRP(), not here. Cf. the (ilo >= p-1) PRP-phase-
+							// already-complete test further below, which encodes the same p-1 convention.
 			RES_SHIFT = 0ull;	// Must set = 0 here to make sure BASE_MULTIPLIER_BITS array gets set = 0 below
 		} else if(TEST_TYPE == TEST_TYPE_PM1) {
 			// Compute stage 1 prime-powers product, store in PM1_S1_PRODUCT, store #bits of same in PM1_S1_PROD_BITS:
@@ -1793,8 +1798,14 @@ READ_RESTART_FILE:
 	} else if(KNOWN_FACTORS[0] != 0ull) {	// PRP-CF - but if ilo < (p-1) it's in the PRP-phase, handle like regular PRP run until that completes
 		ASSERT(TEST_TYPE == TEST_TYPE_PRP,"One or more known-factors in workfile entry requires a PRP= assignment type!");
 		if( ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) && (ilo >= p))
-		 || ((MODULUS_TYPE == MODULUS_TYPE_FERMAT) && (ilo >= p-1)) )
+		 || ((MODULUS_TYPE == MODULUS_TYPE_FERMAT) && (ilo >= p-1)) ) {
+			ihi = ilo;	// The cofactor-PRP code below the PM1_STAGE2 label reads the count of completed
+						// mod-squarings out of ihi, that being where the iteration loop leaves it (ihi ==
+						// maxiter) for a run which finishes its full-modulus phase in this same invocation.
+						// Here we are resuming from a savefile whose residue is already the final one, so
+						// the loop is skipped and ihi still holds the next-checkpoint value set on read.
 			goto PM1_STAGE2;	// The CF-handling is a clause of the if/else beginning at this label
+		}
 	}
 
 	for(;;)
@@ -2484,7 +2495,7 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		// v21: PRP-CF: Cofactor-PRP test applies to primality/Fermat (which we follow by 1 additional mod-squaring
 		// to convert the base^((N-1)/2) Pepin/Euler-PRP residue to a base^(N-1) Fermat-PRP one) and PRP/Mersenne residues:
 		if(KNOWN_FACTORS[0])	// This is automatically false for LL-test
-			isprime = Suyama_CF_PRP(p, &Res64, nfac, a,b,arrtmp, ilo, func_mod_square, n, scrnFlag, &tdiff, gcd_str);
+			isprime = Suyama_CF_PRP(p, &Res64, nfac, a,b,arrtmp, ihi, func_mod_square, n, scrnFlag, &tdiff, gcd_str);
 
 		// JSON-formatted result report for LL/PRP/cofactor-PRP tests of M(p):
 		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
@@ -3314,12 +3325,12 @@ Example: N = M(109) = 2^109-1 = 745988807.870035986098720987332873; let F = 7459
 	B = 3^(F-1) == 610082383855388688949555345767473 (mod N), and we verify that (A - B) == 0 (mod C), thus C is a PRP.
 Similarly, if we let A' = 3^N == 3.A (mod N) and B' = 3^F == 3.B (mod N), that also satisfies (A' - B') == 0 (mod C).
 */
-uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
+uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 nsquares,
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 	int n, int scrnFlag, double *tdiff, char *const gcd_str)
 {
 	uint64 *ai = (uint64 *)a, *bi = (uint64 *)b;	// Handy 'precast' pointers
-	uint32 i,j,k, isprime, ierr = 0, ihi, fbits,lenf;
+	uint32 i,j,k, isprime, ierr = 0, ilo,ihi, fbits,lenf;
 	uint32 kblocks = n>>10, npad = n + ( (n >> DAT_BITS) << PAD_BITS );	// npad = length of padded data array
 	uint64 itmp64, Res35m1, Res36m1;	// Res64 from original PRP passed in via pointer; these are locally-def'd
 	cbuf[0] = '\0';
@@ -3329,8 +3340,8 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	// Pepin-test output = P, vs Mersenne-PRP (type 1) residue = A; thus only need an initial mod-squaring for:
 	// the former. Compute Fermat-PRP residue [A] from Euler-PRP (= Pepin-test) residue via a single mod-squaring:
 	if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
-		ASSERT(ilo == p-1, "Fermat-mod cofactor-PRP test requires p-1 mod-squarings!");
-		snprintf(cbuf,sizeof(cbuf),"Doing one mod-%s squaring of iteration-%u residue [Res64 = %016" PRIX64 "] to get Fermat-PRP residue\n",PSTRING,ilo,*Res64);
+		ASSERT(nsquares == p-1, "Fermat-mod cofactor-PRP test requires p-1 mod-squarings!");
+		snprintf(cbuf,sizeof(cbuf),"Doing one mod-%s squaring of iteration-%u residue [Res64 = %016" PRIX64 "] to get Fermat-PRP residue\n",PSTRING,nsquares,*Res64);
 		mlucas_fprint(cbuf,1);
 		ilo = 0;	ihi = ilo+1;	// Have checked that savefile residue is for a complete PRP test, so reset iteration counter
 		BASE_MULTIPLIER_BITS[0] = 0ull;
@@ -3380,7 +3391,15 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	ilo = 0;	ihi = fbits-1;	// LR modpow; init b[0] = PRP_BASE takes cares of leftmots bit
 	RES_SHIFT = 0ull;	// Zero the residue-shift so as to not have to play games with where-to-inject-the-initial-seed
 	mi64_brev(BASE_MULTIPLIER_BITS,ihi);	// bit-reverse low [ihi] bits of BASE_MULTIPLIER_BITS:
-/*B*/	ierr = func_mod_square(b, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, TRUE, 0x0);
+	// update_shift *must* be False for this step: BASE_MULTIPLIER_BITS here holds the BRed modpow exponent
+	// (F-1), not the random-bit array of the shifted-residue scheme, and fermat_mod_square() folds one bit of
+	// that array into RES_SHIFT per autosquare. With update_shift = True the RES_SHIFT we just zeroed thus went
+	// nonzero on the first set exponent bit - a shift the residue does not actually carry, since here a set bit
+	// means multiply-by-PRP_BASE (3), not the doubling the shift-tracking assumes - and the run then aborted in
+	// any carry routine which rejects shifted residues, i.e. every leading FFT radix < 16. [The final readout
+	// escaped corruption only by an accident of Fermat arithmetic: every prime factor of F[m] == 1 (mod 2^(m+2)),
+	// so F-1 == 0 (mod 2^m = 2^p), and RES_SHIFT - which the loop mod-doubles by p - lands back on 0.]
+/*B*/	ierr = func_mod_square(b, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, FALSE, 0x0);
 	if(ierr) {
 		snprintf(cbuf,sizeof(cbuf),"Error of type[%u] = %s on iteration %u of mod-squaring chain ... aborting\n",ierr,returnMlucasErrCode(ierr),ROE_ITER);
 		mlucas_fprint(cbuf,0); ASSERT(0,cbuf);

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -87,7 +87,7 @@ int		cfgNeedsUpdating(const char *p_in_line);
 const char *returnMlucasErrCode(uint32 ierr);
 void	printMlucasErrCode(uint32 ierr);
 uint64 	shift_word(double a[], int n, const uint64 p, const uint64 shift, const double cy_in);
-uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
+uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 nsquares,
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 	int n, int scrnFlag, double *tdiff, char *const gcd_str);
 int		test_types_compatible(uint32 t1, uint32 t2);


### PR DESCRIPTION
## The bug

A Fermat-mod cofactor-PRP (PRP-CF) run has never been able to complete. It dies in
`Suyama_CF_PRP()` (`src/Mlucas.c`):

```
Suyama-PRP on cofactors of F16: using FFT length 8K = 8192 8-byte floats.
ERROR: Function Suyama_CF_PRP, at line 3332 of file ../src/Mlucas.c
Assertion 'ilo == p-1' failed: Fermat-mod cofactor-PRP test requires p-1 mod-squarings!
```

Reproduced on unmodified `main` (47d75d3) with

```
worktodo.txt: PRP=n/a,1,2,65536,+1,99,0,3,5,"825753601,188981757975021318420037633"
$ Mlucas -fft 8 -cpu 0 -shift 0
```

Two independent efforts hit this from opposite directions: #168 (known-factor validation)
could not build a Fermat PRP-CF end-to-end test because of it, and #174 (Fermat worktodo
FFT-length livelock) surfaced it once the livelock stopped masking it. It is pre-existing
and independent of both.

There turned out to be **two** distinct defects, both confined to the Fermat-mod PRP path.

## Root cause 1 — `maxiter` for Fermat PRP, and `ilo` vs `ihi` at the `Suyama_CF_PRP()` call

For `F[m] = 2^p + 1` the PRP-CF full-modulus phase is a Pépin test: `p-1` mod-squarings of
the seed 3, giving the Euler/Pépin residue `3^((N-1)/2) = 3^(2^(p-1))`. `Suyama_CF_PRP()`
*itself* performs the single extra mod-squaring that converts that into the base-3
Fermat-PRP residue `[A] = 3^(N-1)` — the `func_mod_square()` call it marks `/*A*/`. So the
iteration loop must stop at `p-1`.

`ernstMain()` sets `maxiter = (uint32)p` for every primality/PRP test. The Fermat
`TEST_TYPE_PRIMALITY` clause then does `maxiter -= 1;` ("Pepin-test does p-1 iterations"),
but the Fermat `TEST_TYPE_PRP` clause did not — so Fermat PRP-CF ran **one squaring too
many**. The `p-1` convention is already written down further along in `ernstMain()`, where
the PRP-phase-already-complete test guarding the `goto PM1_STAGE2` is `(ilo >= p-1)` for
Fermat vs `(ilo >= p)` for Mersenne; the two disagreed.

Second, independent half: the value passed to `Suyama_CF_PRP()` was `ilo`. On loop exit
`ilo` is the **start of the final checkpoint interval** — 60000 for F16 at the default
10000-iteration interval — because the loop's `ilo = ihi;` sits *after* its
`if(ihi == maxiter) break;`. The count of completed squarings is in `ihi`, which is exactly
what the Mersenne clause of the same function already asserts against
(`ASSERT(ihi == p, "Gerbicz-check-modified PRP-test requires p mod-squarings!")`, ~90 lines
earlier). So the Fermat assert compared the wrong variable *and* the wrong target.

Fix: `maxiter -= 1` for Fermat/PRP; pass `ihi`; rename the parameter `nsquares` so the two
conventions cannot be conflated again. The one path that *did* satisfy the old assert —
resuming a PRP-CF assignment off a completed Pépin savefile, where `ilo == p-1` exactly and
the loop is skipped via that `goto PM1_STAGE2` — is preserved by setting `ihi = ilo` before
the goto, mirroring what the p-1 clause immediately above already does in the other
direction.

### Why this cannot perturb plain Pépin

A plain Pépin test is `TEST_TYPE_PRIMALITY`, a different clause of the same if/else, which
has always done its own `maxiter -= 1`. Nothing in this patch is reachable from it. Verified
empirically below (byte-identical savefile), not just argued.

## Root cause 2 — the `[B]` modpow in `Suyama_CF_PRP()`

With the assert fixed, the run then died in the `B = 3^(F-1) (mod N)` modpow — the
`func_mod_square()` call `Suyama_CF_PRP()` marks `/*B*/`:

```
Fermat-PRP residue (A)     = 0X7A3617ECEEB13091,20710633406,25060016989
WARN: At line 84 of file ../src/radix8_ditN_cy_dif1.c:
CY routines with radix < 16 do not support shifted residues!
Assertion '0' failed: Error of type[12] = ERR_ASSERT on iteration 0 of mod-squaring chain
```

The `[B]` step loads the bit-reversed modpow exponent `F-1` into `BASE_MULTIPLIER_BITS` and,
two lines earlier, deliberately zeroes `RES_SHIFT` ("so as to not have to play games with
where-to-inject-the-initial-seed"). But it called `func_mod_square()` with
`update_shift = TRUE`, and `fermat_mod_square()` folds one bit of `BASE_MULTIPLIER_BITS`
into `RES_SHIFT` per autosquare (`RES_SHIFT += ((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1);`
in its per-iteration shift bookkeeping) — that array being, in Pépin mode, the random-bit
array of the shifted-residue scheme. So the just-zeroed `RES_SHIFT` went nonzero on the first
set exponent bit, describing a shift the residue does not carry (here a set bit means
multiply-by-`PRP_BASE` = 3, not the doubling the shift bookkeeping assumes), and the run
aborted in a carry routine that rejects shifted residues. Every leading FFT radix < 16 has
that `WARN`+`ERR_ASSERT` guard *except* radix 12, which has no `RES_SHIFT` rejection at all —
and small Fermat numbers use exactly those small leading radices.

Fix: pass `FALSE`. `mers_mod_square()`'s `update_shift` is a bare mod-doubling of an
already-zero `RES_SHIFT`, so Mersenne PRP-CF is bit-for-bit unaffected.

For the record on how bad this was: the final read-out escaped corruption only by an accident
of Fermat arithmetic — every prime factor of `F[m]` is `== 1 (mod 2^(m+2))`, so
`F-1 == 0 (mod 2^m = 2^p)`, and `RES_SHIFT` (mod-doubled by `p` each iteration) lands back on
0 before `convert_res_FP_bytewise()` looks at it. I confirmed this empirically rather than
assuming it: forcing the leading radix to 16 so the carry routine tolerates the bogus shift,
unpatched `main` does produce the correct `[B]`. So for the radices that do carry the guard
this is an outright abort, not silent wrongness.

## Verification

All on this box: x86-64 AVX2, gcc 16.1.1, `bash makemake.sh avx2`.

**Cofactor result cross-checked against an independent computation.** A Python big-int
oracle recomputes the entire Suyama chain from scratch (`p-1` squarings mod `2^65536+1` via
lo-hi folding, the chain cross-checked mod both known factors via Fermat's little theorem,
then `A`, `B`, `(A-B) mod N`, `C = N/F`, `(A-B) mod C`, gcd). Every quantity Mlucas prints
matches it exactly:

| quantity | oracle | Mlucas, patched |
|---|---|---|
| Pépin residue (65535 sq) | `40ABB0C5BFF05CB5, 173595305, 65390296136` | same |
| Fermat-PRP residue `[A]` | `7A3617ECEEB13091, 20710633406, 25060016989` | same |
| `3^(F-1)` residue `[B]` | `DFBA3FBD0A4A225A, 29834196943, 26702937368` | same |
| `(A-B)` Res64 / `C` Res64 | `9A7BD82FE4670E37` / `FB3D3C0858180001` | same |
| `(A-B)/C` quotient | `100594930427180778301295349973864557` | same |
| `(A-B) mod C` | `02664CA2851BBDCA, 763967994, 38394099743` | same |
| verdict | COMPOSITE, C19694, `gcd(A-B,C) = 1` | same |

The oracle's intermediate Res64s at iterations 10000…60000 also match the `.stat` log
line-for-line. The Pépin triplet `40ABB0C5BFF05CB5, 173595305, 65390296136` additionally
matches an independent GMP computation obtained separately.

Identical output from all three routes: start-from-scratch, resume-off-a-Pépin-savefile, and
with the leading radix forced from 8 to 16.

**Plain Pépin unchanged.** F16 at 8K: the `f16` savefile is **byte-identical** (`cmp`) to the
one written by unmodified `main`, and the `.stat` log is identical;
`Res64,Res35m1,Res36m1 = 40ABB0C5BFF05CB5, 173595305, 65390296136`. The F18 100-iteration
self-test writes the same `fermat.cfg` line on both builds —
`7C6B681485EB86DB, 5745147782, 50521157289` — matching the `FermVec[]` reference.

**Mersenne PRP-CF unchanged.** M150011 / 300023 at 7K, radices 28 8 16. The reported JSON
line is identical to unmodified `main` (status `C`, `res64 E501A3C0612833EC`, `res2048`,
residue-type 5, error codes), as is the whole `.stat` log apart from timings.

**Build/self-test.** Clean full `bash makemake.sh avx2`, per-category warning counts identical
to the baseline build. `obj_avx2/Mlucas -s tt` completes with 13K/14K/15K Res64
`E3BC90B0E652C7C0` / `DB8E39C67F8CCA0A` / `B3C5A1C03E26BB17`, matching reference, with only
the known 1K/2K roundoff skips (#101).

**Not tested:** AVX-512, ARM, Windows — no hardware or toolchain for those here. The touched
code is architecture-independent C with no SIMD or platform dependence.

## Two adjacent things found while verifying, deliberately *not* fixed here

1. **Heap over-read on the Mersenne PRP-CF path — now fixed by #183.** The Mersenne clause of
   `Suyama_CF_PRP()` calls `res_SH(ci, n, ...)`, passing the FFT length in doubles as the
   mi64 **limb** count; it should be `(p+63)>>6`. For M150011 at 7K that reads 7168 limbs out
   of an `arrtmp` allocated ~4700 in `ernstMain()`, i.e. roughly 19 KB past the end, so the
   `Res35m1`/`Res36m1` of the printed `"Fermat-PRP residue (A)"` line are garbage-dependent
   and **nondeterministic on unmodified `main`** — three baseline runs of the same assignment
   gave `16004820652/27562695253`, `31756549944/45355397206` and `9053850641/46588539587`.
   The reported `res64` and the cofactor verdict are unaffected (they come from other
   variables), so this is a diagnostic-print and memory-safety defect rather than a wrong
   answer. It is the subject of #183, opened separately; it should also be ASan-visible in CI.

2. **Fermat PRP-CF cannot resume inside the last checkpoint interval.** `ernstMain()`
   deliberately suppresses the final-residue savefile write for cofactor-PRP runs ("Do not
   save a final residue unless p-1"). That is correct for Mersenne (whose final residue is
   the `p+1`-squaring one needing mod-div post-processing), but it means the `p-1`-squaring
   Pépin residue a Fermat PRP-CF restart would want is never checkpointed, so an interruption
   after the last checkpoint costs one interval of rework. Wasteful, not wrong, and identical
   in shape to the Mersenne behaviour — left alone rather than widened into this PR. The
   documented reuse route (run `Fermat,Test=m` first, then add the `PRP=` cofactor entry) does
   resume correctly, and is covered by the tests above.

Adjacent open PRs, for sequencing: #168 (known-factor validation) and #174 (Fermat worktodo
FFT-length livelock). No changes from either are included here; the diff does not overlap
theirs.
