### PR TITLE
radix1024: work around GCC 16 AVX-512 miscompile that silently zeros the residue

### DIFF
--- a/src/radix1024_ditN_cy_dif1.c
+++ b/src/radix1024_ditN_cy_dif1.c
@@ -3085,6 +3085,28 @@ void radix1024_dit_pass1(double a[], int n)
 		#error pthreaded carry code requires GCC build!
 	#endif
 
+	// GCC 16 + AVX-512 + -O3 + LTO miscompiles this function: the carry step returns an
+	// all-zero residue array (and a correspondingly zero roundoff error, so nothing warns),
+	// i.e. a silently wrong result, for every FFT length whose leading radix is 1024 - that
+	// is radix_set 0 of every power-of-2 FFT length from 1M on up, plus 1024K radix_set 1.
+	// The data reaching this function are correct (verified by checksumming the residue array
+	// on both sides of the mers_mod_square dispatch), so the fault is inside this function.
+	// Reproduced under Intel SDE (-skx and -spr) with gcc 16.1.1; the identical source is
+	// clean with gcc 11.4.0, gcc 15.3.0 and clang 22.1.8, and clean with gcc 16.1.1 at -O1,
+	// at -O2, or at -O3 with LTO disabled. A whole-program UBSan build at the exact failing
+	// configuration is clean (887 __ubsan call sites in this function alone), and the alignment
+	// precondition the wtsinit macro relies on is provably satisfied here - wt1 is 128-byte
+	// aligned via ALIGN_DOUBLE, col is a multiple of 1024 and ii of 16, so &wt1[col+ii] is
+	// 64-byte aligned - yet that build's vmovaps on &wt1[col+ii] faults on a 16-mod-64 address,
+	// i.e. a state unreachable from valid inputs. The exact gcc-16 defect was not isolated, so
+	// this caps just this one function at -O2 rather than pretending to fix the generated code.
+	// Compiler- and ISA-gated to keep the normal -O3 codegen everywhere else, since this is a
+	// hot path at the mainstream 1M-8M FFT lengths. The upper version bound is deliberately
+	// open-ended: a silently wrong residue is not an acceptable risk to take on an untested
+	// future gcc.
+#if defined(USE_AVX512) && defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 16)
+	__attribute__((optimize("O2")))
+#endif
 	void*
 	cy1024_process_chunk(void*targ)	// Thread-arg pointer *must* be cast to void and specialized inside the function
 	{


### PR DESCRIPTION
## The bug

Built with **gcc 16.1.1** at `-O3` with `-flto` for **AVX-512**, Mlucas returns an **all-zero residue** —
and a correspondingly **zero roundoff error, so nothing warns** — for every FFT length whose leading radix
is 1024:

```
$ ./Mlucas -m 15000017 -fftlen 1024 -radset 0 -shift 0 -iters 100
Using complex FFT radices      1024        16        32
Res64: 0000000000000000. AvgMaxErr = 0.000000000. MaxErr = 0.000000000.   <- wrong, and silent
```

versus the correct result from the AVX2 build of the same tree and the same compiler:

```
Res64: 34B4CFB331D348C2. AvgMaxErr = 0.000588553. MaxErr = 0.000732422.
```

`rvec[0] == 1024` in `get_fft_radices.c` is **radix_set 0 of every power-of-2 FFT length from 1M to
512M**, plus 1024K radix_set 1 — i.e. the default first-choice radix set for the entire power-of-2 FFT
family, exponents from ~20M upward. Confirmed wrong at 1024K radix_sets 0 and 1 (two exponents, 15000017
and 19800083), 2048K radix_set 0 and 4096K radix_set 0.

Mitigating factor: `-s <tier>` self-tests *do* verify Res64 against the built-in tables, so a user who
runs the self-test at these lengths would see radix_set 0 fail and it would be excluded from
`mlucas.cfg`. Exposure is to an explicit `-radset 0`, to a length with no cfg entry, and to anyone who
reads a self-test failure as "this radix set isn't supported" rather than "my build is broken". (See also
#123: a self-test of a user-specified exponent verifies nothing.)

## Root cause

The fault is in the **generated code**, not in Mlucas's arithmetic.

`mers_mod_square.c` was instrumented to checksum the whole padded residue array at four points. For the
failing case (1024K radix_set 0, `-iters 1`):

```
DBG[entry     ] sumsq=1.60000000e+01  nonzero=1     a[0]=4      <- initial residue OK
DBG[post-dif1 ] sumsq=1.63840000e+04  nonzero=1024  a[0]=4      <- pass-1 forward DIF OK
DBG[post-chunks] sumsq=6.87194767e+10 nonzero=1024  a[0]=8192   <- fwd FFT + dyadic square + inv FFT OK
DBG[post-carry] sumsq=0.00000000e+00  nonzero=0     a[0]=0      <- carry routine zeroed everything
```

(The same instrumentation on the working 1024K radix_set 2 `{256,8,16,16}` gives `post-carry … nonzero=256
a[0]=14`.) Because `USE_THREADS` is unconditional in `makemake.sh`, the carry loop that actually executes
is the copy in `cy1024_process_chunk()`, and capping **just that function** at `-O2` fixes it — which pins
the fault to that function's body.

Multiplying the residue by one zero factor is also **why nothing warns**: `fracmax` measures the distance
of the inverse-weighted data from the nearest integer, and zero is exactly an integer. The
roundoff-error machinery is structurally blind to this failure mode. That is what makes it dangerous
rather than merely wrong.

## It is gcc-16-specific, and it is not an emulator artifact

This box has **no AVX-512 silicon**, so all AVX-512 runtime results are under **Intel SDE 10.8.0**. That
makes "is this real?" the first question, so it was attacked from four directions.

**1. Same emulator, same workload, four binaries — only one is wrong** (1024K radix_set 0):

| build | ISA | result |
|---|---|---|
| gcc 16.1.1 | AVX2, native (no SDE) | `34B4CFB331D348C2` ✓ |
| gcc 16.1.1 | AVX2, **under SDE -skx** | `34B4CFB331D348C2` ✓ |
| gcc 16.1.1 | **AVX-512, under SDE -skx** | `0000000000000000` ✗ |
| clang 22.1.8 | AVX-512, under SDE -skx | ✓ |
| gcc 15.3.0 | AVX-512, under SDE -skx | ✓ |
| gcc 11.4.0 | AVX-512, under SDE -skx | ✓ |
| gcc 16.1.1 | AVX (native), SSE2 (native) | ✓ |

The AVX2 binary runs the identical FFT under the identical SDE invocation and is correct; two other
compilers' AVX-512 binaries are correct under that same invocation.

**2. Not CPU-model-dependent.** `-skx` and `-spr` both give zeros. SDE emitted no
unimplemented/unsupported-instruction diagnostics in any run.

**3. Toolchain-flag dependence, which an emulator cannot explain** (all gcc 16.1.1, AVX-512, 1024K rs0):

| variant | result |
|---|---|
| `-O3 -flto=auto` (makemake.sh default) | `0000000000000000` ✗ |
| `-O3`, no LTO | ✓ |
| `-O1 -flto=auto` | ✓ |
| `-O2` on `radix1024_ditN_cy_dif1.c` only | ✓ |
| `-fno-lto` on that TU only | ✓ |
| `-fno-strict-aliasing` on that TU | ✗ (still zeros) |
| `-fno-tree-vectorize -fno-tree-slp-vectorize` on that TU | **SIGSEGV** |
| `__attribute__((noipa))` on `cy1024_process_chunk` | ✗ (still zeros) |
| `__attribute__((optimize("O2")))` on `cy1024_process_chunk` | ✓ |

`noipa` not helping rules out an inlining/IPA effect: this is LTO's *intra-function* `-O3` recompilation.

**4. The failing code contains no exotic instruction.** `objdump` of `cy1024_process_chunk`: the only
mnemonics present in the broken build and absent from the fixed one are `or`, `seta`, `setae`,
`vmovdqa64`. `vmovdqa64` alone occurs **1837 times** elsewhere in the *correct* binary, so SDE plainly
emulates it faithfully. There is no candidate instruction for a fidelity gap.

### Is it gcc's bug, or ours?

This matters, because if it were our undefined behaviour then capping optimisation would merely hide it and
it would resurface on some other compiler or flag combination. So it was tested rather than assumed. The
conclusion below is **well-supported but not proven**, and the limits are spelled out.

#### The decisive datum

`AVX_cmplx_carry_fast_pow2_wtsinit_X16` documents an alignment precondition — *"It may not look like it but
this is in fact an aligned load"* — and issues `vmovaps` (a **64-byte-aligned** load) on `&wt1[col+ii]`,
plus `-0x30`/`-0x70` off the `wtB`/`wtC` pointers. **That precondition is provably satisfied here:**

- `ALIGN_DOUBLE` (`align.h:59`) is `(((intptr_t)(_p) | 127) + 1)` — it rounds `wt1` up to a **128**-byte
  boundary, so `wt1` is 64-byte aligned;
- `col` ∈ {0, 1024, 2048, 3072} (it starts at `ithread*(khi*RADIX)` and steps by `RADIX`=1024, `khi`=4) and
  `ii` is a multiple of 16 (`CARRY_16_WAY` is the AVX-512 default, `platform.h:284`), so
  `col+ii ≡ 0 (mod 8)` → `&wt1[col+ii]` is 64-byte aligned;
- `co2` = 5119 and `co3` ∈ {4095, 3071, 2047, 1023} are all `≡ 7 (mod 8)`, so `add2-6` and `add3-6` — the
  actual `-0x30`/`-0x70` load addresses — are 64-byte aligned too.

Yet the UBSan build's SDE trace shows that very load faulting **inside `cy1024_process_chunk`**, on an
address `≡ 16 (mod 64)`:

```
TID: 2 executed instruction with an unaligned memory reference to address 0x5657f9838910
INSTR: vmovaps zmm4, zmmword ptr [rax]      FUNCTION: cy1024_process_chunk
```

And **deterministically**: a rerun faults at the same instruction, and although ASLR moves the base
(`0x5657f9838910` → `0x55b1164c8910`) the low bits are *identical* — `0x910`, i.e. `≡ 16 (mod 64)` both
times. A reproducible fixed 16-byte offset is a systematically wrong pointer/index, not random garbage.
**That state is unreachable from valid inputs**, so `col`, `ii`, or the spilled `wtA` pointer was corrupted
at runtime. (Source location: offset `0xC884` into the function — `mov 0x2c0(%rsp),%rax; vmovaps (%rax),%zmm4`,
i.e. the `%[__wtA]` macro operand, spilled to the stack.)

*Correction I owe on my own proof:* I first wrote these index bounds using the **X8** figures (`ii` up to
896, so `col+ii` ∈ [0,3968] and a low index of `wt1[126]`). That was wrong — `CARRY_16_WAY` is the AVX-512
default, so the X16 macro is what compiles, `ii` maxes at 768, `col+ii` ∈ **[0, 3840]** and the low index is
**`wt1[254]`**. Recomputed and corrected; the conclusion is unchanged (both sets are comfortably in range),
but the numbers above are the correct ones.

#### How far the evidence reaches

**UBSan: active, and clean.** Whole-program build at the *exact* failing configuration
(`-O3 -flto=auto -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all`), whole tree
compiled with zero make failures. Instrumentation verified present rather than assumed — **887**
`__ubsan_*` call sites inside `cy1024_process_chunk` and **1153** inside `radix1024_ditN_cy_dif1` in the
linked binary. Under `-fno-sanitize-recover=all` the first violation aborts with a diagnostic; **zero** were
reported, and the run instead proceeded into the carry step. So: no signed overflow, no invalid shift, no
pointer overflow, no type mismatch, no misaligned *scalar* access on this path. The 240K case is
UBSan-clean too.

**ASan: it does not work on this code, so heap OOB is NOT formally excluded.** Stating this plainly rather
than burying it, because it is the real limit on the conclusion:

- **14 translation units refuse to compile** with `-fsanitize=address`, failing with `'asm' operand has
  impossible constraints or there are not enough registers` — ASan's instrumentation exhausts the register
  budget of the hand-written asm. Failing sites: `mi64.c`, `sse2_macro_gcc64.h` (which pulls in
  `dft_macro`, `radix1008/144/176/208/240/256/352/44/48/52`), `radix11_sse_macro.h`,
  `radix13_sse_macro.h`, `twopmodq.c`, `twopmodq64_test.c`.
- A **partial** build does link and run — those 14 compiled UBSan-only, everything else including
  `radix1024_ditN_cy_dif1` and `mers_mod_square` fully ASan-instrumented (verified: 17 and 13 `__asan`
  references respectively).
- **But it fails identically on the 960K control**, which is a known-good case: `SDE ERROR: Could not read
  memory at location 0 nbytes= 64` for *both* 1024K and 960K. A broken control means the partial-ASan build
  is uninformative — it tells us nothing about radix1024.

So **a heap out-of-bounds access outside `wt1` has not been ruled out.** What *can* be shown without ASan is
that the one heap array this path indexes by computed value is in range: `wt1` is allocated
`n/nwt + radix0` = 4096 + 1024 = **5120** doubles, and the indices used are `col+ii` ∈ [0, 3840] and
`co2-1-ii` / `co3-1-ii` ∈ [254, 5118].

> **Dependency worth flagging for reviewers: PR #71** ("Fix 'asm operand has impossible constraints' in
> hand-tuned asm on ancient compilers") targets exactly the error that blocks ASan here, and its file list
> covers most of the affected sites — `sse2_macro_gcc64.h` (the big one, shared by ten of the fourteen),
> `twopmodq.c`, `twopmodq64_test.c` and `radix176/208/352/44/52`. Landing #71 would plausibly make an
> ASan-instrumented AVX-512 build achievable and let this bug be **closed properly rather than contained**.
> Note it would not be sufficient on its own: `mi64.c`, `radix11_sse_macro.h` and `radix13_sse_macro.h` also
> fail here and are not in #71's file list (#71 touches `mi64.h`, not `mi64.c`). So: #71 unblocks sanitizer
> coverage for this bug class, but a little more work is needed for full coverage.

#### On the `-fno-tree-vectorize` → SIGSEGV datapoint

This is the observation that most suggests latent UB, so it deserves a direct answer: **I don't think it
discriminates.** A *single corrupted stack slot* explains all three symptoms (zeros, SIGSEGV, misaligned
load) just as well as UB does. `cy1024_process_chunk` is ~7000 instructions dominated by macro-expanded
inline asm under extreme register pressure, so any codegen change reshuffles the frame and its spill slots
and moves *which* value gets clobbered. Consistent with that, adding even a **pure-read** alignment check on
`add1`/`add2`/`add3` next to the call site makes the wrong answer vanish entirely (correct `…000E`) and the
check never fires — the defect cannot be observed by source-level instrumentation of the failing build.

#### Verdict — RETRACTED. There is no GCC bug; this is our own missing clobber, and #68 fixes it.

An earlier revision of this section claimed the codegen reading was "now proven", with RTL and
`-ffixed` evidence. **That was wrong, and this PR should not be merged as it stands.**

`AVX_cmplx_carry_fast_pow2_errcheck_X16` writes `%zmm18`, `%zmm19` and `%k1`–`%k4`, and on
`upstream/main` declares none of them clobbered. GCC 16 parks `%r15` in `%xmm19` across the asm
because it was told the register was free. That is correct compiler behaviour on incorrect source.

The mistake was reading the clobber list from the wrong tree. The failing build was pristine
`upstream/main` @ `47d75d3`; the list quoted as proof that both registers were declared was read
from a local integration branch with **PR #68** already applied. Same path, same line number,
different content:

```
$ git show 47d75d3:src/carry_gcc64.h | sed -n 12321p
  … "xmm16","xmm17","xmm20", …        <- no k1-k4, no xmm18/19
$ sed -n 12321p src/carry_gcc64.h     # integration branch, PR #68 applied
  … "k1","k2","k3","k4", … "xmm18","xmm19", …
```

Everything else followed from that. The `-ffixed-xmm20 -ffixed-xmm21` "discriminating control" was
read backwards: xmm20/21 *are* declared, so denying them was always going to change nothing — it was
pointing at the source bug, not away from it.

**Proof of the real cause.** Changing only that one clobber list on pristine `47d75d3`,
`"xmm17","xmm20"` → `"xmm17","xmm18","xmm19","xmm20"`, recompiling only
`radix1024_ditN_cy_dif1.o`, same link:

| build (gcc 16.1.1, `-O3 -flto`, SDE `-skx`, 10 iters) | `Res64` |
|---|---|
| pristine `47d75d3` | `0000000000000000` — wrong |
| + `"xmm18","xmm19"` on that one line | `9BDB491DF4C00002` — correct |
| branch with #68 applied, unmodified | `9BDB491DF4C00002` — correct |

An RTL dump (`-fdump-rtl-all-slim`) of the asm the parked value straddles confirms it: the clobber
set lists `xmm31 … xmm20, xmm17, xmm16 …` with **no xmm18, no xmm19, no k-registers** — and the
preprocessed C says the same, so nothing was lost by LTO.

**Recommendation: close this PR in favour of #68**, which declares these clobbers tree-wide and is
the actual fix. The `__attribute__((optimize("O2")))` cap here would otherwise permanently pessimise
`cy1024_process_chunk` to work around a bug that does not exist, and would mislead the next reader.
I have left it open rather than closing it unilaterally.

## The fix

`src/radix1024_ditN_cy_dif1.c` — cap `cy1024_process_chunk()` at `-O2`, gated on compiler and ISA:

```c
#if defined(USE_AVX512) && defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 16)
	__attribute__((optimize("O2")))
#endif
	void*
	cy1024_process_chunk(void*targ)
```

Same containment pattern as `cy320_process_chunk` (#148) and `twopmodq96.c` (#118), with two deliberate
differences: `-O2` rather than `-O0` (mildest level that tests clean), and compiler/ISA-gated rather than
unconditional, because this is a hot path at the mainstream 1M–8M FFT lengths and every other toolchain
should keep its `-O3` codegen. The upper version bound is left open-ended on purpose — a silently wrong
residue is not an acceptable risk to take on an untested future gcc.

### The mechanism, and its known caveat

**I know GCC documents this attribute as debug-only.** Its manual says the `optimize` attribute *"should be
used for debugging purposes only. It is not suitable in production code"* — it interacts unpredictably with
other flags and does not always reset the full optimisation state the way a command-line `-O2` does. Using it
as a *correctness* mechanism against a silently wrong residue deserves scrutiny, so here is the evidence that
it actually does the job here, and the trade-off, so you can overrule it.

**It verifiably takes effect on the real build.** Comparing the mnemonic sequence of
`cy1024_process_chunk` (layout-independent — addresses stripped, opcodes only) across builds, where "branch"
is a clean `rm -rf obj_avx512 && bash makemake.sh avx512` at the genuine project flags, not a test harness:

| build | insns | vs. branch |
|---|---|---|
| unpatched, `-O3 -flto` (**broken**) | 7046 | **1030 lines differ** |
| **branch** (attribute, real `makemake.sh` flags) | 6842 | — |
| attribute prototype (hand-relinked) | 6842 | **identical** |
| whole-TU command-line `-O2`, rest `-O3 -flto` | 6841 | 5 lines differ |

So the attribute (a) demonstrably changes the generated code rather than being silently ignored, and (b)
converges on what a real command-line `-O2` produces for this function — 5 differing lines out of 6842,
0.07%, attributable to the rest of the TU still being at `-O3`. And the branch build reproduces the
prototype exactly, so the result is not an artifact of my relinking.

**Why I judged it acceptable anyway**, explicitly so it can be overruled:
- it is verified working on the one configuration that is broken, end-to-end (correct Res64 at 100
  iterations, three affected radix sets, clean rebuild);
- it is compiler- **and** ISA-gated, so it cannot affect any other build — every non-gcc-16 or
  non-AVX-512 configuration is untouched, byte-for-byte;
- the alternative that avoids the attribute entirely is to reject leading radix 1024 outright, which would
  remove a mainstream FFT length (1M–512M radix_set 0) from every gcc-16 AVX-512 user.

**Escalation path if the attribute proves unreliable across gcc 16.x point releases:** take the #175
approach — a soft-skip guard that refuses leading radix 1024 on affected builds (`WARN` +
`ERR_RADIX0_UNAVAILABLE`, as `radix20_ditN_cy_dif1.c` and #162 already do), trading a lost FFT length for a
guaranteed-absent wrong residue. That is safer but costlier, and I'd rather not spend a mainstream FFT length
unless the cheaper containment is shown to be flaky. Naming it here so it doesn't have to be rediscovered.

**Alternatives not investigated** (flagging, not blocking): a `#pragma GCC optimize` push/pop around the
function, or — better if someone identifies the specific misbehaving pass — a targeted `-fno-<pass>`, which
would be both narrower and not subject to the debug-only caveat. Identifying the pass needs the creduce work
noted above.

**I did not isolate the actual gcc-16 defect.** Doing so needs register/stack-layout debugging of the
AVX-512 inline-asm macro expansions in `radix1024_main_carry_loop.h`; the C level is clean, and the
SIGSEGV that `-fno-tree-vectorize` produces *instead of* zeros is the signature of a wild pointer — the
same family as the already-known `cy320_process_chunk` (#148) and `radix32_wrapper_square` (#162)
corruptions. So this caps the function rather than pretending to fix the codegen. Happy to drop the
version gate to unconditional, or widen it to `>= 15`, if you'd rather be more conservative.

## Verification

Honest about what was and was not tested:

- **gcc 16.1.1 AVX-512 build of this branch, under SDE `-skx`**, after a clean
  `rm -rf obj_avx512 && bash makemake.sh avx512`, 100 iterations each — all four `34B4CFB331D348C2`,
  matching the native AVX2 reference:

  | case | radices | Res64 |
  |---|---|---|
  | 1024K radix_set 0 | {1024,16,32} | `34B4CFB331D348C2` ✓ |
  | 1024K radix_set 1 | {1024,32,16} | `34B4CFB331D348C2` ✓ |
  | 2048K radix_set 0 | {1024,32,32} | `34B4CFB331D348C2` ✓ |
  | 960K radix_set 0 (unaffected control) | {960,16,32} | `34B4CFB331D348C2` ✓ |
- Clean full `bash makemake.sh avx512` and `bash makemake.sh avx2` builds, no new warnings.
- AVX2 `obj_avx2/Mlucas -s tt`: 13K `E3BC90B0E652C7C0`, 14K `DB8E39C67F8CCA0A`, 15K `B3C5A1C03E26BB17` —
  unchanged (the change is a no-op for non-AVX-512 and non-gcc-16 builds).
- Scope swept with the *unfixed* gcc-16 AVX-512 binary: 16 other leading radices clean
  (16/32/64/128/144/160/176/192/208/224/256/288/320/352/768/960, across 30 length/radix_set combinations).
- **Not tested on real AVX-512 hardware** — this box has none. And a targeted CI job cannot confirm it
  either: no CI runner ships gcc 16 (ubuntu-26.04 → gcc 15, which tests clean), so such a job would be
  green on real silicon and prove nothing about this case. A residue-verifying CI job at 1M FFT across all
  radix sets would still be worth having as a general net for this bug *class*, and would catch this once
  runners move to gcc 16.

## Two things worth flagging separately

1. **The silence is the deeper hazard.** An all-zero residue with `MaxErr == 0.0` is an impossible state
   for a real LL/PRP iteration past the first few, yet nothing in Mlucas notices. A cheap generic guard —
   e.g. treating `fracmax == 0.0` on a full pass beyond some iteration, or an all-zero
   Res64/Res35m1/Res36m1 triplet at a checkpoint, as a hard error — would have turned this into a loud
   failure, and would cover the *next* miscompile too, whichever radix it lands on. Not attempted here
   since it touches shared code and wants a maintainer's judgement on the false-positive risk.

2. **A clean repro for #65, found while sweeping** (not addressed by this PR — different symptom, and it
   is LTO-independent so this workaround pattern does not transfer):

   ```
   ./Mlucas -m 4837331 -fftlen 240 -radset 0 -shift 0 -iters 1     # radices {240,16,32}
   ```

   SIGSEGVs under AVX-512 with **gcc 16.1.1 and gcc 15.3.0**, clean with gcc 11.4.0; also crashes at 480K
   radix_set 0. That is exactly the signature in #65 ("Segmentation fault with Clang 18+/GCC 15+ and
   AVX512"), which asks for someone who can run it under a debugger — and this reproduces on a box with no
   AVX-512 hardware, under `sde64 -skx`, from a single command.

   Worth noting it has a **different profile** from the radix1024 bug: it crashes at **every** `-O` level
   tried *including `-O1`*, with LTO on or off, on two gcc majors. A defect that survives `-O1` is far more
   likely a genuine bug (or real UB) in the radix240 AVX-512 path than radix1024's fragile `-O3`+LTO
   corruption — which makes it the more tractable of the two to root-cause properly, and means this PR's
   containment pattern will not transfer to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



