### PR TITLE
carry.h: make the GENFFTMUL carry macro's discard of its cy argument explicit

### DIFF
--- a/src/carry.h
+++ b/src/carry.h
@@ -77,10 +77,20 @@
 	/*if(full_pass && (x != 0. || y != 0.))printf("Block %2u, j = %4u: u += %6d*bpow; v += %6d*bpow; bpow *= b;\n",idx,j,(int)x,(int)y);*/\
 	}
 #else
-	/* V2 computes x-y (= a*u - b*v) on the fly and stores in the normalized x-output, setting y = 0:
+	/* V2 computes x-y (= a*u - b*v) on the fly and stores in the normalized x-output, setting y = 0.
+	Note V2 needs no imaginary-part carry: the single cx carry-chain covers the combined x-y output.
+	The cy parameter is therefore accepted but deliberately unused, so that this and the V1 variant
+	above present the same 5-argument interface and callers need not be written against one of the
+	two. The (void)sizeof below makes that discard explicit: without it, a caller which walks a
+	cy_i[] array purely to supply this argument looks like dead code to -Wunused-but-set-variable
+	(gcc and clang both warn), and "fixing" that warning by dropping the caller's cy_i setup
+	silently breaks the V1 variant. sizeof is used rather than a plain (void)(cy) cast because its
+	operand is unevaluated: it marks cy as used without dereferencing it, which matters because
+	callers pass an lvalue like *addi.
 	*/						// Idx-arg is debug-use only:vvv
 	#define genfftmul_carry_norm_pow2_errcheck(x,y,cx,cy,idx)\
 	{\
+		(void)sizeof(cy);	/* V2 carries only the combined x-y output; see the note above */\
 		/* Multiply the current transform output by any scale factor: */\
 			rt = (x - y)*scale + cx;\
 			temp = DNINT(rt);\


### PR DESCRIPTION
Follow-up to a review question on #126: [`radix32_main_carry_loop.h` has a TODO](https://github.com/primesearch/Mlucas/pull/126#discussion_r3646940419) saying `genfftmul_carry_norm_pow2_errcheck` "doesn't use its cy parameter in its current implementation", and @tdulcet asked whether that should be tracked. Filing it as a change rather than an issue, since there is something concrete to do.

### What's going on

`carry.h` defines `genfftmul_carry_norm_pow2_errcheck()` twice, selected by an `#if 0` / `#else`:

* **V1** (disabled) carries real and imaginary parts separately and uses `cy`.
* **V2** (active) computes `x-y` on the fly, stores it in the `x` output, sets `y = 0`, and needs no imaginary carry — so it accepts `cy` and silently ignores it.

Nothing documented that, and the consequence isn't obvious. A caller that walks a `cy_i[]` array purely to supply that argument looks like dead code: both gcc and clang report the caller's pointer as `variable 'addi' set but not used` in configurations where the sibling Fermat-mod carry block — which *does* read `addi` — is compiled out.

The natural way to silence that warning is to delete the caller's `cy_i` setup. That leaves `addi` uninitialised while `*addi` is still passed. It's inert under V2, because an unused macro parameter is never expanded and therefore never evaluated — but it turns the `#if 0` into a trap: selecting V1 then dereferences an uninitialised pointer, and **neither gcc nor clang diagnoses it at `-O2 -Wall -Wextra`**. I checked.

### The change

Document the asymmetry, and mark `cy` as used inside V2 so callers can keep a uniform 5-argument call and a correct `cy_i` setup without tripping the warning.

`sizeof` rather than a plain `(void)(cy)` cast, because its operand is unevaluated — it marks `cy` used without dereferencing it, which matters since callers pass an lvalue like `*addi`. Confirmed against both gcc and clang that `(void)sizeof(cy)` suppresses `-Wunused-but-set-variable` at the caller exactly as `(void)(cy)` does, while generating no memory read.

### Verification

* `.text` is **byte-identical** for `radix16_ditN_cy_dif1.c` and `radix32_ditN_cy_dif1.c` — the only two callers — so the shipped V2 build is unchanged.
* Both callers still compile with V1 selected.

This is a robustness and documentation change, not a bug fix: `main` does not emit that warning in the default configuration, because `addi` is shared with the Fermat-mod carry block which reads it. The point is to stop the next person from "fixing" the warning the way that breaks V1.
