### PR TITLE
Suyama_CF_PRP: pass correct lengths to res_SH() and gcd()

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3338,7 +3338,11 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 		convert_res_FP_bytewise(a, (uint8 *)ci, n, p, Res64, &Res35m1, &Res36m1);	// Overwrite passed-in Pepin-Res64 with Fermat-PRP one
 		snprintf(cbuf,sizeof(cbuf),"MaxErr = %10.9f\n",MME); mlucas_fprint(cbuf,1);
 	} else if (MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {	// Mersenne PRP-CF doesn't have the Res35m1 or Res36m1 values passed in,
-		res_SH(ci,n,&itmp64,&Res35m1,&Res36m1);			// so we refresh these; see https://github.com/primesearch/Mlucas/issues/27
+		// so we refresh these; see https://github.com/primesearch/Mlucas/issues/27 . res_SH() wants the
+		// mi64 limb-count of the packed-bit residue in ci[], i.e. ceiling(p/64) - NOT the FFT length n,
+		// which counts doubles and is ~3.5x larger. Passing n here ran mi64_div_by_scalar64() off the end
+		// of the ci[] (= arrtmp[]) allocation, giving nondeterministic Res35m1/Res36m1 for residue (A):
+		res_SH(ci,(p+63)>>6,&itmp64,&Res35m1,&Res36m1);
 	} else {
 		// Initialize to invalid value to prevent warnings.
 		Res35m1 = UINT64_MAX;

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3466,7 +3466,14 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 			C cannot be a prime power. (If it is not equal to 1, we have discovered a new factor of C.)"
 		*/
 		sprintf(cbuf,"This cofactor is COMPOSITE [C%u]. Checking prime-power-ness via GCD(A - B,C) ... \n",i); mlucas_fprint(cbuf,1);
-		i = gcd(0,0ull,ai,ci,j,gcd_str);	// 1st arg = stage of (p-1 or ecm) just completed, does not apply here
+		// gcd()'s nlimb arg is the common mi64 length of the 2 vectors it is handed, here ai[] = (A - B)
+		// and ci[] = C. j was overwritten just above with mi64_getlen(bi,j), the nonzero-limb count of the
+		// remainder (A - B) mod C: that is <= the limb count of C, hence generally shorter than (A - B),
+		// which spans all ceiling(p/64) limbs the mi64_sub() above wrote. Passing it lopped the high limbs
+		// off (A - B) - and off C as well, in the rarer case of the remainder being shorter than C - so the
+		// GCD got taken of a different pair of integers. mi64_div() zeroed ci[] across all ceiling(p/64)
+		// limbs before depositing C = N/F in it, so that is the correct common length here:
+		i = gcd(0,0ull,ai,ci,(p+63)>>6,gcd_str);	// 1st arg = stage of (p-1 or ecm) just completed, does not apply here
 		if(i)
 			sprintf(cbuf,"Cofactor is a prime power! GCD(A - B,C) = %s.\n",gcd_str);
 		else


### PR DESCRIPTION
`Suyama_CF_PRP()` passes a wrong length in two separate places. Both are one-token fixes; one commit each so they stay individually reviewable.

---

# 1. `res_SH(ci,n,...)`: FFT length where an mi64 limb count belongs

`Suyama_CF_PRP()` refreshes the Selfridge-Hurwitz residues of the Fermat-PRP residue (A) for the Mersenne PRP-CF path with

```c
res_SH(ci,n,&itmp64,&Res35m1,&Res36m1);
```

`res_SH()`'s second argument is an **mi64 limb count** — it hands it straight to `mi64_div_by_scalar64(a,two35m1,len,0x0)`. `n` is the **FFT length in doubles**, roughly 3.5x the limb count `ceiling(p/64)` of the packed-bit residue sitting in `ci[]`. The adjacent Fermat-branch call `convert_res_FP_bytewise(a, (uint8 *)ci, n, p, ...)` *does* legitimately take the FFT length, which is presumably how the two got mixed up; two lines further down the function computes `j = (p+63)>>6` for exactly this residue.

`ci[]` is the caller's `arrtmp[]`, allocated at `Mlucas.c:1444` for `(pmax_at_FFT_length + 63) >> 5` limbs — about 2x the limb count, always well under `n`. So the call reads past the end of the allocation and folds stale mod-squaring scratch into the reported `Res35m1`/`Res36m1`.

## What I measured

Base: `upstream/main` @ 47d75d3. x86-64 AVX2 build (gcc 16.1.1, `makemake.sh avx2`), `-cpu 0:3`.

**Nondeterminism.** `worktodo.txt` = `PRP=1,2,60083,-1,99,0,3,5,"120167"`, five identical runs in five fresh directories:

```
Fermat-PRP residue (A)     = 0X24CC66BE0BB02940,23727129195,30919441868
Fermat-PRP residue (A)     = 0X24CC66BE0BB02940,31915171107,54234988572
Fermat-PRP residue (A)     = 0X24CC66BE0BB02940, 2031600862, 6368411620
Fermat-PRP residue (A)     = 0X24CC66BE0BB02940,19393213830,43068370267
Fermat-PRP residue (A)     = 0X24CC66BE0BB02940,26426313073,21589706266
```

`Res64` is stable across all five; the two S-H residues differ every run, and all five are wrong. Independent ground truth from `pow(3, M-1, M)` with `M = 2**60083-1`:

```
A low64 = 0x24CC66BE0BB02940   (matches Mlucas)
Res35m1 = 1115347405
Res36m1 = 37294245589
```

**ASan.** nosimd build, `CFLAGS="-Wall -g -Og -fsanitize=address"`, `PRP=1,2,70079,-1,99,0,3,5,"140159"` (FFT 4K):

```
ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 8
    #0 mi64_div_by_scalar64 ../src/mi64.c:6868
    #1 res_SH ../src/Mlucas.c:6012
    #2 Suyama_CF_PRP ../src/Mlucas.c:3341
    #3 ernstMain ../src/Mlucas.c:2487
0x... is located 0 bytes after 22272-byte region [...]
allocated by thread T0 here:
    #1 ernstMain ../src/Mlucas.c:1444
```

4096 limbs read from a 2784-limb (22272-byte) buffer: a 10496-byte over-read. The over-read grows with the FFT length, so at wavefront sizes (p ~ 1e8, n ~ 5.6M doubles) it is tens of MB past the end of a ~25 MB allocation — comfortably into SIGSEGV territory rather than merely garbage output.

## After the fix

- Five runs of the 60083 case: `0X24CC66BE0BB02940, 1115347405,37294245589` — identical every time, and equal to the independently computed value.
- 70079 case: `0X6D67A90ED527939B,17335162093,17730542564`, matching `pow(3,M-1,M)` for p=70079 exactly.
- ASan run: no `heap-buffer-overflow`. (The run still ends with a LeakSanitizer report of 24 bytes in 2 allocations — pre-existing and unrelated.)
- Unchanged: `res64`, the `(A - B) mod C` Res64/35m1/36m1 line, the `COMPOSITE [C18082]` verdict, the JSON results line.
- 100-iteration self-test Res64 at FFT 13K/14K/15K: `E3BC90B0E652C7C0` / `DB8E39C67F8CCA0A` / `B3C5A1C03E26BB17`, all matching reference.

## Other `res_SH()` call sites

Audited all of them; there are exactly three in the tree (`grep -rn res_SH src/`). The other two are correct and untouched:

- `Mlucas.c:2450` — `res_SH(arrtmp,j,...)`, where `j = (p+63)>>6` is set at line 2419 and is used as a limb count throughout the intervening block (`mi64_div(arrtmp,&itmp64,j,1,...)`, `d_uint64_ptr[j-1]`, `mi64_div(c_uint64_ptr,&itmp64,j+1,1,arrtmp,&rmodb)`).
- `Mlucas.c:3457` — `res_SH(bi,j,...)`, where `j = mi64_getlen(bi,j)` on line 3452 is the nonzero-limb count of the `(A - B) mod C` remainder.

## Not verified locally

The reported `Res35m1`/`Res36m1` for residue (A) go to the console and the `p*.stat` log only — the JSON results line for a PRP-CF assignment carries `res64`/`res2048` and not the S-H residues — so I have no evidence that bad values were ever submitted to PrimeNet. I also did not run a wavefront-sized PRP-CF to observe the predicted SIGSEGV; that claim is an extrapolation from the allocation arithmetic, not a measurement.

---

# 2. `gcd(...,ai,ci,j,...)`: remainder length where the (A - B)/C limb count belongs

Second commit. Same function, ~40 lines further down, and this one is *not* an over-read — it is an under-read, so it is silent under ASan and produces a wrong answer instead of a crash.

```c
	i = j;	j = mi64_getlen(ci, j);                                 // j = limb count of C = N/F
	...
	mi64_div_binary(ai,ci, i,j, curr_fac,(uint32 *)&k, bi);         // bi[] = R = (A - B) mod C
	...
	j = mi64_getlen(bi,j);                                          // j = nonzero-limb count of R
	...
	i = gcd(0,0ull,ai,ci,j,gcd_str);
```

`gcd()` is declared

```c
uint32 gcd(uint32 stage, uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb, char *const gcd_str);
```

and with `p == 0`, `nlimb` is the common mi64 length of `vec1` and `vec2` — it goes straight into `mpz_import()` for *both*:

```c
	mpz_import(gmp_arr1, nlimb, -1, sizeof(uint64), 0, 0, vec1);
	...
	mpz_import(gmp_arr2, nlimb, -1, sizeof(uint64), 0, 0, vec2);
```

The two vectors passed here are `ai[]` = (A - B) and `ci[]` = C. But by that point `j` has been overwritten with the length of a *third* array, `bi[]` = the remainder R = (A - B) mod C.

## What the correct length is

`ceiling(p/64)`, i.e. the same `j` the rest of the function uses:

- `ai[]` holds (A - B), a residue mod N, written by `mi64_sub(ai,bi, ai,j)` with `j = (p+63)>>6`; it spans all of those limbs.
- `ci[]` holds C = N/F, deposited by `mi64_div(bi,BASE_MULTIPLIER_BITS, j,lenf, ci,0x0)`. `mi64_div()` opens with `if(q && (q != x)) { mi64_clear(q, lenX); }`, so `ci[]` is zeroed across the full `ceiling(p/64)` limbs (`+1` in the Fermat case) before C is written into its low end. Importing that whole span is therefore both in-bounds — `arrtmp[]` is dimensioned for ~2x that many limbs — and correctly zero-extended. The `mi64_getlen(ci, j)` two lines earlier already relies on exactly this.

## Direction: under-read, so no crash and no ASan hit — just a wrong GCD

R < C <= N/3, so `getlen(R) <= limbs(C) <= ceiling(p/64)`: the length passed is always *at most* the correct one. Nothing is read out of bounds. What happens instead is truncation — `mpz_import()` builds `(A - B) mod 2^(64*nlimb)` in place of (A - B), plus a truncated C in the rarer case where `getlen(R) < limbs(C)`.

The truncation is nonzero exactly when `getlen(R) < ceiling(p/64)`, which in practice means when the bit count of the known-factor product exceeds the population of N's leading limb: `fbits >= ((p-1) mod 64) + 1`. For a real assignment with a couple of known factors that is essentially a coin flip on `p mod 64`, and it grows by a limb per 64 bits of `fbits`. It is also why the part-1 runs above never tripped over it: M60083 has `p mod 64 = 51` and `fbits = 17`, so its truncation is zero and the buggy and fixed builds agree exactly.

## Measured

M72481 / 118288993 / 4513971719 (`fbits` = 59, `p mod 64` = 33 — one limb goes missing). Same AVX2 build as above, `worktodo.txt` = `PRP=1,2,72481,-1,99,0,3,5,"118288993,4513971719"`. `gcd()` already prints the bit lengths of what it actually imported:

```
before:  GCD(A[72446 bits], B[72423 bits]) = 1
after:   GCD(A[72479 bits], B[72423 bits]) = 1
```

Independent ground truth for the same p — A = `pow(3, N-1, N)`, B = `pow(3, F-1, N)`, C = N/F, plain Python with a fast Mersenne reduction:

```
p=72481  fbits=59  limbs(N)=ceil(p/64)=1133
A         low64 = 0x6F06F3184AA618F3   Res35m1=25330160978 Res36m1=18589384171
B         low64 = 0xB2DC6F000FFA9C44   Res35m1=23019015713 Res36m1=15464673011
(A-B)     low64 = 0xBC2A84183AAB7CAF   bits=72479 limbs=1133
C         low64 = 0xE3DCBDF3148BD6E9   bits=72423 limbs=1132
R=(A-B)%C low64 = 0x905E7D83ED6D5BED   bits=72422 limbs=1132  Res35m1=8049071150 Res36m1=50740332975
quotient (A-B)/C = 98761256607606130

gcd() with CORRECT nlimb=1133 : imports A-B as 72479 bits, C as 72423 bits -> gcd=1
gcd() with BUGGY   nlimb=1132 : imports A-B as 72446 bits, C as 72423 bits -> gcd=1
```

Every value matches the run — A and B including their S-H residues, the `(A - B) Res64`, the `C Res64`, the quotient `98761256607606130`, and the remainder's `Res64,35m1,36m1` — and the two `nlimb` rows reproduce the two `GCD(A[...] bits], B[...] bits])` lines exactly. The old code was dropping the top 33 bits of (A - B) and taking the GCD of a different integer.

## Yes, the prime-power verdict can come out wrong — here is one doing it

The check exists to catch `C = q^k`, in which case `gcd(A - B, C) > 1` and the GCD *is* a new factor of C (Phil Moore's post, quoted in the comment right above the call). Replace (A - B) by `(A - B) mod 2^(64*nlimb)` and that guarantee is gone. There are two regimes, depending on whether C survives the truncation:

**(a) Only (A - B) is truncated** — the usual case, `getlen(R) == limbs(C)`. Every prime factor of a Mersenne cofactor is `== 1 (mod 2p)`, hence `> 2p`, so a truncated (A - B) hits one only with probability `~ (#factors of C)/2p`, i.e. essentially never. The verdict is *accidentally* right here, but only because C has no small factors to trip over — the GCD is still being taken of the wrong integer.

**(b) C is truncated too** — when the remainder is a limb shorter than C, which is exactly what happens when C's leading limb is sparsely populated (`fbits ~ ((p-1) mod 64) + 1` modulo 64). Now the imported "C" is `C - 2^(64*nlimb)`, an arbitrary integer with no constraint on its small factors, and it shares one with the truncated (A - B) with probability `1 - prod_{q odd prime}(1 - 1/q^2) ~ 19%`. `gcd()` returns 1 for any GCD of >= 2 bits that survives division by the known factors, so Mlucas announces a prime power.

I put the pre-fix binary through 40 exponents in 79811..81931 chosen to have nonzero truncation, one to three known factors each. 26 ran to a verdict (the other 14 were cut short — see the note at the end). 25 of the 26 landed in regime (a) and correctly said "not a prime power". One landed in regime (b) and got it wrong:

```
                                                       M80329 / 1767239 / 46108847 / 66030439
before:  Raw GCD has 2 bits ... dividing out any known factors...
         GCD(A[80254 bits], B[80256 bits]) = 3
         Cofactor is a prime power! GCD(A - B,C) = 3.

after:   GCD(A[80325 bits], B[80257 bits]) = 1
         Cofactor is not a prime power.
```

Same independent recomputation for this exponent:

```
p=80329  fbits=73  limbs(N)=ceil(p/64)=1256
A         low64 = 0x3330D6F982B64130   Res35m1=10507113021 Res36m1=42841531875
B         low64 = 0xD4ADC6D4D01123CC   Res35m1=7857488950  Res36m1=53923848292
(A-B)     low64 = 0x5E831024B2A51D64   bits=80325 limbs=1256
C         low64 = 0x57FACC1922018D21   bits=80257 limbs=1255
R=(A-B)%C low64 = 0xE577AEB6AD6954DC   bits=80256 limbs=1254  Res35m1=253245987 Res36m1=30973045222
quotient (A-B)/C = 288900890439388229512

gcd() with CORRECT nlimb=1256 : imports A-B as 80325 bits, C as 80257 bits -> gcd=1
gcd() with BUGGY   nlimb=1254 : imports A-B as 80254 bits, C as 80256 bits -> gcd=3
```

C's leading limb holds a single bit, so the remainder is two limbs shorter than (A - B) and `nlimb = getlen(R) = 1254` clipped (A - B) from 80325 to 80254 bits *and* C from 80257 to 80256 bits. Both clipped values happen to be divisible by 3. 3 cannot divide the real C — every prime factor of M80329 is `== 1 (mod 160658)` — so the answer is unambiguously fabricated, and Mlucas reported an 80329-bit composite cofactor as a prime power. Diffing that assignment's output before vs after, the GCD line and the verdict line are the *only* things that change.

The mirror-image failure — a genuine prime-power cofactor being missed — cannot be exhibited on real data, since no Mersenne or Fermat number with a known prime-power cofactor exists to test against. It follows from the same truncation, and a scaled-down replica of `gcd()`'s import semantics (`mpz_import` of `nlimb` limbs of each vector, then `mpz_gcd`) on a synthetic `C = q^2` with the same limb-length relationship shows the shape of it:

```
limbs(A-B)=11  limbs(C)=10  correct nlimb=11  buggy nlimb=10
ground truth gcd(A-B, C) = q ? True
correct nlimb=11  -> GCD is 320 bits, Mlucas prints: Cofactor is a prime power! GCD(A - B,C) = <320-bit value>.
buggy   nlimb=10  -> GCD is 1 bits,   Mlucas prints: Cofactor is not a prime power.
```

i.e. the truncation destroys divisibility by q and the new factor is silently discarded.

## Unchanged by the fix

Diffing the full M72481 run before vs after, the *only* difference outside of RAM/affinity noise is the `GCD(A[...] bits]...)` line; for M80329 it is that line plus the verdict it feeds. `res64`, `res2048`, the `(A - B) mod C` Res64/35m1/36m1 line, the `COMPOSITE [Cnnnnn]` digit count and the whole JSON results line are byte-identical in both cases. The M60083 case from part 1, re-run against the two-fix build, is likewise unchanged (`GCD(A[60082 bits], B[60067 bits]) = 1` either way — `p mod 64 = 51` vs `fbits = 17`, so zero truncation, which is why part 1's runs never surfaced this).

- **ASan** (nosimd, `-Og -fsanitize=address`) on the M72481 case: no `heap-buffer-overflow`, i.e. the now-larger `mpz_import()` stays inside both allocations, and the run reproduces `GCD(A[72479 bits], B[72423 bits]) = 1`. It ends with LeakSanitizer reporting 40 bytes in 3 allocations: 32 in `convert_base10_char_mi64()` and 8 from the `mpz_init_set_ui(gmp_one,1ull)` in `gcd()` that the function's exit path never `mpz_clear()`s. Both are pre-existing and unrelated to this change.
- **Self-tests** on the two-fix build: 100-iteration Res64 at FFT 13K/14K/15K = `E3BC90B0E652C7C0` / `DB8E39C67F8CCA0A` / `B3C5A1C03E26BB17`, all matching reference.

## Not verified locally

As with part 1, the prime-power verdict is console and `p*.stat` output only — it is not part of the JSON results line — so nothing incorrect was ever submitted to PrimeNet on account of this. The cost is a missed (or spurious) prime-power / new-factor detection in the local log.

## Unrelated, but noticed while running the sweep

The 14 assignments that did not finish above died of heap corruption. All four of my sweep processes aborted: 2 with `Fatal glibc error: malloc.c:4241 (_int_malloc): assertion failed: (unsigned long) (size) >= (unsigned long) (nb)` immediately after printing `Checking prime-power-ness via GCD(A - B,C) ...`, and 2 with `realloc(): invalid pointer` (presumably the `static` scratch buffer in `mi64_div_binary()`, which carries a comment about exactly this symptom dating from May/Jun 2022); the remaining assignments were queued behind those aborts in the same `worktodo.txt`. It takes several assignments in one process to show up — re-running the exponent one of them died on, `PRP=1,2,81547,-1,99,0,3,5,"656942633,9699037087"`, on its own completes cleanly, so it looks like state accumulating across assignments rather than anything specific to an exponent.

Scope-wise: this is not something this patch can cause — the change here only alters an `mpz_import()` length, and the aborts were all in the pre-fix binary. I have not attempted a root-cause, and it is not addressed here; flagging it as something the cofactor-PRP path needs looked at separately.
