### PR TITLE
Abort a production run on an identically-zero residue (the failure mode the roundoff check cannot see)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2066,6 +2066,73 @@ READ_RESTART_FILE:
 			mlucas_fprint(cbuf,scrnFlag);
 		}
 
+		/* v21: Identically-zero-residue sanity guard, production runs only.
+		Rationale: the roundoff-error check is structurally blind to a zeroed residue. fracmax measures the
+		distance of the inverse-weighted data from the nearest integer, and zero *is* an integer, so a run
+		whose residue vector has been zeroed - by a miscompiled or defective FFT/carry routine, by failing
+		hardware, or by memory corruption - reports MaxErr/AvgMaxErr = 0, i.e. the health signal users rely
+		on reads maximally *good* precisely when the answer is entirely wrong. Absent this check nothing in
+		the program notices, and the wrong result is written to the savefile and eventually reported.
+
+		Why this state cannot occur in a healthy run of any test type which uses this loop:
+
+		o Pepin (Fermat primality), PRP (both moduli) and p-1 stage 1 all compute s^e (mod N) for a fixed
+		  seed s - 3 for Pepin, PRP_BASE (3 by default) for PRP and p-1 - and some exponent e. The seed is a
+		  unit for every N these paths can be handed: N = 2^p-1 is odd and == 1 (mod 3) for odd p, and
+		  N = F_m = 2^2^m+1 is odd and == 2 (mod 3) for m >= 1, so gcd(s,N) = 1 in both cases. A power of a
+		  unit is a unit, hence nonzero. Zero is *impossible*, at every iteration, not merely unlikely.
+
+		o LL is the one exception, and its zero residue is a *result*, not an error: M(p) is prime iff the
+		  residue after the final (p-2)nd squaring is identically zero. That is literally the isprime test a
+		  few hundred lines below, so ihi == maxiter is exempted. Before the last iteration a zero cannot
+		  occur when M(p) is prime: s_i == 0 forces s_(i+1) == -2, s_(i+2) == 2 and s_j == 2 thereafter, so
+		  s_(p-2) == 2 != 0, contradicting primality. When M(p) is composite an intermediate zero is not
+		  formally impossible, but it has heuristic probability 2^-p per checkpoint (~1e-4515000 at p = 15M),
+		  and such a run would have gone on to report the same "composite" verdict a rerun will reproduce.
+		  So the cost of that outcome is one restarted assignment, against catching a whole class of silent
+		  wrong answers.
+
+		No other test type has a distinguished zero: Pepin signals primality with residue N-1, PRP with
+		residue 1 (or PRP_BASE^2 for the Gerbicz-modified Mersenne form), and p-1 stage 1 has no
+		distinguished residue value at all.
+
+		Deliberately *not* part of the condition: MaxErr. Requiring MME == 0.0 as well would narrow the guard
+		for no safety gain - a zero residue is already impossible on its own - while letting through the cases
+		where the data are zeroed only part-way through the interval, or where a nonzero MME from earlier in
+		the interval survives. (MaxErr == 0.0 is in any case a legitimate value in its own right: it is what
+		the first few iterations of a healthy run report, while the residue is still a small integer.)
+
+		Deliberately not extended to a "residue looks too sparse" test, which would additionally catch the
+		failure mode where the residue collapses to a single power of two rather than to zero: that test is
+		probabilistic rather than impossible-by-construction, and it would need a final-iteration exemption
+		for *every* test type, because at ihi == maxiter the correct answer is exactly what it looks for -
+		0 for an LL prime, N-1 = 2^2^m for a Pepin prime, 1 or PRP_BASE^2 for a PRP. Three chances to abort a
+		multi-week run on its single most important iteration is not a trade worth making here.
+
+		Scope: !INTERACT only. In timing-test/self-test mode (-iters, -s) the residue is checked against the
+		built-in reference tables by the caller and a bad radix set must not abort the sweep; strengthening
+		that pass criterion is a separate matter. We fire before the savefile is written, so the last good
+		checkpoint survives and a restart resumes from known-good data.
+		*/
+		if(!INTERACT && mi64_iszero(arrtmp, j)
+			&& !(TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_MERSENNE && ihi == maxiter))
+		{
+			snprintf(cbuf,sizeof(cbuf), "ERROR: %s at iteration %u: the residue is identically zero (Res64 = %016" PRIX64 ", MaxErr = %10.9f).\n"
+				"This is not a possible result. For a PRP, Pepin or p-1 stage-1 run every iterate is a power of\n"
+				"a unit (mod N) and so can never be 0; for an LL run a zero residue is the \"M(p) is prime\"\n"
+				"verdict, which can only arise at the final iteration %u, not here. It therefore indicates a\n"
+				"broken build (e.g. a miscompiled or defective FFT/carry routine), failing hardware, or memory\n"
+				"corruption.\n"
+				"Note that the roundoff-error check cannot detect this by construction: it measures distance from\n"
+				"the nearest integer, and zero is exactly an integer, so MaxErr/AvgMaxErr read healthy no matter\n"
+				"how wrong the residue is. That is why this is checked separately.\n"
+				"Aborting *before* the savefile update, so the last good checkpoint is preserved. Please report\n"
+				"this, quoting the above line and attaching the %s file.\n"
+				,PSTRING,ihi,Res64,MME,maxiter,STATFILE);
+			mlucas_fprint(cbuf,1);
+			ASSERT(0,"Residue is identically zero - see preceding message.");
+		}
+
 		// Do not save a final residue unless p-1 (if not, still leave penultimate residue file intact).
 		// We don't save "final residue" in cofactor-PRP mode, since in the (mod M(p)) case this is for p+1 squarings (G-check needs this),
 		// i.e. needs a mod-div-by-base^2 postprocessing step to put in form of the p-1 squarings of the standard Fermat-PRP test:


### PR DESCRIPTION
## What this adds

One check, in the production-run checkpoint loop in `src/Mlucas.c`: **if the just-converted integer
residue is identically zero, log a diagnostic and abort — before the savefile is written.**

The point is not any one radix. It is that Mlucas has no way to notice a zeroed residue at all. `fracmax`
measures the distance of the inverse-weighted data from the nearest integer, and **zero is exactly an
integer**, so a run whose residue vector has been zeroed reports `MaxErr = AvgMaxErr = 0` — the one health
signal users watch reads *maximally good* precisely when the answer is entirely wrong. Three separate
defects have shipped with that signature:

| defect | affected builds | reported |
|---|---|---|
| radix1008 Mersenne (FFT 1008K/2016K) | AVX / AVX2 / AVX-512 | `Res64: 0000000000000000. AvgMaxErr = 0.000000000.` (#175) |
| radix4032 Fermat | AVX / AVX2 / AVX-512 | same |
| radix1024 under AVX-512 + LTO | AVX-512 | `Res64: 0000000000000000. AvgMaxErr = 0.000000000. MaxErr = 0.000000000.` (#68) |

Each was found by hand. A generic guard catches the next one for free.

The build-mode column is part measured, part inferred. What is measured, on `upstream/main` @ `47d75d3`:
the *exclusions* — `M15000017 @ 1008K -radset 0 -shift 0 -iters 100` returns the correct
`34B4CFB331D348C2` on both `nosimd` and `sse2` (matching the 1024K control), and `F25 @ 4032K -radset
0 -iters 100` returns the correct `376C33921E5F675F` on `sse2` (matching the 4096K control) — plus one
positive cell, radix1008 on AVX2 (the production run in "Proof it catches a real failure" below). The
plain-AVX and AVX-512 cells are **inferred**: they share the AVX-family arm of the same `#ifdef` ladder
as AVX2, and this box has no AVX-512 silicon. (Note `makemake.sh` with no argument auto-selects the
widest SIMD mode the host supports; the scalar build needs an explicit `nosimd`.)

### What the check does and does not catch

The condition is `mi64_iszero()` over the **whole residue**, not `Res64 == 0`. Those are not the same
test, and the difference is worth stating because a log line showing `Res64: 0000000000000000` does
*not* imply this guard would fire.

The radix992 defect fixed by #179 makes a good illustration — three wrong answers, of which this
guard catches one:

| case | residue | `Res64` as printed | guard fires? |
|---|---|---|---|
| scalar, Mersenne, 100 iters | **nonzero** (`Res mod 2^35-1 = 64`) | `0000000000000000` | no |
| SSE2, Fermat, 100 iters | nonzero | `0000000000000001` | no |
| SSE2, Fermat, 10 iters | identically zero | `0000000000000000` | **yes** |

The first row is the instructive one: dropping the Lucas-Lehmer `-2` turns the iteration into
`x -> x^2`, so from `x0 = 4` the result is `2^(2^k) mod M_p` — a single set bit, whose position is a
property of the exponent. For `p = 15000017` it lands above bit 63, so `Res64` reads as all zeros
while the residue is not zero at all.

So this guard should be understood as catching the *identically-zeroed-array* failure mode — which is
exactly the one the roundoff check is blind to, and the one all three defects in the table above
exhibit — rather than wrong answers in general. A cheap widening, if wanted: also test the
`Res mod 2^35-1` / `Res mod 2^36-1` values against zero, which would have caught two of the three
rows above at no extra cost. The general answer remains a cross-length residue comparison at the
same exponent, which is out of scope here.

---

## False-positive analysis

A guard that falsely aborts a multi-week run is worse than the bug it catches, so this is the part that
matters. The condition is `residue == 0`, **not** "residue looks small/sparse/suspicious", and it is
`!INTERACT`-only.

### Cases where a zero residue is impossible by construction

**PRP (both moduli), Pepin, p-1 stage 1** all compute `s^e (mod N)` for a fixed seed `s` — 3 for Pepin,
`PRP_BASE` (3 by default) for PRP and p-1. The seed is a unit for every modulus these paths accept:
`N = 2^p-1` is odd and `== 1 (mod 3)` for odd `p`; `N = F_m = 2^2^m+1` is odd and `== 2 (mod 3)` for
`m >= 1`. So `gcd(s,N) = 1`, every iterate is a unit, and no iterate can be `0 (mod N)`. Not "unlikely" —
impossible, at every iteration.

### The one legitimate zero: an LL test that has found a prime

M(p) is prime **iff** the residue after the final (p-2)nd squaring is identically zero — that is literally
the `isprime` test a few hundred lines further down this same function. So `ihi == maxiter` is exempted for
LL/Mersenne.

Before the last iteration, a zero cannot occur when M(p) is prime: `s_i == 0` forces `s_(i+1) == -2`,
`s_(i+2) == 2` and `s_j == 2` for all `j >= i+2`, hence `s_(p-2) == 2 != 0`, contradicting primality. When
M(p) is composite an intermediate zero is not *formally* impossible, but its heuristic probability is `2^-p`
per checkpoint (~`1e-4515000` at p = 15M), and a run that hit it would have gone on to report the same
"composite" verdict that a rerun reproduces. The cost in that universe is one restarted assignment.

### Verified empirically, not just argued

All runs are production mode (`worktodo.txt`, no `-iters`), `CheckInterval = 1000` so checkpoints come
often, gcc 16.1.1, AVX2, this branch:

| legitimate-zero / near-zero case | test | result |
|---|---|---|
| **LL of a genuine Mersenne prime** — the case that must not fire | `Test=110503` (M110503 *is* prime) run to completion | 111 checkpoints; final `Iter# = 110501 … Res64: 0000000000000000`; **guard silent**; `M110503 is a known MERSENNE PRIME.` reported |
| PRP, Mersenne | `PRP=N/A,1,2,110503,-1,75,0` to completion | 110 checkpoints, final `Res64: 0000000000000009` (= PRP_BASE²), no fire |
| Pepin, Fermat | `Fermat,Test=16` @ 4K to completion | 66 checkpoints, final `Res64: 40ABB0C5BFF05CB5`, `F16 is not prime`, no fire |
| p-1 stage 1 | `Pminus1=N/A,1,2,110503,-1,1000,0` (B1 clamped to 10000; 14541-bit S1 product) | 14 checkpoints, ran to the stage-1 GCD, no fire |
| healthy LL, larger FFT | M17500013 @ 896K `{224,8,16,16}` | 170 consecutive checkpoints, no fire |
| scalar (`nosimd`) build | `Test=110503` run to completion | 111 checkpoints, final `Res64: 0000000000000000` at iter 110501, guard silent, prime verdict reported — same as AVX2 |
| **restart from savefile** | killed a production LL at iter 6000, restarted | resumed and ran to completion (111 checkpoints), no fire on the first post-restart checkpoint |
| **early iterations / "residue hasn't filled in"** | M15000017 @ 1024K, `-iters 1/2/3` | `Res64` = `…0E`, `…C2`, `…9302` — nonzero from iteration 1. The guard only runs at checkpoints anyway, and `CheckInterval` has a hard floor of 1000. |
| self-test / timing-test modes | see regression section | excluded by `!INTERACT` |

### Cases considered and deliberately excluded

**`MaxErr == 0.0` is not part of the condition.** Two reasons. It adds no safety — a zero residue is already
impossible on its own — and it would *lose* coverage where the data are zeroed only part-way through an
interval, or where a nonzero `MME` from earlier in the interval survives. More importantly, `MaxErr = 0.0`
is a legitimate value in its own right: a healthy `M15000017 -fftlen 1024 -shift 0` reports
`MaxErr = 0.000000000` at 1, 2 and 3 iterations, while the residue is still a small integer. Anything keyed
on it would need interval gating that the zero-residue test does not.

**No "residue looks too sparse" test**, even though one would additionally catch the failure mode where the
residue collapses to a single power of two (see "what this does *not* catch", below). It is probabilistic
rather than impossible-by-construction, and it would need a final-iteration exemption for *every* test type,
because at `ihi == maxiter` the correct answer is exactly what such a test looks for: 0 for an LL prime,
`N-1 = 2^2^m` for a Pepin prime, 1 or `PRP_BASE²` for a PRP. Three chances to abort a multi-week run on its
single most important iteration is not a trade worth making.

**p-1 stage 2 is out of scope** — it does not pass through this loop, and its accumulator is a *product of
differences*, for which zero is not obviously impossible. Deliberately left alone.

**`AME_ITER_START`** gates only the `AvgMaxErr` accumulation, never the residue; it has no bearing on this
condition.

---

## Where it sits and what it does

`src/Mlucas.c`, in the `for(;;)` checkpoint loop of `ernstMain()` — immediately after the interval's
`Iter# = …` progress line is logged, and *before* `WRITE_RESTART_FILE`:

```c
if(!INTERACT && mi64_iszero(arrtmp, j)
    && !(TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_MERSENNE && ihi == maxiter))
{
    ... mlucas_fprint(cbuf,1);
    ASSERT(0,"Residue is identically zero - see preceding message.");
}
```

`arrtmp[0..j-1]` is the residue that `convert_res_FP_bytewise()` just produced a few lines above, so the
test is exact rather than a `Res64` sample, and it costs one `mi64_iszero()` over `p/64` limbs once per
checkpoint — thousands to a million squarings apart.

Ordering matters twice over: the normal progress line is still written first, so the `.stat` file records
the standard `Res64: 0000000000000000 … AvgMaxErr = 0.000000000` datum a maintainer will want; and the abort
happens **before** the savefile update, so the last known-good checkpoint survives and a restart resumes
from good data rather than from a poisoned residue.

`!INTERACT` scoping is deliberate: in `-iters`/`-s` mode the caller compares the residue against the
built-in reference tables, and a bad radix set must not abort the sweep. (That the sweep currently *accepts*
an all-zero residue as a pass is a real problem, but a separate one.)

---

## Proof it catches a real failure

`upstream/main`'s live radix1008 Mersenne defect (#175), AVX2, as an actual production run — same
`worktodo.txt`, same `mlucas.cfg`, same command line, two binaries differing only by this commit:

**Before** (`Mlucas.base`): runs happily, forever.

```
[…] M17500013 Iter# = 1000 [ 0.01% complete] … Res64: 0000000000000000. AvgMaxErr = 0.000000000. MaxErr = 0.000003637.
[…] M17500013 Iter# = 2000 [ 0.01% complete] … Res64: 0000000000000000. AvgMaxErr = 0.000000000. MaxErr = 0.000000000.
[…] M17500013 Iter# = 3000 [ 0.02% complete] … Res64: 0000000000000000. AvgMaxErr = 0.000000000. MaxErr = 0.000000000.
…
$ ls -l p17500013
-rw-r--r-- 1 mark mark 2187549 …          <- zero residue checkpointed to disk
```

**After**: stops at the first checkpoint, writes no savefile.

```
[…] M17500013 Iter# = 1000 [ 0.01% complete] … Res64: 0000000000000000. AvgMaxErr = 0.000000000. MaxErr = 0.000003637.
ERROR: M17500013 at iteration 1000: the residue is identically zero (Res64 = 0000000000000000, MaxErr = 0.000003637).
This is not a possible result. For a PRP, Pepin or p-1 stage-1 run every iterate is a power of
a unit (mod N) and so can never be 0; for an LL run a zero residue is the "M(p) is prime"
verdict, which can only arise at the final iteration 17500011, not here. It therefore indicates a
broken build (e.g. a miscompiled or defective FFT/carry routine), failing hardware, or memory
corruption.
Note that the roundoff-error check cannot detect this by construction: it measures distance from
the nearest integer, and zero is exactly an integer, so MaxErr/AvgMaxErr read healthy no matter
how wrong the residue is. That is why this is checked separately.
Aborting *before* the savefile update, so the last good checkpoint is preserved. Please report
this, quoting the above line and attaching the p17500013.stat file.
ERROR: Function ernstMain, at line 2133 of file ../src/Mlucas.c
Assertion '0' failed: Residue is identically zero - see preceding message.

$ ls p17500013
ls: cannot access 'p17500013': No such file or directory
```

(Repro: `Test=17500013` in `worktodo.txt`, `CheckInterval = 1000` in `mlucas.ini`, an `mlucas.cfg` entry
`1008  msec/iter = … radices = 1008 16 32`, then `./Mlucas -fftlen 1008 -shift 0`. M17500013's default
length is 896K, so 1008K passes the 9/8 command-line-override rule; `-shift 0` because with a nonzero shift
this defect surfaces as a spurious ROE instead.)

The Fermat-side instance of the same bug family has the same signature — `F26 -fft 4032 -radset 0/1
-iters 100` gives `Res64 = 0`, `Res mod 2^35-1 = 0`, `Res mod 2^36-1 = 0`, `AvgMaxErr = MaxErr =
0.000000000`, i.e. an identically-zero residue that this guard's condition matches. (It is not reachable as
a production run today: a 4032-leading radix set cannot be encoded in `fermat.cfg`, since
`get_preferred_fft_radix()` asserts `k <= 1024` on the leading radix.)

### What this does *not* catch — measured, not assumed

**radix992 (#179) is not caught.** Its missing LL carry injection made the run compute `x²` instead of
`x²-2`, i.e. `4^(2^i) = 2^(2^(i+1))` — a *power of two*, not zero. On this branch, scalar build,
`M15000017 -fftlen 992 -radset 0 -shift 0`:

```
-iters  100 -> Res64: 0000000000000000, Res mod 2^35-1 =  64, Res mod 2^36-1 =     32768
-iters 1000 -> Res64: 0000000000000000, Res mod 2^35-1 = 128, Res mod 2^36-1 = 536870912
```

`Res64` is zero only because the single set bit sits above bit 63; the residue itself is nonzero, so the
guard correctly stays silent. Catching that one needs the sparsity test rejected above. Worth saying
plainly rather than claiming the guard covers the whole class.

**radix1024 / AVX-512 (#68)** should be caught — the residue-array instrumentation from that investigation reports
`post-carry sumsq=0.00000000e+00 nonzero=0 a[0]=0`, i.e. an identically-zero residue — but I did not
re-verify it here; this box has no AVX-512 silicon and I did not stand up SDE for this change.

---

## Regression

gcc 16.1.1, `-O3 -flto=auto`, clean builds in `avx2` and `nosimd`; no new warnings in `Mlucas.c` in either.

* `-s tt`: passes, 0 `Res64 Error`s; 13K/14K/15K = `E3BC90B0E652C7C0` / `DB8E39C67F8CCA0A` /
  `B3C5A1C03E26BB17`, matching the built-in references.
* `-s s`: passes, 127 residues, 0 `Res64 Error`s.
* `M3888509 -fft 192 -radset 0/1/2 -iters 100` → `71E61322CCFB396C` for all three, unchanged.
* The production runs in the false-positive table above (LL, PRP, Pepin, p-1, restart) all complete with
  their expected final residues.

Self-tests cannot be affected in any case: the guard is `!INTERACT`.

## Not verified locally

Real AVX-512 hardware (and hence the radix1024 failure #68 fixes); non-x86 targets; Windows/macOS. The change is plain
C with no arch-dependent behaviour.



