### PR TITLE
twopmmodq64/128/192/256: fix start_index underflow that returns the seed for exponents just above the routine width

### DIFF
--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -1214,12 +1214,18 @@ uint64 twopmmodq64(uint64 p, uint64 q)
 	qhalf  = q>>1;	/* = (q-1)/2, since q odd. */
 	// Extract leftmost 7 bits of (p - 64); if > 64, use leftmost 6 instead:
 	pshift = p - 64;	j = leadz64(pshift);
-	leadb = (pshift<<j) >> 57;	// No (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 64) {
-		start_index = 58-j;
-		leadb >>= 1;
+	if(j > 57) {	// pshift < 64, i.e. fewer than 7 significant bits: the 7-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = pshift;	start_index = 0;
 	} else {
-		start_index = 57-j;
+		leadb = (pshift<<j) >> 57;	// No (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 64) {
+			start_index = 58-j;
+			leadb >>= 1;
+		} else {
+			start_index = 57-j;
+		}
 	}
 	/* q must be odd for Montgomery-style modmul to work: */
 	ASSERT((q & 0x1) && (q > 1), "q must be odd > 1!");
@@ -1333,8 +1339,14 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 	uint32 leadb, start_index;
 
 	// Extract leftmost 6 bits of p and subtract from 64:
-	leadb = (p<<j) >> 58;
-	start_index = 58-j;
+	if(j > 58) {	// p < 32, i.e. fewer than 6 significant bits: the 6-bit extraction below would
+					// left-pad p with zeros (leadb != p) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of p as the lead chunk:
+		leadb = p;	start_index = 0;
+	} else {
+		leadb = (p<<j) >> 58;
+		start_index = 58-j;
+	}
 
 	/* q must be odd for Montgomery-style modmul to work: */
 	ASSERT(q1 > 1 && q1 > 1 && q2 > 1 && q3 > 1 , "modulus must be > 1!");

--- a/src/twopmodq128.c
+++ b/src/twopmodq128.c
@@ -93,12 +93,18 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	}
 	// Extract leftmost 8 bits of (p - 128); if > 128, use leftmost 7 instead:
 	x.d0 = 128ull; x.d1 = 0ull; SUB128(p,x,pshift); j = leadz128(pshift);
-	LSHIFT128(pshift,j,x);	leadb = x.d1 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 128) {
-		start_index = 128-7-j;
-		leadb >>= 1;
+	if(j > 120) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
 	} else {
-		start_index = 128-8-j;
+		LSHIFT128(pshift,j,x);	leadb = x.d1 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 128) {
+			start_index = 128-7-j;
+			leadb >>= 1;
+		} else {
+			start_index = 128-8-j;
+		}
 	}
 #if FAC_DEBUG
 	if(dbg) {
@@ -141,7 +147,8 @@ uint128 twopmmodq128(uint128 p, uint128 q)
 	if(leadb == 128)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT128(x,leadb,x);	// x <<= leadb;
+		// x is reused as scratch above, so must zero its high words before seeding with 2^leadb:
+		x.d0 = 1ull; x.d1 = 0ull;	LSHIFT128(x,leadb,x);	// x <<= leadb;
 		MONT_MUL128(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq192.c
+++ b/src/twopmodq192.c
@@ -93,12 +93,18 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	}
 	// Extract leftmost 8 bits of (p - 192); if > 192, use leftmost 7 instead:
 	x.d0 = 192ull; x.d1 = x.d2 = 0ull; SUB192(p,x,pshift); j = leadz192(pshift);
-	LSHIFT192(pshift,j,x);	leadb = x.d2 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	if(leadb > 192) {
-		start_index = 192-7-j;
-		leadb >>= 1;
+	if(j > 184) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
 	} else {
-		start_index = 192-8-j;
+		LSHIFT192(pshift,j,x);	leadb = x.d2 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		if(leadb > 192) {
+			start_index = 192-7-j;
+			leadb >>= 1;
+		} else {
+			start_index = 192-8-j;
+		}
 	}
 #if FAC_DEBUG
 	if(dbg) {
@@ -136,7 +142,9 @@ uint192 twopmmodq192(uint192 p, uint192 q)
 	if(leadb == 192)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT192(x,leadb,x);	// x <<= leadb;
+		// x holds (2 - q*qinv) scratch from the Newton iteration above, whose high words are
+		// nonzero; must zero them before seeding with 2^leadb, else leadb < 64 shifts in garbage:
+		x.d0 = 1ull; x.d1 = x.d2 = 0ull;	LSHIFT192(x,leadb,x);	// x <<= leadb;
 		MONT_MUL192(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 

--- a/src/twopmodq256.c
+++ b/src/twopmodq256.c
@@ -128,8 +128,14 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	}
 	// Extract leftmost 8 bits of (p - 256):
 	x.d0 = 256ull; x.d1 = x.d2 = x.d3 = 0ull; SUB256(p,x,pshift); j = leadz256(pshift);
-	LSHIFT256(pshift,j,x);	leadb = x.d3 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
-	start_index = 256-8-j;
+	if(j > 248) {	// pshift < 128, i.e. fewer than 8 significant bits: the 8-bit extraction below would
+					// left-pad pshift with zeros (leadb != pshift) and underflow the unsigned start_index,
+					// leaving 0 loop passes and returning the seed. Use all of pshift as the lead chunk:
+		leadb = (uint32)pshift.d0;	start_index = 0;
+	} else {
+		LSHIFT256(pshift,j,x);	leadb = x.d3 >> 56;	// leadb = (pshift<<j) >> 57; no (pshift = ~pshift) step in positive-power algorithm!
+		start_index = 256-8-j;
+	}
 #if FAC_DEBUG
 	if(dbg) {
 		printf("leadb = %u\n",j);
@@ -166,7 +172,9 @@ uint256 twopmmodq256(uint256 p, uint256 q)
 	if(leadb == 256)
 		x = rsqr;
 	else {
-		x.d0 = 1ull; LSHIFT256(x,leadb,x);	// x <<= leadb;
+		// x holds (2 - q*qinv) scratch from the Newton iteration above, whose high words are
+		// nonzero; must zero them before seeding with 2^leadb, else leadb < 192 shifts in garbage:
+		x.d0 = 1ull; x.d1 = x.d2 = x.d3 = 0ull;	LSHIFT256(x,leadb,x);	// x <<= leadb;
 		MONT_MUL256(x,rsqr, q,qinv, x);	// x*R (mod q) = MONT_MUL(x,R^2 (mod q),q,qinv)
  	}
 


### PR DESCRIPTION
> **Merge order:** this PR is complete on its own for widths 64, 128 and 256. **Width 192 additionally needs #167** — after this patch a 19,200-case sweep still shows 3,024 mismatches at 192 bits, every one of them the separate `SQR_LOHI192` dropped-carry bug; with #167 applied on top, all four widths sweep clean. #167 touches only `imul_macro1.h`, so the two do not conflict. Details in the verification section below.
>
> Verified to merge cleanly with #172 (which touches the same three files) and with the rest of the current batch (#183, #184, #188, #189, #190).

## Summary

`twopmmodq64`, `twopmmodq128`, `twopmmodq192` and `twopmmodq256` return their **seed instead of a result** — silently, with no assert and no diagnostic — for every exponent in a window just above the routine's own width.

These are the "conventional positive-power" true-mod routines. They set `pshift = p - W` (`W` = 64/128/192/256), extract the leftmost 7 (`W=64`) or 8 (`W>=128`) bits of `pshift` into `leadb`, and derive the powering-loop trip count as `start_index = bitlen(pshift) - (bits extracted)`.

When `pshift` has fewer significant bits than the extraction width, two things break at once:

* the normalize-then-shift extraction left-pads `pshift` with zeros, so `leadb` is a *shifted-up* value, not the true leading chunk;
* `start_index` (a `uint32`) **underflows**. `for(j = start_index-1; j >= 0; j--)` converts that huge unsigned value to a negative `int32`, so the loop runs **zero passes** and the seed is returned unchanged.

## Affected exponent ranges (measured, odd modulus)

| routine | wrong for | i.e. `pshift = p - W` |
|---|---|---|
| `twopmmodq64`  | `p` in **[65, 96]**   | `<= 32` |
| `twopmmodq128` | `p` in **[129, 192]** | `<= 64` |
| `twopmmodq192` | `p` in **[193, 288]** | `<= 96` |
| `twopmmodq256` | `p` in **[257, 383]** | `<= 127` |

The four windows are **not** the same shape. The `if(leadb > W) { use one fewer bit; }` fallback rescues the upper part of the sub-width range for 64/128/192, so those windows stop at `pshift = W/2`; `twopmmodq256` has no such fallback (8 bits can never exceed 256), so its entire sub-8-bit range is affected. The `leadb == W` boundary is also wrong in the 64/128/192 routines, because a 7/8-bit chunk exactly equal to `W` takes the wider-extraction branch.

## Fix

When `pshift` has fewer bits than the extraction width, use `pshift` itself as the leading chunk with `start_index = 0`. In that case `pshift < 128` (`< 64` for the 64-bit routine), so it fits the `leadb` slot and `2^pshift` is exactly the seed the loop-free case wants.

Exercising small `leadb` values exposed a second, latent defect in the multiword routines: the seed was built as

```c
x.d0 = 1ull; LSHIFTn(x,leadb,x);   // x <<= leadb
```

without zeroing `x`'s high words, which at that point still hold the `(2 - q*qinv)` scratch left by the Newton iteration — only its low 128 bits are 1, the rest is nonzero garbage. Upstream never hit it because `leadb` was always `>= W/2` on the reachable paths, which shifts the garbage words out of the result; with `leadb < 128` it shifts straight in. The high words are now zeroed explicitly.

## Other routines with this idiom

The negative-power siblings (`twopmodq63/64/78/96/100/128/128x2/160/192/256` and their `_q4`/`_q8` variants) use the same `leadz`-normalize / `start_index = W - j - k` idiom but form `pshift = p + W`, so `pshift >= W+1` and its bit length can never fall below the extraction width — `start_index >= 0` for every input. **They do not have this defect.**

The one exception is `twopmmodq64_q4`, which does a 6-bit extraction off `p` itself and underflows for `p` in **[1, 31]**. It has no callers anywhere in the tree (only the prototype in `factor.h`), but it is fixed here the same way. Its portable and `YES_ASM` loops both read the same `start_index` (`movslq` sign-extends the underflowed value to -1 and skips the loop, exactly as the C does), so the single fix in the shared prologue covers both.

## Verification

Reference: Python `pow(2, p, q)`. Driver calls each routine directly and prints `p`, `q`, result.

* **`p` = 1..1200 x 16 random moduli, per width** = 19,200 cases/width, 76,800 total.
  * before: **512 / 1024 / 4560 / 2032** mismatches for 64 / 128 / 192 / 256
  * after: **0 / 0 / 3024 / 0**
* **695 large exponents** (`2^e +- 2` for e = 6..63, 400 random `p < 2^62`, and the Mersenne exponents 57885161 / 82589933 / 136279841) x 4 moduli = 2,780 cases/width: **0 mismatches** for widths 64/128/256 after the fix. This covers the untouched common path, including `p` up to ~9.2e18.
* The width-192 residual is **entirely** the separate `SQR_LOHI192` dropped-carry bug (#167, ~25% of inputs, only reachable once `start_index >= 1` — the residual failures start at `p = 385`, the first exponent whose loop actually squares). With #167 applied on top of this patch, **all four widths sweep clean: 0 mismatches** over both the 1..1200 set and the large-exponent set.
* Repeated with a `-DNO_ASM` build to cover the portable code paths: same results.
* `twopmmodq64_q4`: `p` = 0..3000 x 4 moduli = 12,004 cases — 31 wrong exponents before, **0 after**, in both `YES_ASM` and `NO_ASM` builds.
* 100-iteration self-tests unchanged: 13K = `E3BC90B0E652C7C0`, 14K = `DB8E39C67F8CCA0A`, 15K = `B3C5A1C03E26BB17`.

## Not fixed here

Sweeping with **even** moduli (which is the normal case at the `Mlucas.c` call sites, where the modulus is `KNOWN_FACTORS[i]-1`) turns up one further, distinct bug, verified present in `main` and *not* addressed by this PR: the `p <= W` direct-compute early-out is evaluated **before** the power-of-2 is removed from `q`, so for `p` in `(W, W + trailz(q)]` the subsequent `p -= nshift` drops `p` to `<= W` and `pshift = p - W` wraps. Measured failing exponents with `q` a multiple of 8: `p` in {65,66} / {129,130} / {193,194} / {257,258} for the four widths, widening with larger `trailz(q)`. Different root cause and a different fix shape (early-out vs. nshift ordering), and it touches the same lines as #172, so it is left for a separate change.

With this patch plus #167 and #172 applied, the only remaining even-modulus failures are exactly that `(W, W + trailz(q)]` window; everything else sweeps clean.

