### PR TITLE
Pepin test misreports a Fermat prime as composite when the residue shift is nonzero

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1783,6 +1783,10 @@ READ_RESTART_FILE:
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *)
 						= ((MODULUS_TYPE == MODULUS_TYPE_MERSENNE) ? mers_mod_square : fermat_mod_square);
 	int update_shift = (RES_SHIFT != 0ull);	// If shift = 0 at outset, don't update (only need for Fermat-mod, due to the random-bit aspect there)
+	// ...in which case the Fermat-mod sign-flip flag is never updated either, so clear it here: it is a global and
+	// convert_res_FP_bytewise() now acts on it also for RES_SHIFT = 0, so a stale 1 from a preceding shifted
+	// assignment in the same multi-exponent run must not leak into this one.
+	if(!update_shift) RES_SIGN = 0;
 
 	if(TEST_TYPE == TEST_TYPE_PM1 && ilo >= maxiter) {
 		ASSERT(ilo == maxiter && ilo == PM1_S1_PROD_BITS,"For completed S1 expect ilo == maxiter == PM1_S1_PROD_BITS!");
@@ -5984,17 +5988,29 @@ void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, cons
 	must omit said high limb in residue-shift-and-sign-flip below, hence no p+63+(MODULUS_TYPE == MODULUS_TYPE_FERMAT):
 	***/
 	j = (p+63)>>6;	// # of 64-bit limbs
+	uint32 sign_flip = (MODULUS_TYPE == MODULUS_TYPE_FERMAT);
+	/* Whether the residue needs an explicit negation here depends on both RES_SIGN (set by the final mod-squaring:
+	1 = the shifted residue currently in a[] is the negative of 2^RES_SHIFT * R) and on whether we do the rotate:
+	the (p - RES_SHIFT)-bit lcshift carries an implicit factor 2^p == -1 (mod Fm), so it un-negates a sign-flipped
+	residue and negates an unflipped one. With RES_SHIFT = 0 there is no rotate and hence no implicit factor, so
+	the two cases invert. Prior to this fix the RES_SHIFT = 0 case was skipped entirely, which negated the reported
+	residue of any shifted run whose final shift happened to land on 0. */
+	int negate = sign_flip && (RES_SHIFT ? !RES_SIGN : (RES_SIGN != 0));
 	if(RES_SHIFT) {
 	//	fprintf(stderr,"convert_res_FP_bytewise: removing shift = %" PRIu64 "\n",RES_SHIFT);
-		uint32 sign_flip = (MODULUS_TYPE == MODULUS_TYPE_FERMAT);
 		mi64_shlc(u64_ptr, u64_ptr, p, p-RES_SHIFT,j,sign_flip);
-		// If current residue R needed a sign-flip - again, this can only happen in the Fermat-mod case -
-		// our shrc-done-as-shlc already took care of it. If not, need explicit negation. Rather than doing an
-		// explicit Fm - R, can simply do a bitwise-complement of the residue vector and further += 2 of limb 0:
-		if(sign_flip && !RES_SIGN) {	// sign_flip needed here since only do for Fermat case
-		//	fprintf(stderr,"%s: Flipping sign of residue...\n",func);
-			for(ii = 0; ii < j; ii++) { u64_ptr[ii] = ~u64_ptr[ii]; }	u64_ptr[0] += 2;
-		}
+	}
+	// Rather than doing an explicit Fm - R, can simply do a bitwise-complement of the residue vector and add 2:
+	if(negate) {
+	//	fprintf(stderr,"%s: Flipping sign of residue...\n",func);
+		// Fm - R = (2^p - 1 - R) + 2, i.e. bitwise-complement then increment by 2. The increment must be
+		// carry-propagated: R = 1 makes limb 0 of the complement = 2^64-2, and the +2 carries out of it.
+		// R = 1 is precisely the negated final Pepin residue of a Fermat *prime*, so dropping that carry
+		// rendered N-1 as (2^p - 2^64) rather than 0 in every nonzero-shift run.
+		for(ii = 0; ii < j; ii++) { u64_ptr[ii] = ~u64_ptr[ii]; }
+		// Carryout of the add is nonzero only in that R = 1 case, where the exact result 2^p is correctly
+		// represented by the low p bits being 0 - so discarding the carryout is what we want:
+		mi64_add_scalar(u64_ptr, 2ull, u64_ptr, j);
 	}
 	/* Checksums: */
 	if(Res64  ) *Res64 = ((uint64 *)ui64_arr_out)[0];

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -409,7 +409,6 @@ uint32	ernstMain
 	static double *a_ptmp = 0x0, *a = 0x0, *b = 0x0, *c = 0x0, *d = 0x0, *e = 0x0;
 	// uint64 scratch array and 4 pointers used to store cast-to-(uint64 *) version of above b,c,d,e-pointers
 	static uint64 *arrtmp = 0x0, *b_uint64_ptr = 0x0, *c_uint64_ptr = 0x0, *d_uint64_ptr = 0x0, *e_uint64_ptr = 0x0;
-	double final_res_offset;
 
 /*...time-related stuff. clock_t is typically an int (signed 32-bit)
 	and a typical value of CLOCKS_PER_SEC (e.g. as defined in <machine/machtime.h>
@@ -2459,16 +2458,28 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 					if(arrtmp[i] != 0x0) { isprime = 0; break; }
 				}
 			}
-		} else {	// older impl. of LL-test isprime parsed the entire double-float residue array:
+		} else if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
+			/* Pépin test: F_m is prime iff the final residue == N-1 == -1 (mod N). That comparison -
+			unlike the LL test's "residue == 0" in the else-clause below - is NOT invariant under the
+			circular residue shift, so it must not be read off the *shifted* double-float array a[]:
+			doing so reports a genuine Fermat prime as composite whenever the run ends with a nonzero
+			RES_SHIFT, which is the default (the shift is randomized at the start of a fresh run).
+			So use the shift-removed uint64 residue in arrtmp[] - filled by the convert_res_FP_bytewise()
+			call at the end of the iteration loop - which is the same array the Mersenne-PRP clause above
+			tests. It holds the residue fully reduced (mod N) but truncated to p bits, so N-1 = 2^p shows
+			up as all-limbs-zero; a Pépin residue of 0 cannot occur (gcd(3,F_m) = 1), so no ambiguity. */
 			isprime = 1;
-			/* For Fermat numbers, in balanced-digit form, it's prime if the lowest-order digit = -1, all others 0: */
-			final_res_offset = (MODULUS_TYPE == MODULUS_TYPE_FERMAT);
-			a[0] += final_res_offset;
+			j = (p+63)>>6;	// # of 64-bit limbs in the p-bit residue
+			for(i = 0; i < j; i++) {
+				if(arrtmp[i] != 0ull) { isprime = 0; break; }
+			}
+		} else {	// older impl. of LL-test isprime parsed the entire double-float residue array:
+			/* LL test: prime iff residue == 0, which *is* shift-invariant, so the shifted a[] is fine here: */
+			isprime = 1;
 			for(i = 0; i < n; i++) {
 				j = i + ( (i >> DAT_BITS) << PAD_BITS );
 				if(a[j] != 0.0) { isprime = 0; break; }
 			}
-			a[0] -= final_res_offset;
 		}
 
 	/************************************************************************************************************************/
@@ -6005,7 +6016,7 @@ void	convert_res_FP_bytewise(const double a[], uint8 ui64_arr_out[], int n, cons
 	//	fprintf(stderr,"%s: Flipping sign of residue...\n",func);
 		// Fm - R = (2^p - 1 - R) + 2, i.e. bitwise-complement then increment by 2. The increment must be
 		// carry-propagated: R = 1 makes limb 0 of the complement = 2^64-2, and the +2 carries out of it.
-		// R = 1 is precisely the negated final Pepin residue of a Fermat *prime*, so dropping that carry
+		// R = 1 is precisely the negated final Pépin residue of a Fermat *prime*, so dropping that carry
 		// rendered N-1 as (2^p - 2^64) rather than 0 in every nonzero-shift run.
 		for(ii = 0; ii < j; ii++) { u64_ptr[ii] = ~u64_ptr[ii]; }
 		// Carryout of the add is nonzero only in that R = 1 case, where the exact result 2^p is correctly

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -450,8 +450,14 @@ void	mi64_shlc(const uint64 x[], uint64 y[], uint32 nbits, uint32 nshift, uint32
 		if(cy) {
 			if(nwshift < len)
 				cy = mi64_sub_scalar(y+nwshift,cy,y+nwshift,len-nwshift);
-			// In Fermat-mod case, if high bits happen to = 0, must (mod Fm) by adding borrow = 1 back into low limb:
-			ASSERT(mi64_sub_scalar(y,cy,y,len) == 0ull, "Nonzero carryout of (mod Fm) low-limb incrementing!");
+			/* In Fermat-mod case, if high bits happen to = 0, must (mod Fm) by adding borrow = 1 back into low limb.
+			A borrow out of the [nbits]-wide subtract means the exact value (y - u) is negative, and y[] holds it in
+			two's-complement form, i.e. as (y - u) + 2^nbits. Reducing (mod 2^nbits+1) means adding the modulus, so
+			what still needs adding is the +1 - the code here used to *subtract* 1 instead (contra this comment),
+			leaving every underflow result 2 too small. The lone case where this add itself carries out of the
+			[nbits]-wide result is the exact value 2^nbits == -1 (mod Fm), which is not representable in nbits bits
+			and is correctly left encoded as 0 - so no assertion on the carryout: */
+			if(cy) mi64_add_scalar(y,cy,y,len);
 		}
 	} else {
 		cy = mi64_add(y, u, y, nwshift);	ASSERT(cy == 0ull, "Nonzero carryout of nonoverlapping vector add!");


### PR DESCRIPTION
A completed Pépin test that ends with a nonzero residue shift reports a genuine
Fermat prime as composite. The shift is randomized at the start of every fresh
Fermat run, so this is the default configuration, not a corner case.

Three defects in the same "final Fermat-mod residue with a shift in play" path;
the first two also produce wrong `Res64`s for ordinary composite runs, and the
verdict fix depends on them.

## 1. The Pépin verdict is read off the *shifted* residue

`Mlucas.c`, end of the iteration loop: the verdict was computed from the
double-float array `a[]`, which holds the **shifted** residue:

```c
final_res_offset = (MODULUS_TYPE == MODULUS_TYPE_FERMAT);
a[0] += final_res_offset;
for(i = 0; i < n; i++) { ... if(a[j] != 0.0) { isprime = 0; break; } }
```

LL's test is "residue == 0", which is invariant under a circular shift, so LL is
unharmed. Pépin's is "residue == N-1", which is not: with shift `s` the array
holds `±2^s·R`, so the `a[0] == -1` pattern only appears when `s == 0`.

Fixed by testing the shift-removed uint64 residue in `arrtmp[]` - the same array
the Mersenne-PRP clause immediately above already uses. `arrtmp[]` holds the
residue reduced mod N and truncated to p bits, so `N-1 = 2^p` shows up as
all-limbs-zero; a Pépin residue of 0 is impossible (`gcd(3,F_m) = 1`), so the
encoding is unambiguous.

## 2. `mi64_shlc()` Fermat-mod underflow correction has the wrong sign

`mi64.c`. The `sign_flip` path computes `(low << nshift) - (off-shifted high
bits)`. On borrow out of the nbits-wide result the exact value is negative and
`y[]` holds it as `value + 2^nbits`; reducing mod `2^nbits+1` needs **+1** more.
The code subtracted 1 - contradicting its own adjacent comment ("must (mod Fm)
by adding borrow = 1 back into low limb") - so every underflow result was 2 too
small.

This is the routine `convert_res_FP_bytewise()` uses to remove the shift, so it
is a **wrong-residue bug on its own**, reproducible on unpatched `main` with a
one-liner (F16, 4K FFT, leading radix 16 - radix < 16 carry routines reject
shifted residues):

```
Mlucas -f 16 -fft 4 -iters 10 -shift 0     -> Res64: 9DA4A09B9023D001
Mlucas -f 16 -fft 4 -iters 10 -shift 1     -> Res64: 9DA4A09B9023D003   <-- wrong
Mlucas -f 16 -fft 4 -iters 10 -shift 21845 -> Res64: 9DA4A09B9023D001
```

`3^(2^10) mod (2^65536+1)` has low 64 bits `9DA4A09B9023D001`, so shift 0 is the
correct one. After the fix all shifts agree with it at 4, 10 and 100 iterations.
A standalone check of `mi64_shlc()` against an `__int128` reference (nbits = 64,
9 inputs x nshift = 1..63) went from **189/567 cases wrong to 0/567**.

## 3. `convert_res_FP_bytewise()` sign-flip: dropped carry, and skipped at shift 0

- The negation `Fm - R` was `~R` followed by an uncarried `u64_ptr[0] += 2`. For
  `R = 1` the complement's limb 0 is `2^64-2` and the `+2` carries out; the carry
  was dropped. `R = 1` is precisely the negated final Pépin residue of a Fermat
  **prime**, so `N-1` came out as `2^p - 2^64` instead of 0 in every
  nonzero-shift run. Now uses `mi64_add_scalar()`.
- The sign-flip undo sat inside `if(RES_SHIFT)`. It is needed for
  `RES_SHIFT == 0` too, with the opposite polarity (no rotate means no implicit
  `2^p == -1` factor). A shifted run whose final shift lands on 0 (probability
  ~1/p) reported the negative of its residue: observed Res64 `FFFFFFFFFFFFFD90`
  for residue 625, and `1` for `N-1`. `RES_SIGN` is also now cleared for runs
  that do not track a shift, since `convert_res_FP_bytewise()` now consults it
  at shift 0 and it is a never-reset global.

## How this was tested

No Fermat prime is large enough to run (F0..F4 are 3, 5, 17, 257, 65537), so the
final residue was injected instead and the last mod-squarings done by the real
FFT/carry code: craft an F16 Pépin savefile at iteration `maxiter-M` holding
`2^(p/2^M)`. Since `2^p == -1 (mod F16)`, M mod-squarings land exactly on
`N-1` - the final Pépin residue of a genuine Fermat prime - so the correct
verdict is PRIME at every shift. Composite control: residue 5 at the same
iteration, ending on `5^(2^M)`, correct verdict "not prime" at every shift.
(`LowMem = 2` in `mlucas.ini` to disable the G-check, which is mutually
exclusive with shifted Pépin residues.)

Shifts swept, `M = 1`: 0, 1, 2, 3, 7, 1234, 21845, 32767.
`M = 2`: 16384, 20000, 24000, 30000, 45000 (all >= 16384, so the last squaring
sees a shift >= p/2, i.e. `RES_SIGN = 1`; 16384 also lands the final shift on 0).
`M = 3`: 1, 999, 8192, 9000, 20000 (8192 lands the final shift on 0).

| | prime-residue cases | composite-control cases |
|---|---|---|
| before | 1/16 correct (only shift 0 says PRIME) | verdict right, but Res64 off by 2 at 6 of 13 shifts, and negated at final-shift 0 |
| after | 16/16 PRIME, shift-removed Res64 = 0 everywhere | 13/13 "not prime" with the exact residues 25 / 625 / 390625 |

**LL and the other verdicts in that region are unaffected** - I checked: the LL
`residue == 0` test is shift-invariant, and the Mersenne-PRP clause above
already worked from the shift-removed `arrtmp[]`. Real full LL runs confirm it:
M86243 -> "known MERSENNE PRIME", M86249 -> "not prime", at shifts 0, 12345 and
40000, with identical final Res64 across shifts.

Standard self-tests unchanged: 13K `E3BC90B0E652C7C0`, 14K `DB8E39C67F8CCA0A`,
15K `B3C5A1C03E26BB17`.

## Not covered

- Only tested on x86-64 AVX2, gcc 16.1.1, single-threaded.
- Two harness cases (`M = 1` with shift 40000 / 65535) abort inside
  `convert_res_bytewise_FP()` with "Illegal combination of nonzero carry" on both
  the patched and unpatched builds. That is the savefile *read* path choking on a
  residue within `2^7232` of `2^p`, which only arises because the injected
  residues are pure powers of two; it is not on the path this PR changes and I
  did not chase it.
- Fermat PRP-CF is unaffected: it forces `RES_SHIFT = 0` at init, so with the new
  `RES_SIGN` clearing the negate decision is identical to before. The
  Pépin-with-known-factors variant, where `Suyama_CF_PRP()` zeroes `RES_SHIFT`
  partway through, can now negate where it previously did not - in the
  `RES_SIGN = 1` case, where the new behavior is the correct one. I did not run
  that path end to end.
- Resuming a shifted Pépin run from its savefile is still blocked by the
  pre-existing `ASSERT(RES_SHIFT == 0ull, "Shifted residues unsupported for Pépin
  test with Gerbicz check!")` (#99); this PR does not touch that.
