### PR TITLE
factor.c: make the Mfactor worker mutexes static (they currently serialise nothing)

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -2679,7 +2679,11 @@ MFACTOR_HELP:
 		// Proper init (as opposed to no-init) key to avoiding deadlock here.
 		// Started with 2 separate _checkpoint and _foundfactor mutexes here, but since both code sections
 		// in question call some of the same mi64 functions, replaced with 'one mutex to rule them all' model:
-		pthread_mutex_t mutex_mi64        = PTHREAD_MUTEX_INITIALIZER,
+		/* These MUST be static. PerPass_tfSieve() is itself the per-thread worker entry point, so a
+		non-static local here gives every thread its own private mutex on its own stack: each
+		pthread_mutex_lock() below then succeeds immediately against a lock no other thread can even
+		name, and the critical sections serialise nothing at all. */
+		static pthread_mutex_t mutex_mi64        = PTHREAD_MUTEX_INITIALIZER,
 						mutex_updatecount = PTHREAD_MUTEX_INITIALIZER;	// No mi64 calls here.
 	#endif
 		FILE *fp = 0x0;


### PR DESCRIPTION
### The bug

`PerPass_tfSieve()` is the per-thread worker entry point — it is what `threadpool_add_task()` dispatches, `NTHREADS` at a time. Both of its mutexes were declared as **non-static locals**:

```c
pthread_mutex_t mutex_mi64        = PTHREAD_MUTEX_INITIALIZER,
                mutex_updatecount = PTHREAD_MUTEX_INITIALIZER;	// No mi64 calls here.
```

So every thread constructs its own pair on its own stack. Each `pthread_mutex_lock()` then succeeds immediately against a lock no other thread can even name, and **both critical sections provide no mutual exclusion at all**.

The intent was clearly the opposite — the comment immediately above reads:

> Started with 2 separate `_checkpoint` and `_foundfactor` mutexes here, but since both code sections in question call some of the same mi64 functions, replaced with 'one mutex to rule them all' model

### What that leaves unprotected

* **`mutex_mi64`** guards two regions of `PerPass_tfSieve()` — the checkpoint region and the found-factor region — which call `mi64_twopmodq()`, `mi64_twopmodq_qmmp()` and `mi64_div()`. All three own file-static scratch buffers: `mi64_twopmodq()`'s `static uint64 *pshift, *qhalf, *qinv, *x, *lo, *hi`, the equivalent set at the top of `mi64_twopmodq_qmmp()`, and via `mi64_div()` the `static uint64 *scratch` base pointers in `mi64_div_mont()` and `mi64_div_binary()`. So concurrent workers share that scratch with nothing serialising them. `mi64` carries no thread-safety documentation anywhere in the tree, and these are the only two application-level mutexes in the codebase, so this lock was the entire protection.
* **`mutex_updatecount`** guards `*(targ->count) += count;` — a read-modify-write on state shared by every worker — so the reported q-tried total can silently lose updates.

The workers genuinely are concurrent: the dispatch loop adds `NTHREADS` tasks and only afterwards waits for the pool to drain.

### Evidence

Verified by storage class rather than by argument. Compiling `factor.c` with `-DFACTOR_STANDALONE -DP1WORD -DTRYQ=4` and listing symbols:

| | mutex symbols in `factor.o` |
| --- | --- |
| before | *none* — both are stack locals, one pair per thread |
| after | `b mutex_mi64.19`, `b mutex_updatecount.18` — single shared objects in `.bss` |

`factor.c` compiles clean with the fix under both `-DP1WORD` and `-DNWORD`.

### Why the first evidence was storage-class only

When this PR was opened I could not build Mfactor on this machine to run it under ThreadSanitizer, because of a **pre-existing, unrelated build break**: `twopmodq100_2WORD_DOUBLE_q4()` is called from the `USE_FMADD` arm of `PerPass_tfSieve()`'s single-word trial-division dispatch but is defined nowhere in the tree. Under gcc 16 that is a compile error (`implicit declaration of function`); downgrading that diagnostic turns it into `undefined reference to 'twopmodq100_2WORD_DOUBLE_q4'` at link time. Reproduced on `main` with and without sanitizer flags, for both `mfac 1word` and `mfac nword`.

That break is fixed by **#193** (with **#82**); the ThreadSanitizer results below were taken on top of both. It may also explain why these races were never observed in practice — if Mfactor has not built on a recent toolchain for some time, the multithreaded factoring path has not been exercised there.

---

### Relationship to other open PRs

* **#161** (`threadpool: fix unsynchronized busy-wait on free_tasks_queue`) fixes the *dispatch* side of the same threading path — the `while(tpool->free_tasks_queue.num_tasks != NTHREADS)` spin that `PerPass_tfSieve`'s callers use to wait for the pool to drain. This PR fixes the *worker* side. They are complementary and touch no common lines; verified to merge cleanly with each other.
* **#193** and **#82** are the build fixes that make Mfactor buildable at all on a current toolchain; they contribute no behaviour change to the threading path. #193 is specifically the `twopmodq100_2WORD_DOUBLE_q4` break described above.
* **#137** (`fix-gcc16-asm`) is the other gcc-16 build work, but it touches only `radix16_dif_dit_pass.c` and is unrelated to `factor.c`.

---

### ThreadSanitizer confirms the race (added after #193 and #82 made Mfactor buildable)

With #193 and #82 applied, Mfactor builds, so this is now observable directly rather than only by storage class. `Mfactor_1word -m 2147483647 -bmax 50 -nthread 4`, built `-O1 -fsanitize=thread`, on **unmodified** `factor.c`:

```
WARNING: ThreadSanitizer: data race
  Read of size 8 at 0x7ffde3044cd8 by thread T1 (mutexes: write M0):
    #0 PerPass_tfSieve ../src/factor.c:4089
  Previous write of size 8 at 0x7ffde3044cd8 by thread T2 (mutexes: write M1):
    #0 PerPass_tfSieve ../src/factor.c:4089
  Location is stack of main thread.
```

The cited line in that build is exactly `*(targ->count) += count;` — the read-modify-write `mutex_updatecount` is supposed to protect. Six ThreadSanitizer reports in the run, five of them naming that line.

The decisive detail is the mutex annotation: **T1 holds `M0` while T2 holds `M1`**. Both threads are inside the critical section, each holding a lock, and they still race — because each locked its own private copy. That is the bug stated in TSan's own words.

The same run also flags two sites in `threadpool.c`, which is the dispatch-side problem #161 addresses.

**With this patch applied**, rebuilt into a clean object directory and re-run identically:

| | before | after |
| --- | --- | --- |
| worker-vs-worker races | 3 | 2 |
| mutexes held in a worker-vs-worker report | `M0`, `M1` — two *different* locks | `M0` — one shared lock |
| main-vs-worker races | 2 | 3 |

The mutex annotation is the thing to look at: it goes from two distinct locks to one. That is the scope bug fixed, observed directly — the workers now contend the same mutex instead of each taking a private copy.

**It does not make the run TSan-clean, and this patch alone cannot.** The counter races that remain are `main` versus a worker, not worker versus worker:

```
Write of size 8 by main thread:
  #0 main ../src/factor.c:2302
Previous read of size 8 by thread T3 (mutexes: write M0):
  #0 PerPass_tfSieve ../src/factor.c:4093        <- *(targ->count) += count;
As if synchronized via sleep:
  #0 nanosleep ... #2 main ../src/factor.c:2372
```

The main thread touches that memory without taking `mutex_updatecount` at all, and its only "synchronization" with the workers is the `mlucas_nanosleep` spin on `free_tasks_queue` — which is precisely the defect **#161** fixes. So for the shared counter this change is necessary but not sufficient: it wants #161 alongside it. For the `mi64` static scratch, which is only ever touched from workers, this change is the whole fix.

*Caveat on the earlier attempt:* my first before/after comparison was invalid and I nearly reported it as a clean pass. `makemake.sh` refuses to overwrite an existing `obj_mfac/Mfactor_1word` and silently leaves the old binary, so the "after" run re-executed unfixed code — and separately, the patch shifts line numbers, so comparing by a `factor.c:NNNN` citation across builds compares different statements. The numbers above come from a clean `obj_mfac`, with `nm factor.o` checked for the two `.bss` mutex symbols before running, and sites matched by content. (The `factor.c:NNNN` references in the TSan output quoted above are that build's, not `main`'s.)

### All four together: ThreadSanitizer-clean

`#192 + #161 + #193 + #82`, same build (`-O1 -fsanitize=thread`) and same command (`Mfactor_1word -m 2147483647 -bmax 50 -nthread 4`, 4 passes each time):

| applied | TSan reports | worker↔worker | main↔worker | exit |
| --- | --- | --- | --- | --- |
| #193 + #82 only (build fixes; threading untouched) | 6 | 3 | 3 | 66 |
| + **#192** | 6 | 2 | 5 | 66 |
| + **#192 + #161** | **0** | **0** | **0** | **0** |

66 is ThreadSanitizer's default exit code when it has reported something; 0 means it reported nothing. The last run also completes the workload normally — *"Performed 657696 trial divides"*, identical to the middle run, so the clean result is not a run that did less work.

That confirms the split suggested above: **#192 removes the worker↔worker races** (each thread had been locking a private copy of the mutex), and **#161 removes the main↔worker ones** (the `mlucas_nanosleep` spin on `free_tasks_queue` was not a synchronisation edge). Neither is sufficient alone; together the multithreaded Mfactor path is race-free under TSan for this workload. #193 and #82 contribute no behaviour — they are only what makes Mfactor buildable so any of this can be observed.
