### PR TITLE
factor.c: don't take the USE_FMADD path — its 100-bit modpow routines do not exist (Mfactor unbuildable on AVX2 and AVX-512)

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -146,7 +146,17 @@ To build the sieve factoring code in standalone mode, see the compile instructio
 #endif
 
 #ifdef	USE_FMADD	// Need to add 100-bit modpow routines before enabling this for build of this file
-	#warning USE_FMADD set in factor.c ... Using 100-bit FMA-based modpow.
+	/* ...and they never were, so honour that literally rather than merely warning about it: the
+	twopmodq100_2WORD_DOUBLE[_q2,_q4] routines the USE_FMADD call sites below name do not exist.
+	Undef so the dispatch falls through to the implemented paths - USE_FLOAT's 78-bit 3-word-double
+	routines where USE_FLOAT is set, else the 63/64/96/128-bit integer ones.
+	  The undef must cover the whole file, not just those call sites: the same !defined(USE_FMADD)
+	term gates the fbits_in_2p / fbits_in_k / fbits_in_q declarations in PerPass_tfSieve, which the
+	integer fallback paths use. Disabling only the calls trades the missing-function error for an
+	"fbits_in_q undeclared" one.
+	  Delete this #undef when the 100-bit FMA modpow routines are actually written. */
+	#undef USE_FMADD
+	#warning USE_FMADD set for factor.c, but the 100-bit FMA modpow routines it needs do not exist - using the implemented modpow paths instead.
 #endif
 
 #define SPOT_CHECK	0	// Enable periodic Spot-check (PRP or composite) of factor candidates
@@ -3580,7 +3590,11 @@ MFACTOR_HELP:
 								/* Otherwise use 78-bit floating-double-based modmul: */
 								res = twopmodq78_3WORD_DOUBLE_q2(p[0],k_to_try[0],k_to_try[1], 0,tid);
 							#else
-								#error	TRYQ = 2 / P1WORD only allowed if USE_FLOAT or USE_FMADD is defined!
+								/* USE_FMADD is not an alternative here: it is undef'd at the top of this file
+								(its 2-way 100-bit modpow was never written) and there is no integer q2 batch
+								routine to fall through to. Reachable only via a hand-rolled build - makemake.sh
+								always passes -DTRYQ=4 - so use TRYQ = 1 or 4. */
+								#error	TRYQ = 2 / P1WORD requires USE_FLOAT (the 2-way 100-bit FMADD modpow twopmodq100_2WORD_DOUBLE_q2 was never implemented) - build with TRYQ = 1 or 4!
 							#endif	/* #ifdef USE_FMADD */
 
 						  #else


### PR DESCRIPTION
### Mfactor does not build on any AVX2-capable x86-64 machine

`factor.c` calls `twopmodq100_2WORD_DOUBLE()`, `_q2()` and `_q4()` at its TRYQ = 1/2/4 dispatch points, all three under `#ifdef USE_FMADD`. **None of those functions exists anywhere in the tree** — `twopmodq100.c` defines only `twopmodq100_2WORD_DOUBLE_q32()`, and only under `USE_AVX512`. There are no prototypes either, just the three calls.

`USE_FMADD` is not opt-in. `platform.h` auto-defines it for every x86-64 `USE_AVX2` build:

```c
// x86_64 only has FMA support ... as of Intel AVX2+FMA3:
#ifdef USE_AVX2
  #define	USE_FMADD
#endif
```

and `makemake.sh` emits `-DUSE_AVX2 -march=native -mavx2 -mfma` on such a host. So the default `makemake.sh mfac 1word` compiles those calls and fails — an undefined-reference link error, or on gcc ≥ 14, where an implicit function declaration is an error rather than a warning, a hard compile error first.

### The file already anticipated this

```c
#ifdef	USE_FMADD	// Need to add 100-bit modpow routines before enabling this for build of this file
	#warning USE_FMADD set in factor.c ... Using 100-bit FMA-based modpow.
#endif
```

The routines were never added, and a `#warning` prevents nothing. This change honours that comment literally: `#undef USE_FMADD` there, so the dispatch falls through to the implemented paths — `USE_FLOAT`'s 78-bit 3-word-double routines, else the 63/64/96/128-bit integer ones — exactly as on a non-AVX2 build. The `#warning` is reworded to say what actually happened, and the `#undef` should be deleted when the 100-bit FMA routines are written.

### Verified (AVX2 host, gcc 16.1.1)

| | `makemake.sh mfac 1word` |
| --- | --- |
| before | compile error: *implicit declaration of function `twopmodq100_2WORD_DOUBLE_q4`* at `factor.c:3622`; with that diagnostic downgraded, `undefined reference` at link. Same for `mfac nword`. |
| after | builds and links — confirmed at `-O1 -flto=auto` and at `-O3 -flto-partition=none` |

### A second, unrelated blocker remains at the default `-O3 -flto=auto`

Not addressed here. LTO merges translation units, and the non-local inline-asm labels in `twopmodq96.c` then collide:

```
twopmodq96.c:706:  Error: symbol `LoopBeg' is already defined
twopmodq96.c:1023: Error: symbol `twopmodq96_q4_pshiftjmp' is already defined
twopmodq96.c:1036: Error: symbol `LoopEnd' is already defined
```

Those want to be asm-local labels (`%=`, or numeric `1:` / `1b` / `1f`). The same pattern appears in `twopmodq.c`, `twopmodq80.c` and `twopmodq64_test.c` — six distinct label names across four files. Worth its own change; happy to send one.

### Why this may matter beyond the build

If Mfactor has not built on a current toolchain for some time, its multithreaded factoring path has not been exercised — which would help explain #192 (worker mutexes declared as non-static locals, so they serialise nothing) and #161 (unsynchronized busy-wait on the task queue) going unnoticed.


## Why the file-scope `#undef`, and not per-call-site

#81 attacked the same defect by disabling the three call sites (`#ifdef USE_FMADD` → `#if defined(USE_FMADD) && 0`) while leaving `USE_FMADD` itself defined. **That does not fix the AVX2 build**, which is the configuration it was meant to fix.

`USE_FMADD` does more than select a modpow routine: the same `!defined(USE_FMADD)` term gates the *declarations* of `fbits_in_2p` / `fbits_in_k` / `fbits_in_q` in `PerPass_tfSieve` (`factor.c:2631`, `2696`, `3095`), which the integer fallback path then uses at `factor.c:3636`. Disabling only the call sites leaves those guards false, so `fbits_in_q` is never declared while the `#else` branch that uses it now compiles.

Both mechanisms synthesised onto `upstream/main` @ `418f365` so nothing else differs, compiled with exactly the `factor.o` rule from `makemake.sh:553` (`-DFACTOR_STANDALONE -DTRYQ=4`, plus mode flags):

| tree | gcc 16.1.1 avx2 | gcc avx512 | clang 22.1.8 avx2 | clang avx512 |
|---|---|---|---|---|
| unfixed `main` | `implicit declaration of 'twopmodq100_2WORD_DOUBLE_q4'` | same | `call to undeclared function` | same |
| per-call-site (#81) | **`factor.c:3636: error: 'fbits_in_q' undeclared`** | OK | **`undeclared identifier 'fbits_in_q'`** | OK |
| **file-scope `#undef` (this PR)** | OK | OK | OK | OK |

AVX-512 is clean under both because `factor.c:604-609` self-defines `USE_FLOAT` for `USE_AVX512`, so the dispatch takes the `#elif defined(USE_FLOAT)` 78-bit branch, which never touches `fbits_in_q`. **AVX2 is the only mode where the two mechanisms diverge.** #81 has been closed in favour of this PR.

One caveat for anyone editing the `TRYQ = 2` `#error` string: its text is lexed for character constants even inside a *skipped* preprocessor group, so an apostrophe there makes gcc emit `warning: missing terminating ' character` on every build. The wording here is apostrophe-free for that reason.

---

*Scope note: the original title said "unbuildable on AVX2". It is **AVX2 and AVX-512** — `platform.h` defines `USE_AVX2` (and hence `USE_FMADD`) whenever `USE_AVX512` is set, so both of `makemake.sh`'s top two build modes take this path. Independently measured: `mfac 2/3/4word` die on `#error PxWORD may not be used with USE_FMADD`, `1word`/`nword` on the missing `twopmodq100_2WORD_DOUBLE_q4` prototype, at both modes.*
