### PR TITLE
twopmodq*: make inline-asm labels unique per asm statement (LTO build break)

### DIFF
--- a/src/twopmodq.c
+++ b/src/twopmodq.c
@@ -1407,8 +1407,8 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 		"movslq	%[__start_index], %%rcx		\n\t"\
 		"subq $1,%%rcx						\n\t"\
 		"test %%rcx, %%rcx					\n\t"\
-		"jl LoopEnd4a		/* Skip if n < 0 */	\n\t"\
-	"LoopBeg4a:								\n\t"\
+		"jl LoopEnd4a%=		/* Skip if n < 0 */	\n\t"\
+	"LoopBeg4a%=:								\n\t"\
 	"/* SQR_LOHI_q4(x*, lo*, hi*): */	\n\t"\
 		"movq	%%r12,%%rax	/* x0-3 in r8-11. */\n\t"\
 		"mulq	%%rax		\n\t"\
@@ -1510,8 +1510,8 @@ void twopmmodq64_q4(uint64 p, uint64 *i0, uint64 *i1, uint64 *i2, uint64 *i3, ui
 		"/* } endif((p >> j) & (uint64)1) */						\n\t"\
 		"subq	$1,%%rcx	/* j-- */		\n\t"\
 		"cmpq	$0,%%rcx	/* compare j vs 0 */\n\t"\
-		"jge	LoopBeg4a	/* if (j >= 0), Loop */	\n\t"\
-	"LoopEnd4a:							\n\t"\
+		"jge	LoopBeg4a%=	/* if (j >= 0), Loop */	\n\t"\
+	"LoopEnd4a%=:							\n\t"\
 		"movq	%%r12,%[__x0]	\n\t"\
 		"movq	%%r13,%[__x1]	\n\t"\
 		"movq	%%r14,%[__x2]	\n\t"\

--- a/src/twopmodq64_test.c
+++ b/src/twopmodq64_test.c
@@ -490,7 +490,7 @@ uint64 twopmodq64_q4(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		"movq	%[__pshift],%%rax	\n\t"/* Need to follow this with load-j-into-ecx if use HLL loop control in debug mode */\
 		"shrq	%%cl,%%rax				\n\t"\
 		"andq	$0x1,%%rax				\n\t"\
-	"je	twopmodq64_q4_pshiftjmp			\n\t"\
+	"je	twopmodq64_q4_pshiftjmp%=			\n\t"\
 		"\n\t"\
 		"movq	%%r12,%%r8 	\n\t"/* r8  <- Copy of x */\
 		"movq	%%r12,%%rax	\n\t"/* rax <- Copy of x */\
@@ -520,7 +520,7 @@ uint64 twopmodq64_q4(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3)
 		"addq	%%rax,%%r11	\n\t"\
 		"cmovcq %%r11,%%r15	\n\t"\
 		"\n\t"\
-	"twopmodq64_q4_pshiftjmp:	\n\t"\
+	"twopmodq64_q4_pshiftjmp%=:	\n\t"\
 		/* } endif((pshift >> j) & (uint64)1) */\
 		"subq	$1,%%rcx	\n\t"/* j-- */\
 		"cmpq	$0,%%rcx	\n\t"/* compare j vs 0 */\
@@ -832,7 +832,7 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		"movq	%[__pshift],%%rax	\n\t"/* Need to follow this with load-j-into-ecx if use HLL loop control in debug mode */\
 		"shrq	%%cl,%%rax			\n\t"\
 		"andq	$0x1,%%rax			\n\t"\
-	"je	twopmodq64_q8_pshiftjmp		\n\t"\
+	"je	twopmodq64_q8_pshiftjmp%=		\n\t"\
 		"\n\t"\
 		"movq	%[__q0],%%rax  	\n\t"/* rax <- Copy of q */\
 		"leaq (%%r8 ,%%r8 ),%%rbx	\n\t"/* rbx <- x+x, no CF set, leave r8 (x) intact */\
@@ -882,7 +882,7 @@ uint64 twopmodq64_q8(uint64 p, uint64 k0, uint64 k1, uint64 k2, uint64 k3, uint6
 		"subq	%%rax,%%r15		\n\t"\
 		"cmovcq %%rbx,%%r15		\n\t"\
 		"\n\t"\
-	"twopmodq64_q8_pshiftjmp:	\n\t"\
+	"twopmodq64_q8_pshiftjmp%=:	\n\t"\
 		/* } endif((pshift >> j) & (uint64)1) */\
 		"subq	$1,%%rcx	\n\t"/* j-- */\
 		"cmpq	$0,%%rcx	\n\t"/* compare j vs 0 */\

--- a/src/twopmodq80.c
+++ b/src/twopmodq80.c
@@ -4601,7 +4601,7 @@ if(~pshift != p+78) {
 					"movq	%[__pshift],%%rax					\n\t"\
 					"shrq	%%cl,%%rax	/* j already in c-reg */\n\t"\
 					"andq	$0x1,%%rax							\n\t"\
-				"je	twopmodq96_q4_pshiftjmp						\n\t"\
+				"je	twopmodq96_q4_pshiftjmp%=						\n\t"\
 					"			/* Int64 code: if h<l carryout of low 64 bits gives hi=2^32 = 0x100000000, need to zero upper 32 bits prior to double step: */\n\t"\
 					"																							movq	$-1,%%rdi	\n\t"\
 					"																							shrq	$32,%%rdi	\n\t"\
@@ -4658,7 +4658,7 @@ if(~pshift != p+78) {
 					"	subpd		%%xmm13,%%xmm9	/* x mod q, low 26 bits */				\n\t				andq	%%rdi,%%rdx	\n\t"\
 					"																							addq	%%rax,%%r11	\n\t"\
 					"																							adcq	%%rdx,%%r15	\n\t"\
-				"twopmodq96_q4_pshiftjmp:													\n\t"\
+				"twopmodq96_q4_pshiftjmp%=:													\n\t"\
 					"/* } */																\n\t"\
 					"/* Normalize the result: */											\n\t"\
 					"movaps	0x210(%%rsi),%%xmm4		\n\t	movaps	0x210(%%rsi),%%xmm12	\n\t"\

--- a/src/twopmodq96.c
+++ b/src/twopmodq96.c
@@ -703,8 +703,8 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"movslq	%[__start_index], %%rcx		\n\t"\
 			"subq $2,%%rcx						\n\t"\
 			"test %%rcx, %%rcx					\n\t"\
-			"jl LoopEnd		/* Skip if n < 0 */	\n\t"\
-		"LoopBeg:								\n\t"\
+			"jl LoopEnd%=		/* Skip if n < 0 */	\n\t"\
+		"LoopBeg%=:								\n\t"\
 		"/* SQR_LOHI96_q4(x*, lo*, hi*): */	\n\t"\
 			"movq	%%r8 ,%%rax	/* Low 64 bits of x0-3 in r8-11. */\n\t"\
 			"mulq	%%rax		\n\t"\
@@ -961,7 +961,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"movq	%[__pshift],%%rax		\n\t"\
 			"shrq	%%cl,%%rax				\n\t"\
 			"andq	$0x1,%%rax				\n\t"\
-		"je	twopmodq96_q4_pshiftjmp			\n\t"\
+		"je	twopmodq96_q4_pshiftjmp%=			\n\t"\
 			"\n\t"\
 		"/* if h<l carryout of low 64 bits gives hi=2^32 = 0x100000000, need to zero upper 32 bits prior to double step: */\n\t"\
 			"movq	$-1,%%rdi	\n\t"\
@@ -1021,7 +1021,7 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"andq	%%rdi,%%rdx	\n\t"\
 			"addq	%%rax,%%r11	\n\t"\
 			"adcq	%%rdx,%%r15	\n\t"\
-		"twopmodq96_q4_pshiftjmp:					\n\t"\
+		"twopmodq96_q4_pshiftjmp%=:					\n\t"\
 			"/* } endif((pshift >> j) & (uint64)1) */						\n\t"\
 			"movq	%%r8 ,0x80(%%rsi)	/* Write lo 64 bits into [__x.d0] */\n\t"\
 			"movq	%%r12,0x88(%%rsi)	/* Write hi 32 bits into [__x.d1] */\n\t"\
@@ -1033,8 +1033,8 @@ if(dbg)printf("xout = %s\n", &char_buf[convert_uint96_base10_char(char_buf, x)])
 			"movq	%%r15,0xb8(%%rsi)	\n\t"\
 			"subq	$1,%%rcx	/* j-- */		\n\t"\
 			"cmpq	$0,%%rcx	/* compare decremented j vs 0 */\n\t"\
-			"jge	LoopBeg	/* if (j >= 0), Loop */	\n\t"\
-		"LoopEnd:							\n\t"\
+			"jge	LoopBeg%=	/* if (j >= 0), Loop */	\n\t"\
+		"LoopEnd%=:							\n\t"\
 			:	/* outputs: none */\
 			: [__q0] "m" (qptr0)	/* All inputs from memory addresses here */\
 			 ,[__pshift] "m" (pshift)	\


### PR DESCRIPTION
### The build break

At `makemake.sh`'s default `-O3 -flto=auto`, Mfactor fails to assemble:

```
/tmp/ccXXXX.s: Assembler messages:
../src/twopmodq96.c:706:  Error: symbol `LoopBeg' is already defined
../src/twopmodq96.c:1023: Error: symbol `twopmodq96_q4_pshiftjmp' is already defined
../src/twopmodq96.c:1036: Error: symbol `LoopEnd' is already defined
```

The jump targets inside these inline-asm blocks are written as ordinary global labels. That survives a non-LTO build, where each translation unit becomes its own assembly file — but LTO merges translation units into one, so a label gets emitted more than once and the assembler rejects the duplicate.

Two distinct ways it bites here:

* the **same label name is used in two different files** — `twopmodq80.c` also defines a label literally named `twopmodq96_q4_pshiftjmp`;
* a function carrying such a label can be **inlined into more than one caller**, which is why even the uniquely-suffixed `LoopBeg4a`/`LoopEnd4a` in `twopmodq.c` are unsafe.

Note `-flto=auto` hides the real error behind `lto-wrapper: fatal error: make returned 2`; building with `-flto=1` surfaces it.

### The fix

Append gcc's `%=` operator to each label. It substitutes a number unique to each instance of the asm statement, so the emitted symbol is unique per instantiation while the source stays readable.

All of these blocks are **extended** asm (named operands, explicit clobber lists), so `%=` is available. And every label's definition and all its references live inside a **single** asm statement — I checked this explicitly, since `%=` is per-statement and a label referenced across two statements would silently break.

Labels updated (live code only; copies inside `#if 0` blocks are left alone):

| file | labels |
| --- | --- |
| `twopmodq96.c` | `LoopBeg`, `LoopEnd`, `twopmodq96_q4_pshiftjmp` |
| `twopmodq.c` | `LoopBeg4a`, `LoopEnd4a` |
| `twopmodq80.c` | `twopmodq96_q4_pshiftjmp` |
| `twopmodq64_test.c` | `twopmodq64_q4_pshiftjmp`, `twopmodq64_q8_pshiftjmp` |

### Verification

**No code change.** Compiling each of the four files at `-O3` with the Mfactor flag set and diffing disassembly, the only differences are objdump's symbol annotations on jump targets — `<LoopEnd+0x6a6>` became `<LoopEnd1312+0x6a6>`. Normalising the label names away, all four files are **instruction-identical**, same addresses and same offsets.

| check | result |
| --- | --- |
| `twopmodq96.c` / `twopmodq.c` / `twopmodq80.c` / `twopmodq64_test.c` disasm, label names normalised | identical |
| `makemake.sh mfac 1word` at default `-O3 -flto=auto` | builds (previously: assembler errors) |
| built binary's startup self-test | passes, 0 errors — including *"Testing 64-bit 2^p (mod q) functions with 100000 random (p, q odd) pairs"*, which exercises precisely these asm blocks |

### Depends on #193

This is only observable once #193 is applied — without it the Mfactor build fails earlier, at the `USE_FMADD` path's calls to the nonexistent `twopmodq100_2WORD_DOUBLE` routines. Both were applied together for the verification above. With #193 + this change, `makemake.sh mfac 1word` completes at the default flags for the first time on an AVX2 host.
