### PR TITLE
ernstMain: fix infinite loop in the savefile-retry logic

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2760,7 +2760,15 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 	} else if(TEST_TYPE == TEST_TYPE_PRIMALITY || TEST_TYPE == TEST_TYPE_PRP) {
 		strcpy(g_cstr, RESTARTFILE); g_cstr[0] = 'q';		// g_cstr = q[expo]
 	}
-	for(ierr = 0; ; RESTARTFILE[0] = 'q') {	// Start with the p-savefile, inrement to q-savefile on looping
+	/* At most two passes: the primary [p|f]<expo> savefile, then the secondary q<expo>. The loop control
+	must not be carried by RESTARTFILE[0], because the body legitimately rewrites it: on a good secondary
+	the LL/PRP branch below sets it back to 'p'/'f' before renaming q ==> primary. If that rename fails,
+	the q-file survives, ierr is still 1 from the failed primary, and RESTARTFILE[0] is no longer 'q' - so
+	neither exit condition holds, the loop increment sets 'q' again, and we spin on that state forever.
+	Track which pass we are on separately instead. ierr keeps its previous lifetime deliberately: it is
+	ernstMain()'s return code, so resetting it per pass would change what callers see. */
+	int on_secondary_savefile = 0;
+	for(ierr = 0; ; ) {	// Start with the p-savefile, increment to q-savefile on looping
 		if(restart_file_valid(RESTARTFILE, p, (uint8 *)arrtmp, (uint8 *)e_uint64_ptr)) {
 			// If end of a regular (non-s2-continuation) p-1 run and primary good, rename it from [p|f][expo] ==> [p|f][expo].s1;
 			// if primary missing/corrupt, rename secondary q[expo] ==> [p|f][expo].s1:
@@ -2782,9 +2790,10 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 			}
 		} else
 			ierr = 1;
-		// If no errors on primary, break; otherwise loop
-		if(!ierr || RESTARTFILE[0] == 'q')
+		// If no errors on primary, break; otherwise try the secondary, once.
+		if(!ierr || on_secondary_savefile)
 			break;
+		on_secondary_savefile = 1;	RESTARTFILE[0] = 'q';
 	}
 	// If completion of LL/PRP run, or secondary was not used as a backup for p-1 stage 1 savefile rename, delete it now:
 	RESTARTFILE[0] = 'q';


### PR DESCRIPTION
### The hang

The savefile-recovery loop keeps its control state in two variables the loop body rewrites:

```c
for(ierr = 0; ; RESTARTFILE[0] = 'q') {
    ...
    if(!ierr || RESTARTFILE[0] == 'q')
        break;
}
```

* `ierr` is initialised once, *outside* the loop, so once the primary savefile has failed it stays 1.
* `RESTARTFILE[0]` is not a loop counter. The LL/PRP branch inside the body deliberately sets it back to `'p'`/`'f'` before renaming the secondary `q<expo>` savefile onto the primary name.

So if the primary is missing or corrupt, the secondary is good, **and that rename fails**, neither exit condition can hold — `ierr` is still 1, and `RESTARTFILE[0]` is `'p'`/`'f'` rather than `'q'`. The loop increment sets `'q'` again, the q-file is still present because the rename failed, and the state repeats exactly. Forever.

A stale `q<expo>` savefile plus anything that blocks the rename — permissions, a directory in the way, a full or read-only filesystem — hangs the run at this point.

### The fix

Track which pass we are on in a separate variable, leaving the body free to rewrite `RESTARTFILE[0]`. The loop is bounded at two passes by construction.

**`ierr` keeps its previous lifetime deliberately.** It is `ernstMain()`'s return value — `return(ierr)` further down, and `Mdata.h` documents these as the caller-visible error codes — and nothing reassigns it between the loop and that return. Resetting it per pass would read more cleanly but would change what callers see, so the sticky behaviour is preserved exactly.

### Verification

The loop was extracted into a standalone harness running both revisions over all 8 combinations of *(primary valid, secondary valid, rename fails)*. It also models the detail that a **successful** rename removes the q-file — without that, the model wrongly reports two hanging cases instead of one.

| valid p | valid q | rename fails | before | after |
| --- | --- | --- | --- | --- |
| no | no | no | ierr=1, 2 passes | ierr=1, 2 passes |
| no | no | yes | ierr=1, 2 passes | ierr=1, 2 passes |
| no | yes | no | ierr=1, 3 passes | ierr=1, 2 passes |
| no | yes | **yes** | **HANGS** | ierr=1, 2 passes |
| yes | * | * | ierr=0, 1 pass | ierr=0, 1 pass |

* hangs in exactly one case before; terminates in all 8 after;
* the returned `ierr` is identical in all 7 cases that terminated before, so no caller-visible behaviour changes;
* one case drops from 3 passes to 2, same result.

`Mlucas.c` compiles clean.

### Scope

Not folded into #170 — that PR is about detecting savefile write/read truncation, and its edits in this area are in the *write* path (`fclose` → `close_savefile`), not this read-path retry loop. The two do not overlap.
