### PR TITLE
pm1: fix two bounds defects in the stage-1 prime-powers product

### DIFF
--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -116,7 +116,7 @@ void	write_fft_debug_data(double a[], int jlo, int jhi);
 uint32	pm1_set_bounds(const uint64 p, const uint32 n, const uint32 tf_bits, const double tests_saved);
 uint32	pm1_check_bounds();
 uint32	compute_pm1_s1_product(const uint64 p);
-uint32	pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uint32 *nmul, uint64 *maxmult);
+uint32	pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uint32 accum_alloc, uint32 *nmul, uint64 *maxmult);
 int		 read_pm1_s1_prod(const char *fname, uint64 p, uint32 *nbits, uint64 arr[], uint64 *sum64);
 int		write_pm1_s1_prod(const char *fname, uint64 p, uint32 nbits, uint64 arr[], uint64 sum64);
 void	pm1_bigstep_size(uint32 *nbuf, uint32 *bigstep, uint32 *m, const uint32 psmall);

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -442,6 +442,13 @@ uint32 pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uin
 				j++;
 #endif
 			}
+			/* loop = 64/maxbits assumes every factor folded in here is < 2^maxbits, which is true for
+			primes <= b1 but not for the up-to-(loop-1) primes past b1 that the batching can pull in, and
+			badly wrong for tiny b1 (at b1 = 3, loop = 32 and the batch product needs 169 bits). Rather
+			than trust the count, check the multiply itself and flush the batch early if it would wrap -
+			p is deliberately not advanced here, so the next pass re-folds this same prime power: */
+			if(mult > (~0ull)/prod)
+				break;
 			mult *= prod;
 #ifdef PM1_DEBUG
 			if(j > 1)

--- a/src/pm1.c
+++ b/src/pm1.c
@@ -360,7 +360,7 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 		// For M(p) want to seed the S1 prime-powers product with 2*p; for F(m) we want seed = 2^(m+2). Since in the latter
 		// case our input p contains 2^m, can handle both cases via iseed = 4*p, giving an extra *2 in the Mersenne case:
 		iseed = p<<2;	ASSERT((iseed>>2) == p,"Binary exponent overflows (uint64)4*p in compute_pm1_s1_product!");
-		len = pm1_s1_ppow_prod(iseed, B1, PM1_S1_PRODUCT, &nmul, &maxmult);	PM1_S1_PROD_B1 = B1;
+		len = pm1_s1_ppow_prod(iseed, B1, PM1_S1_PRODUCT, s1p_alloc, &nmul, &maxmult);	PM1_S1_PROD_B1 = B1;
 		nbits = (len<<6)-mi64_leadz(PM1_S1_PRODUCT,len);
 		if(len > s1p_alloc) {
 			sprintf(cbuf,"Size of S1 prime-powers product exceeds alloc of PM1_S1_PRODUCT[]!");
@@ -408,11 +408,12 @@ uint32 compute_pm1_s1_product(const uint64 p) {
 
 // Compute product of Stage 1 prime powers and store in a uint64[] accumulator.
 // Pointer-args nmul and maxmult return #mi64_mul_scalar calls and max value of the scalar multiplier for same:
-uint32 pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uint32 *nmul, uint64 *maxmult) {
+uint32 pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uint32 accum_alloc, uint32 *nmul, uint64 *maxmult) {
 	uint32 p = 2,i,len,maxbits = 64-leadz64(b1);
 	uint32 loop = 64/maxbits;	// Number of prime-powers we can accumulate inside inner loop while remaining < 2^64
 	uint64 tmp,prod,mult,cy = 0ull;
 	ASSERT(accum != 0x0, "Null accum[] pointer in s1_ppow_prod()");
+	ASSERT(accum_alloc != 0, "Zero accumulator allocation in s1_ppow_prod()");
 	ASSERT(accum != 0x0, "Zero initial seed in s1_ppow_prod()");
 	accum[0] = iseed; len = 1; *nmul = 0; *maxmult = 0ull;
 // Debug-only - allows testing of S1 on known-factor case without actually running S2:
@@ -460,6 +461,10 @@ uint32 pm1_s1_ppow_prod(const uint64 iseed, const uint32 b1, uint64 accum[], uin
 		}
 		*maxmult = MAX(mult,*maxmult);
 		cy = mi64_mul_scalar(accum, mult, accum, len);	++*nmul;
+		/* Bound the growth here, where the write happens. The caller sizes accum[] from an
+		estimate of the product length, and used to check that estimate only *after* this
+		function returned - by which point an under-estimate has already been written past. */
+		ASSERT(len < accum_alloc, "S1 prime-powers product exceeds the accumulator allocation!");
 		accum[len] = cy; len += (cy != 0ull);
 	}
 #ifdef PM1_DEBUG


### PR DESCRIPTION
Two bounds defects in the p-1 stage-1 prime-powers product, in adjacent functions — `compute_pm1_s1_product()` and the `pm1_s1_ppow_prod()` it wraps. One commit each.

## 1. The batch multiplier can silently wrap

`pm1_s1_ppow_prod()` folds prime powers into a `uint64` batch multiplier and sizes the batch by a count rather than by checking the multiply:

```c
maxbits = 64 - leadz64(b1);   loop = 64/maxbits;
```

That assumes every factor folded in is `< 2^maxbits`, which fails twice over: the batching consumes `loop` primes per pass **regardless of b1**, so it pulls in up to `loop-1` primes past b1; and for small b1 the count is wildly optimistic — at `b1 = 3`, `loop = 32` and the batch product needs **169 bits**. The excess wraps mod 2^64, giving a meaningless stage-1 exponent with no diagnostic at all.

Fixed by checking the multiply and flushing the batch early if it would wrap. `p` is deliberately not advanced in that case, so the next pass re-folds the same prime power. Where the batch boundaries fall does not affect the accumulated product — only the number of `mi64_mul_scalar()` calls — so this is transparent wherever the old code did not overflow.

**Reachability.** `pm1_check_bounds()` clamps `B1 >= 10000`, but that clamp is inside `#ifndef PM1_DEBUG` — so a `PM1_DEBUG` build with a small `-b1` hits this directly, which is exactly the build you reach for when debugging p-1.

**Verified** with a model of the loop that reproduces the C exactly, sweeping `b1 = 3..3000`:

| | result |
| --- | --- |
| b1 where the old code overflows `uint64` | precisely **[3, 15]** |
| b1 where the product differs old vs new | precisely **[3, 15]** — i.e. only where the old value was a wrapped one |
| b1 ≥ 16 | product **and** `mi64_mul_scalar()` call count identical |

So no production configuration changes behaviour.

*Not fixed here:* the batching still consumes up to `loop-1` primes beyond b1, so B1 is not honoured exactly. That one is benign — the computed exponent is then a strict multiple of the intended one, so stage 1 still finds every factor it should.

## 2. The accumulator bound is checked after the write

```c
ebits     = (uint32)((lg-A)*B1/(ln-A));        // A = 1.1
s1p_alloc = ((ebits + 63)>>6) + 1;
PM1_S1_PRODUCT = ALLOC_UINT64(PM1_S1_PRODUCT, s1p_alloc);
...
len = pm1_s1_ppow_prod(iseed, B1, PM1_S1_PRODUCT, &nmul, &maxmult);   // writes
...
if(len > s1p_alloc) { ... ASSERT(0,cbuf); }                            // checks
```

`pm1_s1_ppow_prod()` never received the allocation size, so it grew the accumulator (`accum[len] = cy; len += (cy != 0ull);`) with no bound. The `len > s1p_alloc` test can only run once the function has returned — by which point any overrun has already happened, and if it corrupted the allocator the ASSERT may never be reached to report it. It is a post-mortem, not a guard.

Fixed by passing `s1p_alloc` in and asserting before each growth, so the check sits at the write. The caller's test stays as a harmless backstop.

**This is robustness, not a live bug.** The `ebits` estimate runs 2.5–3.7% high against the actual product size across B1 = 10⁴..2×10⁶ (len 227 vs alloc 236 limbs at 10⁴; 45088 vs 46221 at 2×10⁶), and `ebits/(B1/ln2) = (ln B1 − 1.1·ln2)/(ln B1 − 1.1)` stays ≥ 1.016 across the whole `uint32` B1 range while the true size is under `(θ(B1) + prime-power surplus)/ln2`. The new ASSERT cannot fire for any legal B1 — but the margin shrinks monotonically with B1, and today's failure mode would be a silent heap overrun rather than a clean abort.

## Build note

`pm1.c` compiles clean. The `PM1_STANDALONE` build is broken on `main` for an unrelated reason — a conflicting `cbuf` declaration, fallout from the `cstr`→`g_cstr` rename — so it could not be exercised here.
