### PR TITLE
pm1: fix the PM1_STANDALONE build — cbuf declared narrower than its extern

### DIFF
--- a/src/pm1.c
+++ b/src/pm1.c
@@ -43,7 +43,8 @@ Then to run, e.g.
 	uint32 PM1_S2_NBUF = 0;	// # of floating-double residue-length memblocks available for Stage 2
 	uint32 B1 = 0;
 	uint64 B2 = 0ull, B2_start = 0ull;
-	char cbuf[STR_MAX_LEN*2];
+	char cbuf[STR_MAX_LEN*3];	// Must match the extern in Mdata.h - a narrower definition here is a
+								// conflicting type, and breaks the PM1_STANDALONE build outright.
 	uint32 SYSTEM_RAM, MAX_RAM_USE;	// Total usable main memory size, and max. amount of that to use per instance, in MB
 	double MME;
 #else


### PR DESCRIPTION
Building the p-1 prime-pairing simulator fails outright on `main`:

```
pm1.c:46:14:    error: conflicting types for 'cbuf'; have 'char[2048]'
Mdata.h:230:13: note: previous declaration of 'cbuf' with type 'char[3072]'
```

`pm1.c`'s `PM1_STANDALONE` block defines its own `cbuf[STR_MAX_LEN*2]` while `Mdata.h` declares `extern char cbuf[STR_MAX_LEN*3]`.

The desync dates to `10d6aa00` ("Remove format warnings from Mlucas.c", 2024-09-08), which widened the `Mdata.h` declaration to `STR_MAX_LEN*2+200` without touching `pm1.c`; `ee323452` (2026-07-27) later changed that to `STR_MAX_LEN*3`, which only altered the sizes quoted in the error message. So this build has been broken since Sep 2024. Two object declarations with different complete array bounds are a C constraint violation, so it is not a recent-compiler artifact — it errors under gcc 16.1.1 in `-std=c89/c99/c11/c17` alike, and under clang 22.

*(An earlier revision of this description blamed the `cstr` → `g_cstr` rename, and said a gcc ≥ 14 warning-to-error promotion was what turned it fatal. Both were wrong: the rename the previous day left the size alone, and the diagnostic has always been an error.)*

### Why it's worth fixing rather than leaving

This is the build documented in the file's own header comment:

```
clang -c -O3 -g3 -ggdb -DINCLUDE_GMP=0 -DINCLUDE_HWLOC=0 -DPM1_STANDALONE [-DPM1_DEBUG] -O3 pm1.c
```

It runs the stage-2 prime-pairing logic in **seconds, with no FFT**, which is how pairing changes get validated without a multi-hour run. Losing it makes p-1 work materially harder to check — the bounds fixes in #196 had to fall back to a Python model of the loop precisely because this would not build.

### Verified

`pm1.c` compiles clean with `-DPM1_STANDALONE`, links, and the simulator runs, reproducing the expected reference output for `-bigstep 420 -b1 100000 -b2 3000000 -m 8`:

```
M =  8: #buf =  384, #pairs: 85077, #single: 37586 (81.91% paired), #blocks: 6502, #modmul: 135667
```

— identical to what this harness produced before the desync landed, so the fix restores the behaviour and not merely the compile.

### Related

Third build configuration found rotted in this batch, after #193 (Mfactor unbuildable on any AVX2 host — a call to routines that exist nowhere) and #82 (Mfactor's LTO build broken by non-local inline-asm labels). All three are configurations nothing exercises routinely. It may be worth having CI compile-check `PM1_STANDALONE` and `Mfactor` so they cannot rot again silently.
