### PR TITLE
imul_macro1.h: CMPULT128B/C truncate the high word to 32 bits

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -229,10 +229,10 @@ that is advantageous on at least an appreciable set of CPUs.
 #define	CMPULT128(__x, __y)				((uint64)__x.d1 < (uint64)__y.d1 || ((uint64)__x.d1 == (uint64)__y.d1 && (uint64)__x.d0 < (uint64)__y.d0))
 #define	CMPULT96(__x, __y)				((uint32)__x.d1 < (uint32)__y.d1 || ((uint32)__x.d1 == (uint32)__y.d1 && (uint64)__x.d0 < (uint64)__y.d0))
 
-#define	CMPULT128B(__xhi, __xlo, __y)	((uint32)__xhi < (uint32)__y.d1 || ((uint32)__xhi == (uint32)__y.d1 && (uint64)__xlo < (uint64)__y.d0))
+#define	CMPULT128B(__xhi, __xlo, __y)	((uint64)__xhi < (uint64)__y.d1 || ((uint64)__xhi == (uint64)__y.d1 && (uint64)__xlo < (uint64)__y.d0))
 #define	CMPULT96B(__xhi, __xlo, __y)	((uint32)__xhi < (uint32)__y.d1 || ((uint32)__xhi == (uint32)__y.d1 && (uint64)__xlo < (uint64)__y.d0))
 
-#define	CMPULT128C(__x, __yhi, __ylo)	((uint32)__x.d1 < (uint32)__yhi || ((uint32)__x.d1 == (uint32)__yhi && (uint64)__x.d0 < (uint64)__ylo))
+#define	CMPULT128C(__x, __yhi, __ylo)	((uint64)__x.d1 < (uint64)__yhi || ((uint64)__x.d1 == (uint64)__yhi && (uint64)__x.d0 < (uint64)__ylo))
 #define	CMPULT96C(__x, __yhi, __ylo)	((uint32)__x.d1 < (uint32)__yhi || ((uint32)__x.d1 == (uint32)__yhi && (uint64)__x.d0 < (uint64)__ylo))
 
 #define	CMPULT192(__x, __y)				((uint64)__x.d2 < (uint64)__y.d2 || ((uint64)__x.d2 == (uint64)__y.d2 && (uint64)__x.d1 < (uint64)__y.d1) || ((uint64)__x.d2 == (uint64)__y.d2 && (uint64)__x.d1 == (uint64)__y.d1 && (uint64)__x.d0 < (uint64)__y.d0))


### PR DESCRIPTION
```c
#define CMPULT128B(__xhi, __xlo, __y)  ((uint32)__xhi < (uint32)__y.d1 || ((uint32)__xhi == (uint32)__y.d1 && (uint64)__xlo < (uint64)__y.d0))
#define CMPULT128C(__x, __yhi, __ylo)  ((uint32)__x.d1 < (uint32)__yhi  || ((uint32)__x.d1 == (uint32)__yhi  && (uint64)__x.d0 < (uint64)__ylo))
```

These are the **128-bit** compare forms, and `uint128` is `struct uint64x2` — `d1` is a `uint64` (`types.h:573-576`). Casting the high word to `uint32` discards bits 96..127, so any comparison decided above bit 95 uses the wrong bits and silently returns the opposite answer.

The `uint32` casts look plausible because they are correct one size down: `CMPULT96` compares a `uint96`, whose `d1` really *is* a `uint32`. Someone copying that pattern up to 128 bits kept the cast. The correct 128-bit form sits right next door at `CMPULT128`, using `uint64` throughout.

Fixing the two roots fixes the family — `CMPUGT128B`, `CMPUGT128C`, `CMPULE128B` and `CMPUGE128B` are all defined in terms of `CMPULT128B`/`C`.

### Verification

Against a true 128-bit compare over 200 000 uniform-random operand pairs:

| | `CMPULT128B` | `CMPULT128C` |
| --- | --- | --- |
| pristine `main` | **100096 / 200000 disagree (50.0 %)** | 100096 / 200000 |
| with this fix | 0 / 200000 | 0 / 200000 |

### Reachability: dead, and fixed anyway

These macros have no uses outside `imul_macro1.h`. I fixed them because they are a booby trap rather than a live fault — the names read as drop-in siblings of the working forms, so the next caller to reach for one inherits a comparison that is wrong about half the time, with nothing to indicate it. Happy to drop this if you would rather leave unused code untouched.

Same file as #198 (a dropped carry in `MULH128x96`/`MULH128`) and #167, but a disjoint region; verified to merge cleanly with both.
