### PR TITLE
imul_macro1.h: SQR_LOHI160_q8 never writes lanes 4-7's third output word

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -5799,10 +5799,10 @@ ALU ops to split the 5 64-bit outputs into a pair of uint160s.
 		__lo1.d0 =  __wa1;						__lo1.d1 = __wb1;						__lo1.d2 =  __wc1 & 0x00000000ffffffff;\
 		__lo2.d0 =  __wa2;						__lo2.d1 = __wb2;						__lo2.d2 =  __wc2 & 0x00000000ffffffff;\
 		__lo3.d0 =  __wa3;						__lo3.d1 = __wb3;						__lo3.d2 =  __wc3 & 0x00000000ffffffff;\
-		__lo4.d0 =  __wa4;						__lo4.d1 = __wb4;						__lo0.d2 =  __wc0 & 0x00000000ffffffff;\
-		__lo5.d0 =  __wa5;						__lo5.d1 = __wb5;						__lo1.d2 =  __wc1 & 0x00000000ffffffff;\
-		__lo6.d0 =  __wa6;						__lo6.d1 = __wb6;						__lo2.d2 =  __wc2 & 0x00000000ffffffff;\
-		__lo7.d0 =  __wa7;						__lo7.d1 = __wb7;						__lo3.d2 =  __wc3 & 0x00000000ffffffff;\
+		__lo4.d0 =  __wa4;						__lo4.d1 = __wb4;						__lo4.d2 =  __wc4 & 0x00000000ffffffff;\
+		__lo5.d0 =  __wa5;						__lo5.d1 = __wb5;						__lo5.d2 =  __wc5 & 0x00000000ffffffff;\
+		__lo6.d0 =  __wa6;						__lo6.d1 = __wb6;						__lo6.d2 =  __wc6 & 0x00000000ffffffff;\
+		__lo7.d0 =  __wa7;						__lo7.d1 = __wb7;						__lo7.d2 =  __wc7 & 0x00000000ffffffff;\
 		\
 		__hi0.d0 = (__wc0>>32) + (__wd0<<32);	__hi0.d1 = (__wd0>>32) + (__we0<<32);	__hi0.d2 = (__we0>>32);\
 		__hi1.d0 = (__wc1>>32) + (__wd1<<32);	__hi1.d1 = (__wd1>>32) + (__we1<<32);	__hi1.d2 = (__we1>>32);\


### PR DESCRIPTION
The output block of `SQR_LOHI160_q8` writes the wrong destination on its last four lines:

```c
__lo4.d0 = __wa4;  __lo4.d1 = __wb4;  __lo0.d2 = __wc0 & 0x00000000ffffffff;
__lo5.d0 = __wa5;  __lo5.d1 = __wb5;  __lo1.d2 = __wc1 & 0x00000000ffffffff;
__lo6.d0 = __wa6;  __lo6.d1 = __wb6;  __lo2.d2 = __wc2 & 0x00000000ffffffff;
__lo7.d0 = __wa7;  __lo7.d1 = __wb7;  __lo3.d2 = __wc3 & 0x00000000ffffffff;
```

The third column should read `__lo4.d2 = __wc4` … `__lo7.d2 = __wc7`. As written, `__lo0.d2` … `__lo3.d2` are assigned a **second** time with the same values — harmless — and **`__lo4.d2` … `__lo7.d2` are never written at all**, so lanes 4–7 return whatever the caller's `uint160` happened to contain.

Only the fully-expanded body has this. The sibling definitions of `SQR_LOHI160_q4`/`_q8` in the other branch just call `SQR_LOHI160` N times and cannot drift this way, and `SQR_LOHI160_q4`'s own output block is correct.

### Verification

Against the scalar `SQR_LOHI160` as reference, with **all outputs pre-poisoned** so an unwritten word is detectable, 20 000 iterations:

| | L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| pristine `main` | 0 | 0 | 0 | 0 | **20000** | **20000** | **20000** | **20000** |
| with this fix | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

### Reachability: latent

`SQR_LOHI160_q8` has no call sites anywhere in the tree, and `twopmodq160()` itself has no live callers. Worth fixing as a loaded gun for whoever next enables the pipelined 160-bit path — the failure is total for half the lanes, but only surfaces once something calls it.

Third PR against this file in the current batch, alongside #198 (dropped carry in `MULH128x96`/`MULH128`) and #199 (`CMPULT128B/C` truncating the high word); all disjoint regions.
