### PR TITLE
imul_macro1.h: SQR_LOHI160 and MULH160 lose the word-1 carry past word 2

### DIFF
--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -5409,7 +5409,7 @@ ALU ops to split the 5 64-bit outputs into a pair of uint160s.
 		__w3 += __b >> 63;\
 		__w2 = (__b << 1) + (__a >> 63);\
 		__a <<= 1;\
-		__w1 += __a;	__w2 += (__w1 < __a);	/*          w1 done. */\
+		__w1 += __a;	__w2 += (__w1 < __a);	__w3 += (__w2 < (__w1 < __a));	/* carry out of __w2 reaches __w3: the +1 can wrap a __w2 of 2^64-1 */	/*          w1 done. */\
 		/* Now calculate (x1^2 + 2*x0*x2) and add into middle part (w2 and w3): */\
 		SQR_LOHI64(__x.d1,       &__a ,&__b );	/*   x1^2  */\
 		__w2 += __a;	__w3 += (__w2 < __a);\
@@ -5476,7 +5476,7 @@ ALU ops to split the 5 64-bit outputs into a pair of uint160s.
 		__w3 += __b >> 63;\
 		__w2 = (__b << 1) + (__a >> 63);\
 		__a <<= 1;\
-		__w1 += __a;	__w2 += (__w1 < __a);	/*          w1 done. */\
+		__w1 += __a;	__w2 += (__w1 < __a);	__w3 += (__w2 < (__w1 < __a));	/* carry out of __w2 reaches __w3: the +1 can wrap a __w2 of 2^64-1 */	/*          w1 done. */\
 		/* Now calculate (x1^2 + 2*x0*x2) and add into middle part (w2 and w3): */\
 		SQR_LOHI64(__x.d1,        __a , __b );	/*   x1^2  */\
 		__w2 += __a;	__w3 += (__w2 < __a);\
@@ -5967,11 +5967,11 @@ On 32-bit hardware, take advantage of the fact that x2 and y2 are only 32 bits w
 		\
 		/* Now add cross terms: */\
 		/* Add x0*y1 to w1-3: */\
-		__w1 += __a;	__w2 += (__w1 < __a);\
+		__w1 += __a;	__w2 += (__w1 < __a);	__w3 += (__w2 < (__w1 < __a));	/* carry out of __w2 reaches __w3: the +1 can wrap a __w2 of 2^64-1 */\
 		__w2 += __b;	__w3 += (__w2 < __b);\
 		\
 		/* Add x1*y0 to w1-3: */\
-		__w1 += __c;	__w2 += (__w1 < __c);\
+		__w1 += __c;	__w2 += (__w1 < __c);	__w3 += (__w2 < (__w1 < __c));	/* carry out of __w2 reaches __w3: the +1 can wrap a __w2 of 2^64-1 */\
 		__w2 += __d;	__w3 += (__w2 < __d);\
 		\
 		/* Add x0*y2 to w2-4: */\
@@ -6051,11 +6051,11 @@ On 32-bit hardware, take advantage of the fact that x2 and y2 are only 32 bits w
 		\
 		/* Now add cross terms: */\
 		/* Add x0*y1 to w1-3: */\
-		__w1 += __a;	__w2 += (__w1 < __a);\
+		__w1 += __a;	__w2 += (__w1 < __a);	__w3 += (__w2 < (__w1 < __a));	/* carry out of __w2 reaches __w3: the +1 can wrap a __w2 of 2^64-1 */\
 		__w2 += __b;	__w3 += (__w2 < __b);\
 		\
 		/* Add x1*y0 to w1-3: */\
-		__w1 += __c;	__w2 += (__w1 < __c);\
+		__w1 += __c;	__w2 += (__w1 < __c);	__w3 += (__w2 < (__w1 < __c));	/* carry out of __w2 reaches __w3: the +1 can wrap a __w2 of 2^64-1 */\
 		__w2 += __d;	__w3 += (__w2 < __d);\
 		\
 		/* Add x0*y2 to w2-4: */\


### PR DESCRIPTION
```c
__w1 += __a;	__w2 += (__w1 < __a);
```

The carry into `__w2` is added, but no carry *out* of `__w2` is propagated — so if `__w2` is `2^64-1` when that `+1` arrives, it wraps to 0 and the carry into `__w3` vanishes. The correct idiom is already in this file: `MULH192` does `__w2 += __cy2; __cy3 += (__w2 < __cy2);`.

Fixed at six sites — `SQR_LOHI160` and `MULH160`, each in both of its conditional-branch copies (`MULH160` has two such adds per body).

### Deliberately not changed: MULL160 / MULL192

The same construct appears there and is **correct**. `MULL160` is a low-half multiply: it declares only `__w0,__w1,__w2` — there is no `__w3` — and finishes with `__lo.d2 = __w2 & 0x00000000ffffffff`, so a carry out of `__w2` lies outside the result by construction. `SQR_LOHI160`/`MULH160` declare `__w1..__w4` and read `__w3`/`__w4` in their outputs, which is exactly what makes the lost carry a defect there and not here.

### Verification

Against an independently written exact `__int128` reference, using the two witnesses recorded in the original audit:

| | `main` | exact | with fix |
| --- | --- | --- | --- |
| `SQR_LOHI160({0xfffffffffffffffe, 0x8000000000000001, 0x1})` | `0x00000004FFFFFFFF` | `0x00000005FFFFFFFF` | matches |
| `MULH160({…8d4dc579}, {…a0e3bf9f})` | `0x1F1657B7B42646FC` | `0x1F1657B8B42646FC` | matches |

My reference agrees with the audit's independently computed expected values in both cases, so two separately-written references concur.

**A random sweep does not exercise this.** It needs an intermediate `__w2` of *exactly* `2^64-1` — the audit estimated ~2^-64 and measured 0 in 200 000 uniform-random trials. The 200 000-case sweep in my reference harness (not included in this PR; available on request) is therefore a **negative control only**: clean before and after, confirming ordinary inputs are unaffected.

### Reachability: latent

`SQR_LOHI160`/`MULH160` are used only inside `twopmodq160.c`, whose entry point has no live callers.

Fourth PR against this file in the batch, with #198, #199 and #200; all disjoint regions.

