### PR TITLE
sse2_macro_gcc64.h: declare xmm8/xmm9 clobbered in the AVX-512 SSE2_RADIX_05_DFT_0TWIDDLE (fixes the radix-240 and radix-320 AVX-512 SIGSEGVs)

### DIFF
--- a/src/sse2_macro_gcc64.h
+++ b/src/sse2_macro_gcc64.h
@@ -2928,7 +2928,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		 ,[__o2] "m" (Xo2)\
 		 ,[__o3] "m" (Xo3)\
 		 ,[__o4] "m" (Xo4)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm31"	/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -3019,7 +3019,7 @@ Use x0-7 for I-addresses, x8-15 for O-addresses - by the time we need x15 for ou
 		 ,[__o2] "m" (Xo2)\
 		 ,[__o3] "m" (Xo3)\
 		 ,[__o4] "m" (Xo4)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm31"	/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm31"	/* Clobbered registers */\
 	);\
 	}
 


### PR DESCRIPTION
## Summary

Resolves #65.

The AVX-512 version of `SSE2_RADIX_05_DFT_0TWIDDLE` in `src/sse2_macro_gcc64.h` — and its KNC/IMCI512 sibling — uses `%%zmm8` and `%%zmm9` as scratch:

```
"vaddpd	    (%%rsi),%%zmm4,%%zmm8	\n\t"
"vaddpd	0x40(%%rsi),%%zmm5,%%zmm9	\n\t"
...
"vfmadd132pd	%%zmm31,%%zmm4,%%zmm9	\n\t"
"vfmadd132pd	%%zmm31,%%zmm5,%%zmm8	\n\t"
```

but its clobber list stops at `xmm7`:

```
: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi",
  "xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm31"
```

The list was inherited from the AVX2 version of the macro, which genuinely only touches `zmm0-7`; the AVX-512 rewrite added two temporaries and the list was not updated. The compiler is therefore entitled to keep live values in `xmm8`/`xmm9` across the asm block, and the block destroys them.

This is a program-side contract violation, not a compiler defect. That it looks compiler-version-specific is only a matter of which registers each release's allocator happens to pick.

## Reproducer

Any x86-64 host; no AVX-512 silicon needed if you use Intel SDE.

```
./makemake.sh avx512
sde64 -skx -- ./obj_avx512/Mlucas -m 4837331 -fftlen 240 -radset 0 -shift 0 -iters 100
```

* gcc 15.3.0 and gcc 16.1.1 → **SIGSEGV** in `cy240_process_chunk`
* clang → no crash, but a bogus `MaxErr = 0.4999979` / `ERR_ROUNDOFF`
* gcc 11.4.0 → happens to look clean

It fails at **every `-O` level including `-O1`**, with and without LTO. That is the giveaway that this is not a codegen-quality problem.

## Diagnosis

`cy240_process_chunk` faults at the first statement of the AVX-512 weight-init block in `radix240_main_carry_loop.h`:

```c
l = j & (nwt-1);
n_minus_sil->d0 = n-si[l];      tmp->d0 = wt0[l];
```

Register state at the fault, from a `ucontext` dump in a SIGSEGV handler under SDE:

* `n = 245760`, `nwt = 128`, `l = 16` — all correct
* `si == NULL` and `wt0 == NULL`

So the index arithmetic is fine; the two weight-table base pointers are gone. Two clean NULLs is the signature of *never assigned*, not *overwritten with garbage*.

An instrumented build shows both pointers valid on the first `j`-iteration and NULL on the second. The disassembly shows why: gcc parks them in vector registers to survive the GPR-clobbering inline asm, relaying them as each block's declared clobbers force it —

```
199298: vmovq %rsi,%xmm8   /  1992ad: vmovq %rax,%xmm9    <- before the 15-DFT loop
19a029: vmovdqa64 %xmm8,%xmm16 / %xmm9,%xmm17             <- into the 16-DFT loop
19ab43: vmovq %xmm16,%rsi  /  19ab49: vmovq %xmm17,%rax   <- back at the loop back-edge
```

The relay only makes sense if gcc believes `xmm8`/`xmm9` survive the 15-DFT asm. The three `SSE2_RADIX_05_DFT_0TWIDDLE` expansions inside `SSE2_RADIX_15_DIF` and three more inside `SSE2_RADIX_15_DIT` destroy them.

## Verification

Negative control run first, on unfixed source, so the probe is known to catch the bug:

| build | source | result |
|---|---|---|
| gcc 16.1.1 `-O3 -flto`, AVX-512 | unfixed | SIGSEGV, exit 139 |
| gcc 16.1.1 `-O3 -flto`, AVX-512 | fixed | `Res64: B0D0E72B7C87C174`, `MaxErr = 0.3125` |

Against a native AVX2 build of the same tree (no SDE, no AVX-512):

| case | expected | fixed AVX-512 under SDE |
|---|---|---|
| M4837331 @ 240K radset 0 `{240,16,32}` | `B0D0E72B7C87C174` | matches |
| M4837331 @ 240K radset 1 `{240,32,16}` | `B0D0E72B7C87C174` | matches |
| M4837331 @ 240K radset 2 `{60,8,16,16}` | `B0D0E72B7C87C174` | matches |
| M9530803 @ 480K radset 0 `{240,32,32}` | `6D52BCCB796A46E9` | matches (SIGSEGV before) |

## Scope

The only leading radices whose AVX-512 build expands this macro are **240** and **320** — FFT lengths 240K/480K/960K/1920K/… and 640K/1280K/2560K/…

radix320 carries the identical latent defect (2 expansion sites). gcc 16 does not happen to allocate
`xmm8`/`xmm9` across them, so 640K radset 0 is correct even unfixed there — but **gcc 11.4 does allocate
them, and that is the cause of the radix320 SIGSEGV reported in #148.** Measured in an `ubuntu:22.04` /
gcc 11.4 container under `sde64 -skx`, on pristine `418f365` with no other change:

| tree | `M12628613 @ 640K, radices {320,32,32}`, 4 threads |
|---|---|
| pristine | SIGSEGV at `0x7d80` |
| + `"xmm8","xmm9"` on **one** clobber list (only `radix320_ditN_cy_dif1.o` rebuilt) | `Res64: F951B697F5C5032A` — correct |
| fix reverted | SIGSEGV again |
| pristine + `-ffixed-xmm8 -ffixed-xmm9`, no source change | correct |
| pristine + `-ffixed-xmm12 -ffixed-xmm13` (also heavily allocated in that function, never written by the asm) | SIGSEGV |

The last pair is the discriminating control: it is those two specific registers, not generic allocation
perturbation. The disassembly of the failing binary closes it — `cy320_process_chunk` has exactly three
64-bit reads of `xmm8`: `vmovdqa64 %xmm29,%xmm8` parks a pointer, `vfmadd132pd %zmm31,%zmm5,%zmm8` (the
macro body, verbatim) destroys it, and `vmovq %xmm8,%r8` then feeds it to `SSE2_RADIX_64_DIF` as a base
address. Lane 0 of that FMA is `0.0`, so the pointer becomes NULL and only the callee's offset survives —
which is exactly the "small integer, base lost, offset kept" symptom #148 describes, and why the faulting
address is a clean repeatable `0x7d80`.

So this PR supersedes #148, which attributed the same crash to a GCC 11 codegen bug and worked around it
with `__attribute__((optimize("O0")))`. #148 has been closed.

## A note on sanitizers, since it may save someone else the detour

**UBSan is structurally blind to this and actively misleading here.** Built at the exact failing configuration on unfixed source — 731 `__ubsan_*` call sites inside `cy240_process_chunk` alone — it emits zero diagnostics **and returns the correct residue**. A missing clobber is not undefined behaviour in the sanitizer's sense, and the instrumentation itself perturbs register allocation enough to hide the symptom. A clean UBSan run on this defect class is not evidence of anything.

What actually diagnosed it: the `ucontext` dump, the instrumented run, reading the disassembly, and a mechanical diff of registers-used against registers-declared over the preprocessed TU.

## Related, not fixed here

**This section has been corrected twice; this version is the accurate one.**

The original version listed further missing-clobber sites found by a script that preprocesses each
TU and diffs registers-used against registers-declared. I then removed that list, having convinced
myself the script was unreliable. **That removal was itself the error — the script was right.**

Specifically, it reported `AVX_cmplx_carry_fast_pow2_errcheck_X16` as using `zmm18`/`zmm19` (and the
mask registers `k1`–`k4`) without declaring them. That is **true** on `upstream/main`:

```
$ git show 47d75d3:src/carry_gcc64.h | sed -n 12321p
  : "cc","memory","rax",…,"xmm16","xmm17","xmm20","xmm21",…,"xmm30","xmm31"
```

No `xmm18`, no `xmm19`, no `k1`–`k4`. I had read that line out of a local integration branch which
already had **#68** applied, where the registers *are* declared — same path, same line number,
different content.

**These sites are the subject of #68** ("Declare AVX-512 opmask/high-vector clobbers; harden
carry-loop index arithmetic"), which fixes them tree-wide and is still open. That PR is also the real
fix for the radix1024 AVX-512 silent-zero residue. #181 proposed an `optimize("O2")` workaround
for that on the theory that it was a GCC 16 miscompile; it is not - the clobber list really is
missing on `main` - so #181 has been closed in favour of #68.

The `SSE2_RADIX_05_DFT_0TWIDDLE` fix in *this* PR is unaffected either way: it was root-caused from a
`ucontext` register dump and the disassembly, and verified by residue against a native AVX2 build,
not from that script.

Two real defects in the script are worth fixing before it becomes a CI lint, but both produce **false
positives**, not the false negative I wrongly inferred: it does not join `\` line-continuations (so a
clobber list split across lines reads as "every register missing"), and joining naively still fails
when a line carries a trailing comment before the backslash.
## Caveat on the issue title

This does **not** explain the "Clang 18+" half of #65. clang 18.1.3 does not reproduce the crash, and clang 22.1.8 without a sanitizer is correct both before and after this fix. If the original reporter's clang failure was a distinct problem, it may still be open — worth confirming with them before closing the issue outright.




