### PR TITLE
radix1008/radix4032: fix the silent all-zero-residue carry defects in the ODD_RADIX==63 SIMD paths

### DIFF
--- a/src/radix1008_main_carry_loop.h
+++ b/src/radix1008_main_carry_loop.h
@@ -218,7 +218,15 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		addr = &prp_mult;
 		tmp = s1p00; tm1 = cy_r; tm2 = cy_r+1; itmp = bjmodn; itm2 = bjmodn+4;
 		// Beyond chain length 8, the chained-weights scheme becomes too inaccurate, so re-init seed-wts every 8th pass:
-		incr = 4;	// incr must divide RADIX/8!
+		// *** incr must divide nloop = RADIX/8 = 126, and be <= 8. 4 does NOT divide 126: with incr = 4 the
+		// inner l-loop below overran nloop by 2 on its final pass, reading poff[252],poff[254] past the end of
+		// poff[RADIX>>2] and writing 2 carry-macro calls' worth of data past cy_r/bjmodn, which silently zeroed
+		// the residue (Res64 = 0 with a perfect-looking AvgMaxErr). 3 is the largest divisor of 126 that is <= 4,
+		// so it restores the invariant without lengthening the carry chain. ***
+		incr = 3;	// incr must divide RADIX/8!
+	#if ((RADIX>>3) % 3)
+		#error carry-chain length incr must divide nloop = RADIX>>3 !
+	#endif
 		for(loop = 0; loop < nloop; loop += incr)
 		{
 			co2 = co2save;	// Need this for all wts-inits beynd the initial set, due to the co2 = co3 preceding the (j+2) data
@@ -641,7 +649,7 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 				// Each AVX carry macro call also processes 4 prefetches of main-array data
 				tm2 = (vec_dbl *)(a + j1 + pfetch_dist + poff[(int)(tm1-cy_r)]);	// poff[] = p0,4,8,...; (tm1-cy_r) acts as a linear loop index running from 0,...,RADIX-1 here.
 													/* (cy_i_cy_r) --vvvvvv  vvvvvvvvvvvvvvvvv--[1,2,3]*ODD_RADIX; assumed << l2_sz_vd on input: */
-				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x1f80, 0x3c0,0x780,0xb40, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
+				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x1f80, 0xfc0,0x1f80,0x2f40, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
 				tm0 += 16; tm1++;
 				MOD_ADD32(ic_idx, 8, ODD_RADIX, ic_idx);
 				MOD_ADD32(jc_idx, 8, ODD_RADIX, jc_idx);

--- a/src/radix4032_main_carry_loop.h
+++ b/src/radix4032_main_carry_loop.h
@@ -490,61 +490,74 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 
 		// Oct 2014: Try getting most of the LOACC speedup with better accuracy by breaking the complex-roots-of-(-1)
 		// chaining into 2 or more equal-sized subchains, each starting with 'fresh' (unchained) complex roots:
+		// *** RADIX 4032 is 4x RADIX 1008, so for a given LOACC setting it needs 2 EXTRA folds to obtain the
+		// same complex-roots-of(-1) subchain length that radix1008 uses. The ladder below was copy-pasted verbatim
+		// from radix1008 (note the stale radix1008 filename in the #error text), which left the subchain 4x too
+		// long: at LOACC=0 the single subchain ran the full 1008 carry-macro calls and tripped a roundoff error
+		// at iteration 25. NFOLD = LOACC+2 restores parity with radix1008. ***
 		#if (LOACC == 0)
 			#warning LOACC = 0
-			#define NFOLD 0
+			#define NFOLD 2
 		#elif (LOACC == 1)
 			#warning LOACC = 1
-			#define NFOLD 1
+			#define NFOLD 3
 		#elif (LOACC == 2)
 			#warning LOACC = 2
-			#define NFOLD 2
+			#define NFOLD 4
 		#elif (LOACC == 3)
 			#warning LOACC = 3
-			#define NFOLD 3
+			#define NFOLD 5
 		#elif (LOACC == 4)
 			#warning LOACC = 4
-			#define NFOLD 4
+			#define NFOLD 6
 		#elif (LOACC == 5)
 			#warning LOACC = 5
-			#define NFOLD 5
+			#define NFOLD 7
 		#else
-			#error If LOACC defined for build of radix1008_ditN_cy_dif1.c, must be given value 0,1,2,3,4 or 5!
+			#error If LOACC defined for build of radix4032_ditN_cy_dif1.c, must be given value 0,1,2,3,4 or 5!
 		#endif
 
 		#ifdef USE_AVX512
 		// For NFOLD > 3,  RADIX not divisible by 2^(3+NFOLD), so use a more-general inner-loop scheme which can handle that:
 		  #if NFOLD == 0
-			const int nexec[] = {126};
+			const int nexec[] = {504};
 		  #elif NFOLD == 1
-			const int nexec[] = {63,63};
+			const int nexec[] = {252,252};
 		  #elif NFOLD == 2
-			const int nexec[] = {32,31,32,31};
+			const int nexec[] = {126,126,126,126};
 		  #elif NFOLD == 3
-			const int nexec[] = {16,16,16,15,16,16,16,15};
+			const int nexec[] = {63,63,63,63,63,63,63,63};
 		  #elif NFOLD == 4
-			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
+			const int nexec[] = {32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31};
 		  #elif NFOLD == 5
-			const int nexec[] = {4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3};
+			const int nexec[] = {16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15};
+		  #elif NFOLD == 6
+			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
+		  #elif NFOLD == 7
+			const int nexec[] = {4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3};
 		  #else
-			#error NFOLD may only range from 0-5!
+			#error NFOLD may only range from 0-7!
 		  #endif
 		#elif defined(USE_AVX)
 		// For NFOLD > 3,  RADIX not divisible by 2^(3+NFOLD), so use a more-general inner-loop scheme which can handle that:
 		  #if NFOLD == 0
-			const int nexec[] = {252};
+			const int nexec[] = {1008};
 		  #elif NFOLD == 1
-			const int nexec[] = {126,126};
+			const int nexec[] = {504,504};
 		  #elif NFOLD == 2
-			const int nexec[] = {63,63,63,63};
+			const int nexec[] = {252,252,252,252};
 		  #elif NFOLD == 3
-			const int nexec[] = {32,31,32,31,32,31,32,31};
+			const int nexec[] = {126,126,126,126,126,126,126,126};
 		  #elif NFOLD == 4
-			const int nexec[] = {16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15};
+			const int nexec[] = {63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63};
 		  #elif NFOLD == 5
-			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
+			const int nexec[] = {32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31};
+		  #elif NFOLD == 6
+			const int nexec[] = {16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15};
+		  #elif NFOLD == 7
+			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
 		  #else
-			#error NFOLD may only range from 0-5!
+			#error NFOLD may only range from 0-7!
 		  #endif
 		#endif
 
@@ -593,7 +606,7 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 				// Each AVX carry macro call also processes 4 prefetches of main-array data
 				tm2 = (vec_dbl *)(a + j1 + pfetch_dist + poff[(int)(tm1-cy_r)]);	// poff[] = p0,4,8,...; (tm1-cy_r) acts as a linear loop index running from 0,...,RADIX-1 here.
 													/* (cy_i_cy_r) --vvvvvv  vvvvvvvvvvvvvvvvvvvv--[1,2,3]*ODD_RADIX; assumed << l2_sz_vd on input: */
-				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x7e00, 0x1f80,0x3f00,0x5e80, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
+				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x7e00, 0xfc0,0x1f80,0x2f40, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
 				tm0 += 16; tm1++;
 				MOD_ADD32(ic_idx, 8, ODD_RADIX, ic_idx);
 				MOD_ADD32(jc_idx, 8, ODD_RADIX, jc_idx);
@@ -615,7 +628,7 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 				// Each AVX carry macro call also processes 4 prefetches of main-array data
 				tm2 = (vec_dbl *)(a + j1 + pfetch_dist + poff[(int)(tm1-cy_r)]);	// poff[] = p0,4,8,...; (tm1-cy_r) acts as a linear loop index running from 0,...,RADIX-1 here.
 													/* (cy_i_cy_r) --vvvvvv  vvvvvvvvvvvvvvvvvvvv--[1,2,3]*ODD_RADIX; assumed << l2_sz_vd on input: */
-				SSE2_fermat_carry_norm_errcheck_X4_loacc(tm0,tmp,tm1,0x7e00, 0x1f80,0x3f00,0x5e80, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7, tm2,p1,p2,p3, addr);
+				SSE2_fermat_carry_norm_errcheck_X4_loacc(tm0,tmp,tm1,0x7e00, 0x7e0,0xfc0,0x17a0, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7, tm2,p1,p2,p3, addr);
 				tm0 += 8; tm1++;
 				MOD_ADD32(ic_idx, 4, ODD_RADIX, ic_idx);
 				MOD_ADD32(jc_idx, 4, ODD_RADIX, jc_idx);


### PR DESCRIPTION
## Summary

`radix1008` and `radix4032` each returned `Res64 = 0000000000000000` — a silent all-zero residue reported with a *perfect* `AvgMaxErr`, because `fracmax` measures distance from the nearest integer and zero is exactly an integer.

They turn out to be **two unrelated defects that merely share `ODD_RADIX == 63`**, and they are exact mirror images. Measured at one FFT length and exponent so the radix sets are directly comparable:

| leading radix | Mersenne | Fermat |
|---|---|---|
| 1008 | `Res64 = 0` | ok |
| 4032 | ok | `Res64 = 0` |

## 1. radix1008, Mersenne, AVX/AVX2 — an unenforced divisibility invariant

The LOACC carry loop is chunked as

```c
for(loop = 0; loop < nloop; loop += incr)
    for(l = loop; l < loop+incr; l++) ...
```

The inner loop runs `[loop, loop+incr)` unconditionally, so correctness requires `incr | nloop`. The source comment states the invariant — `incr must divide RADIX/8!` — but nothing enforced it. With `nloop = RADIX>>3 = 126` and `incr = 4`, the final chunk executed **two carry-macro calls past the end**:

* `poff[l+l]` reached `poff[252]` and `poff[254]`, out of `static int poff[RADIX>>2]` = 252 entries;
* `tmp`, `tm1`/`tm2` and `itmp`/`itm2` were advanced two calls too far and the macro *writes* through them, past `cy_r` and `bjmodn`.

ASan on the unfixed code pins it exactly:

```
'poff' (line 2498) spans [128, 1136)  <== memory access at offset 1136 overflows this variable
```

`[128,1136)` is 1008 bytes = 252 ints, and offset 1136 is `poff[252]`.

**Fix:** `incr = 3` — the largest divisor of 126 that does not lengthen the carry chain — plus a compile-time guard so the invariant can't silently rot again:

```c
#if ((RADIX>>3) % 3)
    #error carry-chain length incr must divide nloop = RADIX>>3 !
#endif
```

A tree-wide audit found this is the **only** live violation of that invariant: the modern radices zero out `incr_*` in the ISA modes where it would not divide.

## 2. radix4032, Fermat — a clone of radix1008 that was never rescaled

That radix4032 was cloned from radix1008 is self-evident from the file itself: its own `#error` text still names `radix1008_ditN_cy_dif1.c`. Three RADIX-dependent things were left at radix1008's values. Each was shown to be independently load-bearing by fixing them in sequence and re-measuring:

* **`nexec[]` tables** were byte-identical to radix1008's, summing to 252/126 rather than the required `RADIX>>2` / `RADIX>>3` = 1008/504 — so three quarters of the Fermat carries were never performed at all;
* **the `[1,2,3]*ODD_RADIX*SZ_VD` byte offsets** passed to `SSE2_fermat_carry_norm_errcheck_X{4,8}_loacc` were 4× and 2× too large;
* **the `LOACC → NFOLD` ladder** was inherited unchanged, leaving the complex-roots-of(−1) subchain 4× longer than radix1008's; with the first two fixed this alone tripped a roundoff error at iteration 25. The runtime `[long] → [medium]` chain-length fallback cannot rescue this, because `NFOLD` is fixed at compile time.

## 3. radix1008, Fermat, AVX-512 — wrong `ODD_RADIX` in the offsets

The `X8_loacc` offsets were `0x3c0, 0x780, 0xb40`. Those are `[1,2,3] × 15 × 64` — the `ODD_RADIX == 15` values, copy-pasted from radix240/radix960. For `ODD_RADIX == 63` they must be `[1,2,3] × 63 × 64` = `0xfc0, 0x1f80, 0x2f40`. The wrong values produced `nonzero exit carry` at iteration 1 under SDE.

## Verification

Every probe was first shown to reproduce the defect on **unfixed** code — including an unfixed AVX-512 build that reproduced `nonzero exit carry at iter 1` verbatim, and an ASan pair (unfixed: heap overflow; fixed: clean). Results are checked against `nosimd` reference residues and against cross-radix agreement at a fixed FFT length, never against `AvgMaxErr`.

**Mersenne**

| leading radix | nosimd | SSE2 | AVX | AVX2 | AVX-512 (SDE) |
|---|---|---|---|---|---|
| 1008 | ok | ok | **fixed** (was ROE it. 13) | **fixed** (was `Res64 = 0`) | still unsupported, see below |
| 4032 | ok | ok | ok | ok | still unsupported, see below |

**Fermat**

| leading radix | nosimd | SSE2 | AVX | AVX2 | AVX-512 (SDE) |
|---|---|---|---|---|---|
| 1008 | ok | ok | ok | ok | **fixed** (was `ERR_CARRY` it. 1) |
| 4032 | ok | ok | **fixed** (was `Res64 = 0`) | **fixed** (was `Res64 = 0`) | **fixed** (was `ERR_CARRY`) |

Six previously-failing cells fixed. AVX-512 rows are via Intel SDE (`sde64 -skx`), 10 iterations; the rest are 100 iterations, `-shift 0`, single-threaded.

## Not addressed here: AVX-512 Mersenne

`radix1008_main_carry_loop.h` and `radix4032_main_carry_loop.h` carry

```
#warning No avx-512 mers-mod carry support yet!
```

and are the only two files in the tree that do — under `USE_AVX512` + Mersenne the carry step emits no code at all. That is a **missing feature**, not a defect in the code that exists, and it is out of scope for this PR.

Worth being explicit about one consequence: the abort actually seen in that configuration comes from slightly upstream — the thread-local `half_arr` memcheck, which reads `#ifdef USE_AVX` and therefore probes AVX offsets `+40/+56` in an AVX-512 build. radix960, which does support AVX-512 Mersenne, has the missing `#ifdef USE_AVX512` no-op arm. **Adding that arm here would be wrong**: it would convert a loud abort into a run that silently produces garbage, because the carry underneath is still absent. The abort is, by accident, the correct behaviour, and it should stay until the carry is implemented.

## Relationship to other open PRs

* **#175** (soft-skip the SIMD-broken 63·2^k leading radices) is the containment for exactly these failures. With this PR applied most of what it guards is no longer broken, so it can be narrowed — Fermat to `radix0 == 63` at every SIMD level, Mersenne to `radix0 == 63` everywhere plus `{1008, 4032}` under AVX-512 only. **Merge order matters: #175 first, then narrow.** Narrowing without this fix re-exposes the silent-zero cells.
* **#156** (scalar-mode Fermat cycle-index increment mod `nwt`) touches the same two radices on the scalar path. Verified merge-clean against this branch.
* radix63 itself is **not** part of this and is not fixed. Its carry step is entirely scalar — no SIMD carry macro at all — so it shares none of the machinery repaired here. It has its own separate defects and #175 should keep rejecting it.
