### PR TITLE
radix1008/radix4032: implement the missing AVX-512 Mersenne-mod carry

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -3945,7 +3945,7 @@ int 	main(int argc, char *argv[])
 	uint32 numrad = 0, rad_prod = 0, rvec[10], rvec2[10];	/* Temporary storage for FFT radices */
 	double	runtime,/* wruntime, */ runtime_best,wruntime_best, tdiff;	// v20: w-prefixed are weighted by associated ROEs
 	double	roerr_avg = 0, roerr_max = 0;
-	int		radix_set, radix_best, nradix_set_succeed;
+	int		radix_set, radix_best, nradix_set_succeed, nradix_set_skipped, nradix_set_tried;
 
 	uint32 mvec_res_t_idx = 0;	/* Lookup index into the res_triplet table */
 	uint32 new_data;
@@ -4662,6 +4662,7 @@ TIMING_TEST_LOOP:
 		runtime_best = wruntime_best = 0.0;
 		radix_best = -1;
 		nradix_set_succeed = 0;
+		nradix_set_skipped = 0;	// #radix-sets this build has no implementation for - not failures, see below
 
 		/* If user-specified radix set, do only that one: */
 		if(radset >= 0)
@@ -4718,7 +4719,19 @@ TIMING_TEST_LOOP:
 			else if(retVal)	// Bzzzzzzzzzzzt!!! That answer is incorrect. The penalty is death:
 			{
 				printMlucasErrCode(retVal);
-				if( !userSetExponent && ((iters == 100) || (iters == 1000) || (iters == 10000)) )
+				// ERR_RADIX0_UNAVAILABLE means "this build has no working implementation of this leading radix"
+				// - e.g. the many radixNN_ditN_cy_dif1.c "No AVX-512 support; Skipping this leading radix."
+				// self-rejections, and the mers|fermat_mod_square guards on known-broken leading radices. That is
+				// "not applicable", not "computed the wrong answer", so it must not count against this FFT length
+				// in the pass-fraction test below: a length whose remaining radix sets are all correct should still
+				// get a cfg-file entry. Note we deliberately do NOT extend this to ERR_ASSERT, which the mod_square
+				// routines also return for the genuine "max_fp < 0.01 during DWT-unweighting" numerical failure -
+				// that one is a wrong-answer signal and must keep counting as a failure.
+				if(retVal == ERR_RADIX0_UNAVAILABLE) {
+					nradix_set_skipped++;
+					if( !userSetExponent && ((iters == 100) || (iters == 1000) || (iters == 10000)) )
+						fprintf(stderr, "This radix set is not available in this build - skipping it (not counted as a failure).\n");
+				} else if( !userSetExponent && ((iters == 100) || (iters == 1000) || (iters == 10000)) )
 					fprintf(stderr, "Error detected - this radix set will not be used.\n");
 				if(radset >= 0)	// If user-specified radix set, do only that one:
 					goto DONE;
@@ -4781,15 +4794,20 @@ TIMING_TEST_LOOP:
 		}
 
 		// If get no successful reference-Res64-matching results, or less than half of results @this FFT length match, skip it:
-		if(radix_best < 0 || runtime_best == 0.0 || nradix_set_succeed < (radix_set+1)/2)
+		// The denominator counts only the radix sets this build can actually run: ones which self-rejected with
+		// ERR_RADIX0_UNAVAILABLE are unimplemented here, not wrong, so counting them as failures would discard an
+		// FFT length whose remaining radix sets all produce the correct residue. When every set was skipped the
+		// (radix_best < 0) test still catches the length, so no cfg entry gets written on a vacuous 0-of-0.
+		nradix_set_tried = radix_set - nradix_set_skipped;	// #radix-sets actually attempted by this build
+		if(radix_best < 0 || runtime_best == 0.0 || nradix_set_succeed < (nradix_set_tried+1)/2)
 		{
-			sprintf(cbuf, "WARNING: %d of %d radix-sets at FFT length %u K passed - skipping it. PLEASE CHECK YOUR BUILD OPTIONS.\n",nradix_set_succeed,radix_set,iarg);
+			sprintf(cbuf, "WARNING: %d of %d radix-sets at FFT length %u K passed (%d skipped as unavailable in this build) - skipping it. PLEASE CHECK YOUR BUILD OPTIONS.\n",nradix_set_succeed,nradix_set_tried,iarg,nradix_set_skipped);
 			fprintf(stderr,"%s", cbuf);
 		}
 		/* If get a nonzero best-runtime, write the corresponding radix set index to the .cfg file: */
 		else
 		{
-			sprintf(cbuf, "INFO: %d of %d radix-sets at FFT length %u K passed - writing cfg-file entry.\n",nradix_set_succeed,radix_set,iarg);
+			sprintf(cbuf, "INFO: %d of %d radix-sets at FFT length %u K passed (%d skipped as unavailable in this build) - writing cfg-file entry.\n",nradix_set_succeed,nradix_set_tried,iarg,nradix_set_skipped);
 			fprintf(stderr,"%s", cbuf);
 
 			/* Divide by the number of iterations done in the self-test: */

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -338,24 +338,6 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			}
 		}
 
-	#ifdef USE_AVX512
-		/* radix1008 (= 63*16) and radix4032 (= 63*64) have no AVX-512 Mersenne-mod carry:
-		radix{1008,4032}_main_carry_loop.h carry the '#warning No avx-512 mers-mod carry support yet!',
-		and under USE_AVX512 + Mersenne the carry step emits no code whatsoever.
-
-		Without this check the run still fails, but further downstream and less clearly: the
-		thread-local half_arr memcheck reads '#ifdef USE_AVX', so in an AVX-512 build it probes the
-		4-lane AVX offsets +40/+56 and asserts. radix960, which does support AVX-512 Mersenne, carries
-		a no-op '#ifdef USE_AVX512' arm that silences exactly that assert. Do NOT add that arm here
-		while the carry is still missing: it would turn a loud failure into a silently wrong residue.
-
-		Remove this check when the AVX-512 Mersenne carry is implemented, not before. */
-		if(radix0 == 1008 || radix0 == 4032)
-		{
-			sprintf(cbuf  ,"Leading radix %u has no AVX-512 Mersenne-mod carry implementation; Skipping this leading radix.\n", (uint32)radix0);
-			WARN(HERE, cbuf, "", 1); return(ERR_RADIX0_UNAVAILABLE);
-		}
-	#endif
 
 		sprintf(cbuf,"Using complex FFT radices*");
 		char_addr = strstr(cbuf,"*");

--- a/src/mers_mod_square.c
+++ b/src/mers_mod_square.c
@@ -338,6 +338,25 @@ The scratch array (2nd input argument) is only needed for data table initializat
 			}
 		}
 
+	#ifdef USE_AVX512
+		/* radix1008 (= 63*16) and radix4032 (= 63*64) have no AVX-512 Mersenne-mod carry:
+		radix{1008,4032}_main_carry_loop.h carry the '#warning No avx-512 mers-mod carry support yet!',
+		and under USE_AVX512 + Mersenne the carry step emits no code whatsoever.
+
+		Without this check the run still fails, but further downstream and less clearly: the
+		thread-local half_arr memcheck reads '#ifdef USE_AVX', so in an AVX-512 build it probes the
+		4-lane AVX offsets +40/+56 and asserts. radix960, which does support AVX-512 Mersenne, carries
+		a no-op '#ifdef USE_AVX512' arm that silences exactly that assert. Do NOT add that arm here
+		while the carry is still missing: it would turn a loud failure into a silently wrong residue.
+
+		Remove this check when the AVX-512 Mersenne carry is implemented, not before. */
+		if(radix0 == 1008 || radix0 == 4032)
+		{
+			sprintf(cbuf  ,"Leading radix %u has no AVX-512 Mersenne-mod carry implementation; Skipping this leading radix.\n", (uint32)radix0);
+			WARN(HERE, cbuf, "", 1); return(ERR_RADIX0_UNAVAILABLE);
+		}
+	#endif
+
 		sprintf(cbuf,"Using complex FFT radices*");
 		char_addr = strstr(cbuf,"*");
 		for(i = 0; i < NRADICES; i++)

--- a/src/radix1008_ditN_cy_dif1.c
+++ b/src/radix1008_ditN_cy_dif1.c
@@ -175,6 +175,13 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 #if !defined(MULTITHREAD) && !defined(USE_SSE2)
 	double wi_re,wi_im;
 #endif
+  #ifdef USE_AVX512	// AVX-512: main-array loop stride = 2*RE_IM_STRIDE = 16, so the wraparound-carry
+	const int jhi_wrap_mers = 15;	// cleanup pass must cover 16 words, not 8. Cf. radix56/radix960.
+	const int jhi_wrap_ferm = 15;
+  #else
+	const int jhi_wrap_mers =  7;
+	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
+  #endif
 	int NDIVR,i,j,j1,jt,jstart,jhi,full_pass,khi,l,outer;
 #if !defined(MULTITHREAD) && !defined(USE_SSE2)
 	int j2,jp;
@@ -288,7 +295,7 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 #ifndef MULTITHREAD
 	int *itmp;	// Pointer into the bjmodn array
 #endif
-#if !defined(MULTITHREAD) && defined(USE_AVX) && !defined(USE_AVX512)
+#if !defined(MULTITHREAD) && defined(USE_AVX)
 	int *itm2;
 #endif
 	int err;
@@ -303,7 +310,7 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
   #endif
   #ifdef USE_AVX512
 	double t0,t1,t2,t3;
-	static struct uint32x8 /* *n_minus_sil,*n_minus_silp1, */*sinwt,*sinwtm1;
+	static struct uint32x8 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
   #elif defined(USE_AVX)
 	static struct uint32x4 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
   #else
@@ -371,10 +378,7 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 	static vec_dbl *__r0;	// Base address for discrete per-thread local stores
   #else
 	double	/* Addresses into array sections */
-		*add1,*add2
-	  #ifndef USE_AVX512
-		,*add0,*add3
-	  #endif
+		*add1,*add2,*add0,*add3
 	  #ifndef USE_SSE2
 		,*add4,*add5,*add6,*add7,*add8,*add9,*adda,*addb,*addc,*addd,*adde,*addf
 	  #endif
@@ -692,7 +696,11 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		VEC_DBL_INIT(two  , 2.0  );	VEC_DBL_INIT(one  , 1.0  );
 		VEC_DBL_INIT(sqrt2, SQRT2);	VEC_DBL_INIT(isrt2, ISRT2);
 		VEC_DBL_INIT(cc0, c16  );	VEC_DBL_INIT(ss0, s16);	// Radix-16 DFT macros assume [sqrt2,isrt2,cc0,ss0] memory ordering
+	  #ifdef USE_AVX512	// In AVX-512 mode, use VRNDSCALEPD for rounding and hijack this vector-data slot for the 4 base/baseinv-consts
+		sse2_rnd->d0 = base[0]; sse2_rnd->d1 = baseinv[1]; sse2_rnd->d2 = wts_mult[1]; sse2_rnd->d3 = inv_mult[0];
+	  #else
 		VEC_DBL_INIT(sse2_rnd, crnd);		/* SSE2 math = 53-mantissa-bit IEEE double-float: */
+	  #endif
 
 	// Init-mode calls to these functions which maintain an internal local-alloc static store:
 		thr_id = -1;	// Use this special thread id for any macro-required thread-local-data inits...
@@ -1042,8 +1050,8 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 
   #ifdef USE_AVX512
    #ifndef MULTITHREAD
-	//n_minus_sil   = (struct uint32x8 *)sse_n + 1;
-	//n_minus_silp1 = (struct uint32x8 *)sse_n + 2;
+	n_minus_sil   = (struct uint32x8 *)sse_n + 1;
+	n_minus_silp1 = (struct uint32x8 *)sse_n + 2;
 	sinwt         = (struct uint32x8 *)sse_n + 3;
 	sinwtm1       = (struct uint32x8 *)sse_n + 4;
    #endif
@@ -1537,7 +1545,7 @@ for(outer=0; outer <= 1; outer++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 7;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
@@ -1557,7 +1565,7 @@ for(outer=0; outer <= 1; outer++)
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 15;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_ferm;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + n_div_nwt/CY_THREADS;
 		}
@@ -1698,7 +1706,11 @@ for(outer=0; outer <= 1; outer++)
 		ASSERT(tdat[ithread].wts_idx_inc2 == wts_idx_inc2, "thread-local memcheck fail!");
 		ASSERT(tdat[ithread].r00 == __r0 + ithread*cslots_in_local_store, "thread-local memcheck fail!");
 		tmp = tdat[ithread].half_arr;
+	  #ifdef USE_AVX512	// In AVX-512 mode, use VRNDSCALEPD for rounding and hijack this vector-data slot for the 4 base/baseinv-consts
+		ASSERT(((tmp-1)->d0 == base[0] && (tmp-1)->d1 == baseinv[1] && (tmp-1)->d2 == wts_mult[1] && (tmp-1)->d3 == inv_mult[0]), "thread-local memcheck failed!");
+	  #else
 		ASSERT(((tmp-1)->d0 == crnd && (tmp-1)->d1 == crnd), "thread-local memcheck failed!");
+	  #endif
 	#endif
 		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 		{
@@ -2033,11 +2045,11 @@ for(outer=0; outer <= 1; outer++)
 	*/
 	if(TRANSFORM_TYPE == RIGHT_ANGLE)
 	{
-		j_jhi =15;
+		j_jhi = jhi_wrap_ferm;
 	}
 	else
 	{
-		j_jhi = 7;
+		j_jhi = jhi_wrap_mers;
 	}
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
@@ -2690,7 +2702,7 @@ void radix1008_dit_pass1(double a[], int n)
 	#endif
 	#ifdef USE_AVX512
 		double t0,t1,t2,t3;
-		struct uint32x8 /* *n_minus_sil,*n_minus_silp1, */*sinwt,*sinwtm1;
+		struct uint32x8 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
 	#elif defined(USE_AVX)
 		struct uint32x4 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
 	#else
@@ -2710,10 +2722,7 @@ void radix1008_dit_pass1(double a[], int n)
 
 		const double crnd = 3.0*0x4000000*0x2000000;
 		double
-			*add1, *add2
-		  #ifndef USE_AVX512
-			,*add0, *add3
-		  #endif
+			*add1, *add2, *add0, *add3
 		  #ifndef USE_SSE2
 			, *add4, *add5, *add6, *add7, *add8, *add9, *adda, *addb, *addc, *addd, *adde, *addf
 		  #endif
@@ -2724,7 +2733,7 @@ void radix1008_dit_pass1(double a[], int n)
 		vec_dbl *tm0;
 	  #endif
 		int *itmp;	// Pointer into the bjmodn array
-	  #if defined(USE_AVX) && !defined(USE_AVX512)
+	  #if defined(USE_AVX)
 		int *itm2;
 	  #endif
 	  #ifndef USE_AVX
@@ -2865,7 +2874,9 @@ void radix1008_dit_pass1(double a[], int n)
 
 		ASSERT((r00 == thread_arg->r00), "thread-local memcheck failed!");
 		ASSERT((half_arr == thread_arg->half_arr), "thread-local memcheck failed!");
+	  #ifndef USE_AVX512	// In AVX-512 mode, use VRNDSCALEPD for rounding and hijack this vector-data slot for the 4 base/baseinv-consts
 		ASSERT((sse2_rnd->d0 == crnd && sse2_rnd->d1 == crnd), "thread-local memcheck failed!");
+	  #endif
 		tmp = half_arr;
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 	{
@@ -2889,8 +2900,8 @@ void radix1008_dit_pass1(double a[], int n)
 		sse_sw  = sse_bw    + RE_IM_STRIDE;
 		sse_n   = sse_sw    + RE_IM_STRIDE;
 	  #ifdef USE_AVX512
-		//n_minus_sil   = (struct uint32x8 *)sse_n + 1;
-		//n_minus_silp1 = (struct uint32x8 *)sse_n + 2;
+		n_minus_sil   = (struct uint32x8 *)sse_n + 1;
+		n_minus_silp1 = (struct uint32x8 *)sse_n + 2;
 		sinwt         = (struct uint32x8 *)sse_n + 3;
 		sinwtm1       = (struct uint32x8 *)sse_n + 4;
 		bjmodn = (int*)(sinwtm1 + RE_IM_STRIDE);

--- a/src/radix1008_ditN_cy_dif1.c
+++ b/src/radix1008_ditN_cy_dif1.c
@@ -1714,7 +1714,10 @@ for(outer=0; outer <= 1; outer++)
 	#endif
 		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 		{
-		#ifdef USE_AVX
+		#ifdef USE_AVX512
+			/* No-Op: in AVX-512 Mersenne mode there are no base/baseinv mini-tables in half_arr - the
+			carry macros use opmasked conditional-doubling of broadcast consts instead. Cf. radix960. */
+		#elif defined(USE_AVX)
 			// Grab some elt of base-data [offset by, say, +32] and mpy by its inverse [+16 further]
 			dtmp = (tmp+40)->d0 * (tmp+56)->d0;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");
 			dtmp = (tmp+40)->d1 * (tmp+56)->d1;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");
@@ -2880,7 +2883,9 @@ void radix1008_dit_pass1(double a[], int n)
 		tmp = half_arr;
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 	{
-	  #ifdef USE_AVX
+	  #ifdef USE_AVX512
+		/* No-Op: see the corr. comment in the main routine. */
+	  #elif defined(USE_AVX)
 		// Grab some elt of base-data [offset by, say, +32] and mpy by its inverse [+16 further]
 		dtmp = (tmp+40)->d0 * (tmp+56)->d0;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");
 		dtmp = (tmp+40)->d1 * (tmp+56)->d1;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");

--- a/src/radix1008_main_carry_loop.h
+++ b/src/radix1008_main_carry_loop.h
@@ -175,19 +175,20 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			target_idx = -1;
 		}
 
-	#ifdef USE_AVX512
-
-		#warning No avx-512 mers-mod carry support yet!
-		(void)wt0; (void)wt1; (void)col; (void)co2; (void)co3; (void)sinwt; (void)sw; (void)si; (void)itmp; (void)add1; (void)add2; // silence warnings
-
-	#elif defined(USE_AVX)
+	#ifdef USE_AVX
 
 		add1 = &wt1[col  ];
 		add2 = &wt1[co2-1];
 		add3 = &wt1[co3-1];
-
-		l= j & (nwt-1);						tmp = half_arr + 128;	/* ptr to local storage for the doubled wtl,wtn terms: */
-		n_minus_sil  ->d0 = n-si[l  ];		tmp->d0 = wt0[    l  ];
+		/* ptr to local storage for the doubled wtl,wtn terms: */
+	  #ifdef USE_AVX512
+		tmp = half_arr +  64;	// No lookup-tables used in avx-512; instead use opmasked conditional-doubling;
+								// 1st 64 slots hold outputs of wtsinit call. Only half of said slots used in 8-way-init mode.
+	  #else
+		tmp = half_arr + 128;	// 1st 64 slots are basic-4 LUTs, next 32 are the additional 2 LOACC LUTs, next 32 hold outputs of wtsinit call
+	  #endif
+		l= j & (nwt-1);						// These rcol wts-terms are for individual-double-broadcast-to-full-vector-width,
+		n_minus_sil  ->d0 = n-si[l  ];		tmp->d0 = wt0[    l  ];	// hence the mixing of fwd/inv wts, which is normally taboo.
 		n_minus_silp1->d0 = n-si[l+1];		tmp->d1 = wt0[nwt-l  ]*scale;
 		sinwt        ->d0 = si[nwt-l  ];	tmp->d2 = wt0[    l+1];
 		sinwtm1      ->d0 = si[nwt-l-1];	tmp->d3 = wt0[nwt-l-1]*scale;
@@ -209,24 +210,69 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		n_minus_silp1->d3 = n-si[l+1];		tmp->d1 = wt0[nwt-l  ]*scale;
 		sinwt        ->d3 = si[nwt-l  ];	tmp->d2 = wt0[    l+1];
 		sinwtm1      ->d3 = si[nwt-l-1];	tmp->d3 = wt0[nwt-l-1]*scale;
+	  #ifdef USE_AVX512
+		l= (j+8) & (nwt-1);					tmp -= 3;	// Reset to same tmp-startval as above, now copy data into d4-7 slots of vec_dbl
+		n_minus_sil  ->d4 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d4 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d4 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d4 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
 
+		l= (j+10) & (nwt-1);				++tmp;
+		n_minus_sil  ->d5 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d5 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d5 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d5 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
+
+		l= (j+12) & (nwt-1);				++tmp;
+		n_minus_sil  ->d6 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d6 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d6 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d6 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
+
+		l= (j+14) & (nwt-1);				++tmp;
+		n_minus_sil  ->d7 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d7 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d7 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d7 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
+	  #endif
+
+	#ifdef USE_AVX512
+	  // carry_gcc64.h:16296: "For AVX512, support only the fast [i.e. LOACC] Mers-carry macros" - there is no
+	  // AVX-512 analog of AVX_cmplx_carry_norm_errcheck_X4, so *every* USE_SHORT_CY_CHAIN setting must be routed
+	  // through the chained-weights path below (cf. radix960/radix56, which achieve the same by forcing their
+	  // LOACC-selector nonzero under AVX-512). The chain length is still varied with USE_SHORT_CY_CHAIN so the
+	  // runtime chain-shortening ROE fallback in mers_mod_square.c still has an effect.
+	  if(1) {
+	#else
 	  if(USE_SHORT_CY_CHAIN < USE_SHORT_CY_CHAIN_MAX) {	// LOACC with tunable DWT-weights chaining
+	#endif
 
 		uint32 ii,incr,loop,nloop = RADIX>>3, co2save = co2;
 
 		i = (!j);	// Need this to force 0-wod to be bigword
 		addr = &prp_mult;
-		tmp = s1p00; tm1 = cy_r; tm2 = cy_r+1; itmp = bjmodn; itm2 = bjmodn+4;
+		tmp = s1p00; tm1 = cy_r; tm2 = cy_r+1; itmp = bjmodn; itm2 = bjmodn+4;	// tm2,itm2 unused in AVX-512 mode
 		// Beyond chain length 8, the chained-weights scheme becomes too inaccurate, so re-init seed-wts every 8th pass:
 		// *** incr must divide nloop = RADIX/8 = 126, and be <= 8. 4 does NOT divide 126: with incr = 4 the
 		// inner l-loop below overran nloop by 2 on its final pass, reading poff[252],poff[254] past the end of
 		// poff[RADIX>>2] and writing 2 carry-macro calls' worth of data past cy_r/bjmodn, which silently zeroed
 		// the residue (Res64 = 0 with a perfect-looking AvgMaxErr). 3 is the largest divisor of 126 that is <= 4,
-		// so it restores the invariant without lengthening the carry chain. ***
-		incr = 3;	// incr must divide RADIX/8!
-	#if ((RADIX>>3) % 3)
+		// so it restores the invariant without lengthening the carry chain. 126 = 2*3^2*7, so the complete set
+		// of legal (i.e. nloop-dividing) chain lengths <= 8 is {1,2,3,6,7}. ***
+	  #ifdef USE_AVX512
+		if(USE_SHORT_CY_CHAIN == 0)			incr = 7;	// [long]
+		else if(USE_SHORT_CY_CHAIN == 1)	incr = 6;	// [med]
+		else if(USE_SHORT_CY_CHAIN == 2)	incr = 3;	// [short]
+		else								incr = 2;	// [hiacc] - no true HIACC macro in AVX-512, use shortest legal chain
+	   #if ((RADIX>>3) % 7) || ((RADIX>>3) % 6) || ((RADIX>>3) % 3) || ((RADIX>>3) % 2)
 		#error carry-chain length incr must divide nloop = RADIX>>3 !
-	#endif
+	   #endif
+	  #else
+		incr = 3;	// incr must divide RADIX/8!
+	   #if ((RADIX>>3) % 3)
+		#error carry-chain length incr must divide nloop = RADIX>>3 !
+	   #endif
+	  #endif
 		for(loop = 0; loop < nloop; loop += incr)
 		{
 			co2 = co2save;	// Need this for all wts-inits beynd the initial set, due to the co2 = co3 preceding the (j+2) data
@@ -239,16 +285,19 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
 						// (and only then: for all subsequent blocks it's superfluous), this assignment decrements co2 by radix(1).
 			// *But*: since the init macro does an on-the-fly version of this between j,j+2 portions, external code co2=co3 must come *after* both ctmp-data octets are inited.
-		  #ifdef USE_AVX512
-			ASSERT(0, "AVX-512 version of AVX_cmplx_carry_fast_wtsinit_X8 not yet ported!");
-		  #endif
 			AVX_cmplx_carry_fast_wtsinit_X8(add1,add2,add3, itmp, half_arr,sign_mask, n_minus_sil,n_minus_silp1,sinwt,sinwtm1, sse_bw,sse_n)
 
 			for(l = loop; l < loop+incr; l++) {
 				// Each AVX carry macro call also processes 8 prefetches of main-array data
 				add0 = a + j1 + pfetch_dist + poff[l+l];
+			  // In AVX-512 mode, the 4 doubles base[0],baseinv[1],wts_mult[1],inv_mult[0] are in the d0-3 slots of the otherwise-unused sse2_rnd vec_dbl:
+			  #ifdef USE_AVX512
+				AVX_cmplx_carry_fast_errcheck_X8(tmp, tm1    , itmp     , half_arr,i,sign_mask,sse_bw,sse_n,sse_sw, add0,p1,p2,p3,p4, addr);
+				tmp += 16; tm1 += 1;           itmp += 8;            i = 0;	// CY-ptr only advances 1 in AVX-512 mode, since all 8 dbl-carries fit in a single vec_dbl
+			  #else
 				AVX_cmplx_carry_fast_errcheck_X8(tmp, tm1,tm2, itmp,itm2, half_arr,i,sign_mask,sse_bw,sse_n,sse_sw, add0,p1,p2,p3,p4, addr);
 				tmp += 16; tm1 += 2; tm2 += 2; itmp += 8; itm2 += 8; i = 0;
+			  #endif
 			}
 		}
 

--- a/src/radix1008_main_carry_loop.h
+++ b/src/radix1008_main_carry_loop.h
@@ -218,7 +218,15 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		addr = &prp_mult;
 		tmp = s1p00; tm1 = cy_r; tm2 = cy_r+1; itmp = bjmodn; itm2 = bjmodn+4;
 		// Beyond chain length 8, the chained-weights scheme becomes too inaccurate, so re-init seed-wts every 8th pass:
-		incr = 4;	// incr must divide RADIX/8!
+		// *** incr must divide nloop = RADIX/8 = 126, and be <= 8. 4 does NOT divide 126: with incr = 4 the
+		// inner l-loop below overran nloop by 2 on its final pass, reading poff[252],poff[254] past the end of
+		// poff[RADIX>>2] and writing 2 carry-macro calls' worth of data past cy_r/bjmodn, which silently zeroed
+		// the residue (Res64 = 0 with a perfect-looking AvgMaxErr). 3 is the largest divisor of 126 that is <= 4,
+		// so it restores the invariant without lengthening the carry chain. ***
+		incr = 3;	// incr must divide RADIX/8!
+	#if ((RADIX>>3) % 3)
+		#error carry-chain length incr must divide nloop = RADIX>>3 !
+	#endif
 		for(loop = 0; loop < nloop; loop += incr)
 		{
 			co2 = co2save;	// Need this for all wts-inits beynd the initial set, due to the co2 = co3 preceding the (j+2) data
@@ -641,7 +649,7 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 				// Each AVX carry macro call also processes 4 prefetches of main-array data
 				tm2 = (vec_dbl *)(a + j1 + pfetch_dist + poff[(int)(tm1-cy_r)]);	// poff[] = p0,4,8,...; (tm1-cy_r) acts as a linear loop index running from 0,...,RADIX-1 here.
 													/* (cy_i_cy_r) --vvvvvv  vvvvvvvvvvvvvvvvv--[1,2,3]*ODD_RADIX; assumed << l2_sz_vd on input: */
-				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x1f80, 0x3c0,0x780,0xb40, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
+				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x1f80, 0xfc0,0x1f80,0x2f40, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
 				tm0 += 16; tm1++;
 				MOD_ADD32(ic_idx, 8, ODD_RADIX, ic_idx);
 				MOD_ADD32(jc_idx, 8, ODD_RADIX, jc_idx);

--- a/src/radix4032_ditN_cy_dif1.c
+++ b/src/radix4032_ditN_cy_dif1.c
@@ -1661,7 +1661,10 @@ for(outer=0; outer <= 1; outer++)
 	#endif
 		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 		{
-		#ifdef USE_AVX
+		#ifdef USE_AVX512
+			/* No-Op: in AVX-512 Mersenne mode there are no base/baseinv mini-tables in half_arr - the
+			carry macros use opmasked conditional-doubling of broadcast consts instead. Cf. radix960. */
+		#elif defined(USE_AVX)
 			// Grab some elt of base-data [offset by, say, +32] and mpy by its inverse [+16 further]
 			dtmp = (tmp+40)->d0 * (tmp+56)->d0;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");
 			dtmp = (tmp+40)->d1 * (tmp+56)->d1;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");
@@ -3116,7 +3119,9 @@ void radix4032_dit_pass1(double a[], int n)
 		tmp = half_arr;
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 	{
-	  #ifdef USE_AVX
+	  #ifdef USE_AVX512
+		/* No-Op: see the corr. comment in the main routine. */
+	  #elif defined(USE_AVX)
 		// Grab some elt of base-data [offset by, say, +32] and mpy by its inverse [+16 further]
 		dtmp = (tmp+40)->d0 * (tmp+56)->d0;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");
 		dtmp = (tmp+40)->d1 * (tmp+56)->d1;	ASSERT(fabs(dtmp - 1.0) < EPS, "thread-local memcheck failed!");

--- a/src/radix4032_ditN_cy_dif1.c
+++ b/src/radix4032_ditN_cy_dif1.c
@@ -176,6 +176,13 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 #if !defined(MULTITHREAD) && !defined(USE_SSE2)
 	double wi_re,wi_im;
 #endif
+  #ifdef USE_AVX512	// AVX-512: main-array loop stride = 2*RE_IM_STRIDE = 16, so the wraparound-carry
+	const int jhi_wrap_mers = 15;	// cleanup pass must cover 16 words, not 8. Cf. radix56/radix960.
+	const int jhi_wrap_ferm = 15;
+  #else
+	const int jhi_wrap_mers =  7;
+	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
+  #endif
 	int NDIVR,i,j,j1,jt,jstart,jhi,full_pass,khi,l,outer;
 #if !defined(MULTITHREAD) && !defined(USE_SSE2)
 	int j2,jp;
@@ -255,7 +262,7 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 #ifndef MULTITHREAD
 	int *itmp;	// Pointer into the bjmodn array
 #endif
-#if !defined(MULTITHREAD) && defined(USE_AVX) && !defined(USE_AVX512)
+#if !defined(MULTITHREAD) && defined(USE_AVX)
 	int *itm2;
 #endif
 	int err;
@@ -640,7 +647,11 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 		ASSERT((radix4032_creals_in_local_store << L2_SZ_VD) >= ((intptr_t)half_arr - (intptr_t)r00) + (j << L2_SZ_VD), "radix4032_creals_in_local_store checksum failed!");
 
 		/* SSE2 math = 53-mantissa-bit IEEE double-float: */
+	  #ifdef USE_AVX512	// In AVX-512 mode, use VRNDSCALEPD for rounding and hijack this vector-data slot for the 4 base/baseinv-consts
+		sse2_rnd->d0 = base[0]; sse2_rnd->d1 = baseinv[1]; sse2_rnd->d2 = wts_mult[1]; sse2_rnd->d3 = inv_mult[0];
+	  #else
 		VEC_DBL_INIT(sse2_rnd, crnd);
+	  #endif
 
 	// Init-mode calls to these functions which maintain an internal local-alloc static store:
 		thr_id = -1;	// Use this special thread id for any macro-required thread-local-data inits...
@@ -1481,7 +1492,7 @@ for(outer=0; outer <= 1; outer++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 7;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
@@ -1501,7 +1512,7 @@ for(outer=0; outer <= 1; outer++)
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 15;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_ferm;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + n_div_nwt/CY_THREADS;
 		}
@@ -1642,7 +1653,11 @@ for(outer=0; outer <= 1; outer++)
 		ASSERT(tdat[ithread].wts_idx_inc2 == wts_idx_inc2, "thread-local memcheck fail!");
 		ASSERT(tdat[ithread].r00 == __r0 + ithread*cslots_in_local_store, "thread-local memcheck fail!");
 		tmp = tdat[ithread].half_arr;
+	  #ifdef USE_AVX512	// In AVX-512 mode, use VRNDSCALEPD for rounding and hijack this vector-data slot for the 4 base/baseinv-consts
+		ASSERT(((tmp-1)->d0 == base[0] && (tmp-1)->d1 == baseinv[1] && (tmp-1)->d2 == wts_mult[1] && (tmp-1)->d3 == inv_mult[0]), "thread-local memcheck failed!");
+	  #else
 		ASSERT(((tmp-1)->d0 == crnd && (tmp-1)->d1 == crnd), "thread-local memcheck failed!");
+	  #endif
 	#endif
 		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 		{
@@ -1977,11 +1992,11 @@ for(outer=0; outer <= 1; outer++)
 	*/
 	if(TRANSFORM_TYPE == RIGHT_ANGLE)
 	{
-		j_jhi =15;
+		j_jhi = jhi_wrap_ferm;
 	}
 	else
 	{
-		j_jhi = 7;
+		j_jhi = jhi_wrap_mers;
 	}
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)
@@ -2960,7 +2975,7 @@ void radix4032_dit_pass1(double a[], int n)
 		vec_dbl *tm0;
 	  #endif
 		int *itmp;	// Pointer into the bjmodn array
-	  #if defined(USE_AVX) && !defined(USE_AVX512)
+	  #if defined(USE_AVX)
 		int *itm2;
 	  #endif
 	  #ifndef USE_AVX
@@ -3095,7 +3110,9 @@ void radix4032_dit_pass1(double a[], int n)
 
 		ASSERT((r00 == thread_arg->r00), "thread-local memcheck failed!");
 		ASSERT((half_arr == thread_arg->half_arr), "thread-local memcheck failed!");
+	  #ifndef USE_AVX512	// In AVX-512 mode, use VRNDSCALEPD for rounding and hijack this vector-data slot for the 4 base/baseinv-consts
 		ASSERT((sse2_rnd->d0 == crnd && sse2_rnd->d1 == crnd), "thread-local memcheck failed!");
+	  #endif
 		tmp = half_arr;
 	if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE)
 	{

--- a/src/radix4032_main_carry_loop.h
+++ b/src/radix4032_main_carry_loop.h
@@ -127,19 +127,20 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			target_idx = -1;
 		}
 
-	#ifdef USE_AVX512
-
-		#warning No avx-512 mers-mod carry support yet!
-		(void)n_minus_sil; (void)n_minus_silp1; (void)sinwt; (void)add0; (void)add1; (void)add2; (void)add3; (void)col; (void)co2; (void)co3; (void)wt0; (void)wt1; (void)sw; (void)si; (void)itmp; // silence warnings
-
-	#elif defined(USE_AVX)
+	#ifdef USE_AVX
 
 		add1 = &wt1[col  ];
 		add2 = &wt1[co2-1];
 		add3 = &wt1[co3-1];
-
-		l= j & (nwt-1);						tmp = half_arr + 128;	/* ptr to local storage for the doubled wtl,wtn terms: */
-		n_minus_sil  ->d0 = n-si[l  ];		tmp->d0 = wt0[    l  ];
+		/* ptr to local storage for the doubled wtl,wtn terms: */
+	  #ifdef USE_AVX512
+		tmp = half_arr +  64;	// No lookup-tables used in avx-512; instead use opmasked conditional-doubling;
+								// 1st 64 slots hold outputs of wtsinit call. Only half of said slots used in 8-way-init mode.
+	  #else
+		tmp = half_arr + 128;	// 1st 64 slots are basic-4 LUTs, next 32 are the additional 2 LOACC LUTs, next 32 hold outputs of wtsinit call
+	  #endif
+		l= j & (nwt-1);						// These rcol wts-terms are for individual-double-broadcast-to-full-vector-width,
+		n_minus_sil  ->d0 = n-si[l  ];		tmp->d0 = wt0[    l  ];	// hence the mixing of fwd/inv wts, which is normally taboo.
 		n_minus_silp1->d0 = n-si[l+1];		tmp->d1 = wt0[nwt-l  ]*scale;
 		sinwt        ->d0 = si[nwt-l  ];	tmp->d2 = wt0[    l+1];
 		sinwtm1      ->d0 = si[nwt-l-1];	tmp->d3 = wt0[nwt-l-1]*scale;
@@ -161,16 +162,67 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 		n_minus_silp1->d3 = n-si[l+1];		tmp->d1 = wt0[nwt-l  ]*scale;
 		sinwt        ->d3 = si[nwt-l  ];	tmp->d2 = wt0[    l+1];
 		sinwtm1      ->d3 = si[nwt-l-1];	tmp->d3 = wt0[nwt-l-1]*scale;
+	  #ifdef USE_AVX512
+		l= (j+8) & (nwt-1);					tmp -= 3;	// Reset to same tmp-startval as above, now copy data into d4-7 slots of vec_dbl
+		n_minus_sil  ->d4 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d4 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d4 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d4 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
 
+		l= (j+10) & (nwt-1);				++tmp;
+		n_minus_sil  ->d5 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d5 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d5 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d5 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
+
+		l= (j+12) & (nwt-1);				++tmp;
+		n_minus_sil  ->d6 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d6 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d6 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d6 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
+
+		l= (j+14) & (nwt-1);				++tmp;
+		n_minus_sil  ->d7 = n-si[l  ];		tmp->d4 = wt0[    l  ];
+		n_minus_silp1->d7 = n-si[l+1];		tmp->d5 = wt0[nwt-l  ]*scale;
+		sinwt        ->d7 = si[nwt-l  ];	tmp->d6 = wt0[    l+1];
+		sinwtm1      ->d7 = si[nwt-l-1];	tmp->d7 = wt0[nwt-l-1]*scale;
+	  #endif
+
+	#ifdef USE_AVX512
+	  // carry_gcc64.h:16296: "For AVX512, support only the fast [i.e. LOACC] Mers-carry macros" - there is no
+	  // AVX-512 analog of AVX_cmplx_carry_norm_errcheck_X4, so *every* USE_SHORT_CY_CHAIN setting must be routed
+	  // through the chained-weights path below (cf. radix960/radix56, which achieve the same by forcing their
+	  // LOACC-selector nonzero under AVX-512). The chain length is still varied with USE_SHORT_CY_CHAIN so the
+	  // runtime chain-shortening ROE fallback in mers_mod_square.c still has an effect.
+	  if(1) {
+	#else
 	  if(USE_SHORT_CY_CHAIN < USE_SHORT_CY_CHAIN_MAX) {	// LOACC with tunable DWT-weights chaining
+	#endif
 
 		uint32 ii,incr,loop,nloop = RADIX>>3, co2save = co2;
 
 		i = (!j);	// Need this to force 0-wod to be bigword
 		addr = &prp_mult;
-		tmp = s1p00; tm1 = cy_r; tm2 = cy_r+1; itmp = bjmodn; itm2 = bjmodn+4;
+		tmp = s1p00; tm1 = cy_r; tm2 = cy_r+1; itmp = bjmodn; itm2 = bjmodn+4;	// tm2,itm2 unused in AVX-512 mode
 		// Beyond chain length 8, the chained-weights scheme becomes too inaccurate, so re-init seed-wts every 8th pass:
+		// *** incr must divide nloop = RADIX/8 = 504, and be <= 8. The inner l-loop below runs [loop,loop+incr)
+		// unclamped, so a non-dividing incr overruns poff[RADIX>>2] and writes past cy_r/bjmodn - see the
+		// radix1008 sibling, where incr = 4 vs nloop = 126 silently zeroed the residue. 504 = 2^3*3^2*7, so the
+		// legal (i.e. nloop-dividing) chain lengths <= 8 are {1,2,3,4,6,7,8}. ***
+	  #ifdef USE_AVX512
+		if(USE_SHORT_CY_CHAIN == 0)			incr = 8;	// [long]
+		else if(USE_SHORT_CY_CHAIN == 1)	incr = 6;	// [med]
+		else if(USE_SHORT_CY_CHAIN == 2)	incr = 4;	// [short]
+		else								incr = 2;	// [hiacc] - no true HIACC macro in AVX-512, use shortest legal chain
+	   #if ((RADIX>>3) % 8) || ((RADIX>>3) % 6) || ((RADIX>>3) % 4) || ((RADIX>>3) % 2)
+		#error carry-chain length incr must divide nloop = RADIX>>3 !
+	   #endif
+	  #else
 		incr = 4;	// incr must divide RADIX/8!
+	   #if ((RADIX>>3) % 4)
+		#error carry-chain length incr must divide nloop = RADIX>>3 !
+	   #endif
+	  #endif
 		for(loop = 0; loop < nloop; loop += incr)
 		{
 			co2 = co2save;	// Need this for all wts-inits beynd the initial set, due to the co2 = co3 preceding the (j+2) data
@@ -183,16 +235,19 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			co2 = co3;	// For all data but the first set in each j-block, co2=co3. Thus, after the first block of data is done
 						// (and only then: for all subsequent blocks it's superfluous), this assignment decrements co2 by radix(1).
 			// *But*: since the init macro does an on-the-fly version of this between j,j+2 portions, external code co2=co3 must come *after* both ctmp-data octets are inited.
-		  #ifdef USE_AVX512
-			ASSERT(0, "AVX-512 version of AVX_cmplx_carry_fast_wtsinit_X8 not yet ported!");
-		  #endif
 			AVX_cmplx_carry_fast_wtsinit_X8(add1,add2,add3, itmp, half_arr,sign_mask, n_minus_sil,n_minus_silp1,sinwt,sinwtm1, sse_bw,sse_n)
 
 			for(l = loop; l < loop+incr; l++) {
 				// Each AVX carry macro call also processes 8 prefetches of main-array data
 				add0 = a + j1 + pfetch_dist + poff[l+l];
+			  // In AVX-512 mode, the 4 doubles base[0],baseinv[1],wts_mult[1],inv_mult[0] are in the d0-3 slots of the otherwise-unused sse2_rnd vec_dbl:
+			  #ifdef USE_AVX512
+				AVX_cmplx_carry_fast_errcheck_X8(tmp, tm1    , itmp     , half_arr,i,sign_mask,sse_bw,sse_n,sse_sw, add0,p1,p2,p3,p4, addr);
+				tmp += 16; tm1 += 1;           itmp += 8;            i = 0;	// CY-ptr only advances 1 in AVX-512 mode, since all 8 dbl-carries fit in a single vec_dbl
+			  #else
 				AVX_cmplx_carry_fast_errcheck_X8(tmp, tm1,tm2, itmp,itm2, half_arr,i,sign_mask,sse_bw,sse_n,sse_sw, add0,p1,p2,p3,p4, addr);
 				tmp += 16; tm1 += 2; tm2 += 2; itmp += 8; itm2 += 8; i = 0;
+			  #endif
 			}
 		}
 

--- a/src/radix4032_main_carry_loop.h
+++ b/src/radix4032_main_carry_loop.h
@@ -490,61 +490,74 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 
 		// Oct 2014: Try getting most of the LOACC speedup with better accuracy by breaking the complex-roots-of-(-1)
 		// chaining into 2 or more equal-sized subchains, each starting with 'fresh' (unchained) complex roots:
+		// *** RADIX 4032 is 4x RADIX 1008, so for a given LOACC setting it needs 2 EXTRA folds to obtain the
+		// same complex-roots-of(-1) subchain length that radix1008 uses. The ladder below was copy-pasted verbatim
+		// from radix1008 (note the stale radix1008 filename in the #error text), which left the subchain 4x too
+		// long: at LOACC=0 the single subchain ran the full 1008 carry-macro calls and tripped a roundoff error
+		// at iteration 25. NFOLD = LOACC+2 restores parity with radix1008. ***
 		#if (LOACC == 0)
 			#warning LOACC = 0
-			#define NFOLD 0
+			#define NFOLD 2
 		#elif (LOACC == 1)
 			#warning LOACC = 1
-			#define NFOLD 1
+			#define NFOLD 3
 		#elif (LOACC == 2)
 			#warning LOACC = 2
-			#define NFOLD 2
+			#define NFOLD 4
 		#elif (LOACC == 3)
 			#warning LOACC = 3
-			#define NFOLD 3
+			#define NFOLD 5
 		#elif (LOACC == 4)
 			#warning LOACC = 4
-			#define NFOLD 4
+			#define NFOLD 6
 		#elif (LOACC == 5)
 			#warning LOACC = 5
-			#define NFOLD 5
+			#define NFOLD 7
 		#else
-			#error If LOACC defined for build of radix1008_ditN_cy_dif1.c, must be given value 0,1,2,3,4 or 5!
+			#error If LOACC defined for build of radix4032_ditN_cy_dif1.c, must be given value 0,1,2,3,4 or 5!
 		#endif
 
 		#ifdef USE_AVX512
 		// For NFOLD > 3,  RADIX not divisible by 2^(3+NFOLD), so use a more-general inner-loop scheme which can handle that:
 		  #if NFOLD == 0
-			const int nexec[] = {126};
+			const int nexec[] = {504};
 		  #elif NFOLD == 1
-			const int nexec[] = {63,63};
+			const int nexec[] = {252,252};
 		  #elif NFOLD == 2
-			const int nexec[] = {32,31,32,31};
+			const int nexec[] = {126,126,126,126};
 		  #elif NFOLD == 3
-			const int nexec[] = {16,16,16,15,16,16,16,15};
+			const int nexec[] = {63,63,63,63,63,63,63,63};
 		  #elif NFOLD == 4
-			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
+			const int nexec[] = {32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31};
 		  #elif NFOLD == 5
-			const int nexec[] = {4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3};
+			const int nexec[] = {16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15};
+		  #elif NFOLD == 6
+			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
+		  #elif NFOLD == 7
+			const int nexec[] = {4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,3};
 		  #else
-			#error NFOLD may only range from 0-5!
+			#error NFOLD may only range from 0-7!
 		  #endif
 		#elif defined(USE_AVX)
 		// For NFOLD > 3,  RADIX not divisible by 2^(3+NFOLD), so use a more-general inner-loop scheme which can handle that:
 		  #if NFOLD == 0
-			const int nexec[] = {252};
+			const int nexec[] = {1008};
 		  #elif NFOLD == 1
-			const int nexec[] = {126,126};
+			const int nexec[] = {504,504};
 		  #elif NFOLD == 2
-			const int nexec[] = {63,63,63,63};
+			const int nexec[] = {252,252,252,252};
 		  #elif NFOLD == 3
-			const int nexec[] = {32,31,32,31,32,31,32,31};
+			const int nexec[] = {126,126,126,126,126,126,126,126};
 		  #elif NFOLD == 4
-			const int nexec[] = {16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15};
+			const int nexec[] = {63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63};
 		  #elif NFOLD == 5
-			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
+			const int nexec[] = {32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31,32,31};
+		  #elif NFOLD == 6
+			const int nexec[] = {16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15,16,16,16,15};
+		  #elif NFOLD == 7
+			const int nexec[] = {8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7,8,8,8,8,8,8,8,7};
 		  #else
-			#error NFOLD may only range from 0-5!
+			#error NFOLD may only range from 0-7!
 		  #endif
 		#endif
 
@@ -593,7 +606,7 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 				// Each AVX carry macro call also processes 4 prefetches of main-array data
 				tm2 = (vec_dbl *)(a + j1 + pfetch_dist + poff[(int)(tm1-cy_r)]);	// poff[] = p0,4,8,...; (tm1-cy_r) acts as a linear loop index running from 0,...,RADIX-1 here.
 													/* (cy_i_cy_r) --vvvvvv  vvvvvvvvvvvvvvvvvvvv--[1,2,3]*ODD_RADIX; assumed << l2_sz_vd on input: */
-				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x7e00, 0x1f80,0x3f00,0x5e80, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
+				SSE2_fermat_carry_norm_errcheck_X8_loacc(tm0,tmp,tm1,0x7e00, 0xfc0,0x1f80,0x2f40, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7,k8,k9,ka,kb,kc,kd,ke,kf, tm2,p1,p2,p3,p4, addr);
 				tm0 += 16; tm1++;
 				MOD_ADD32(ic_idx, 8, ODD_RADIX, ic_idx);
 				MOD_ADD32(jc_idx, 8, ODD_RADIX, jc_idx);
@@ -615,7 +628,7 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 				// Each AVX carry macro call also processes 4 prefetches of main-array data
 				tm2 = (vec_dbl *)(a + j1 + pfetch_dist + poff[(int)(tm1-cy_r)]);	// poff[] = p0,4,8,...; (tm1-cy_r) acts as a linear loop index running from 0,...,RADIX-1 here.
 													/* (cy_i_cy_r) --vvvvvv  vvvvvvvvvvvvvvvvvvvv--[1,2,3]*ODD_RADIX; assumed << l2_sz_vd on input: */
-				SSE2_fermat_carry_norm_errcheck_X4_loacc(tm0,tmp,tm1,0x7e00, 0x1f80,0x3f00,0x5e80, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7, tm2,p1,p2,p3, addr);
+				SSE2_fermat_carry_norm_errcheck_X4_loacc(tm0,tmp,tm1,0x7e00, 0x7e0,0xfc0,0x17a0, half_arr,sign_mask,k1,k2,k3,k4,k5,k6,k7, tm2,p1,p2,p3, addr);
 				tm0 += 8; tm1++;
 				MOD_ADD32(ic_idx, 4, ODD_RADIX, ic_idx);
 				MOD_ADD32(jc_idx, 4, ODD_RADIX, jc_idx);


### PR DESCRIPTION
> **Stacked on #204 and #175 — merge after both.** #175's commits appear here until it lands, after which this reduces to its own.

**This PR now also deletes #175's guard**, and that is load-bearing rather than tidy-up.

#175 added a check in `mers_mod_square.c` returning `ERR_RADIX0_UNAVAILABLE` for `radix0 == 1008 || 4032` under `USE_AVX512`, because those leading radices had no AVX-512 Mersenne carry and the failure would otherwise have surfaced as a confusing `half_arr` memcheck assert. Its comment names the exit condition:

> *Remove this check when the AVX-512 Mersenne carry is implemented, not before.*

This PR is that implementation. **Merging #175 and this one without removing the guard produces a tree where the carry exists and nothing can reach it** — `-fft 1008K` under AVX-512 still exits having run nothing, and the feature is inert. That was measured, not assumed.

It also pairs with the preceding commit here, which adds the no-op `USE_AVX512` arm to the Mersenne memcheck — the arm #175's comment warns must *not* be added while the carry is missing, since it would turn a loud failure into a silently wrong residue. Adding the arm and removing the guard are correct only together, and only once the carry is present.

### Verified under Intel SDE

Built at `avx512`, run under `sde64 -skx`, against the scalar reference for the same exponent and iteration count:

| config | Res64 |
|---|---|
| nosimd — 1008K radsets 0/1/2, and 1024K | `88FA8A9F67AD8633` |
| **avx512/SDE** — 1008K radset 0, single-threaded | `88FA8A9F67AD8633` |

Multithreaded AVX-512 additionally needs #152 and #207 — without them a 4-thread run halts on roundoff at iteration 1 (`maxerr 0.493`). With the full chain applied it matches the same residue at 4 threads. Those are separate members of the same chain, tracked in #224.

---

## Summary

`radix1008_main_carry_loop.h` and `radix4032_main_carry_loop.h` are the only two files in the tree carrying

```
#warning No avx-512 mers-mod carry support yet!
```

Under `USE_AVX512` + Mersenne the carry step emits **no code at all**, so an AVX-512 build cannot run any of the ten FFT lengths whose leading radix has odd part 63 — 1008K, 2016K, 4032K, 8064K, 16128K, 32256K, 64512K, 129024K, 258048K, 516096K. Every radix set at those lengths leads with 63, 1008 or 4032, so there is no in-length fallback: the whole length is unavailable.

This implements the carry. **No new inline asm was written** — the AVX-512 `AVX_cmplx_carry_fast_wtsinit_X8` and `AVX_cmplx_carry_fast_errcheck_X8` macros already exist in `carry_gcc64.h` and are `ODD_RADIX`-agnostic; the work was wiring, plus two pieces of supporting infrastructure that turned out to be missing.

> **Stacked on #204.** The first of the three commits shown here belongs to that PR. Please merge #204 first; this PR's own contribution is the two commits on top, and the diff will shrink to those once #204 lands.

## Which template applies

Not radix960, despite that being the obvious candidate. Both target files declare `struct uint32x8` index vectors, so they are **8-way**, not `CARRY_16_WAY`. `radix56_main_carry_loop.h` is the correct model. The AVX and AVX-512 arms are merged into one `#ifdef USE_AVX` block in that style, with the AVX-512 extensions:

* the four extra `d4`–`d7` weight-init blocks at `j+8,10,12,14`;
* `tmp = half_arr + 64` rather than `+ 128` (AVX-512 uses opmasked conditional-doubling, not lookup tables);
* the 3-argument `AVX_cmplx_carry_fast_errcheck_X8` call with `tm1 += 1` — all eight double-carries fit in one `vec_dbl` — against the AVX 5-argument form;
* `if(1)` in place of `if(USE_SHORT_CY_CHAIN < USE_SHORT_CY_CHAIN_MAX)`, because there is no AVX-512 HIACC macro.

Also deleted a stale `ASSERT(0, "AVX-512 version of AVX_cmplx_carry_fast_wtsinit_X8 not yet ported!")`. That macro *is* ported, at `carry_gcc64.h:6093`; the stub was simply out of date.

## Two missing prerequisites, each load-bearing

Neither was visible by reading — the second only surfaced once the first was fixed.

**1. The `sse2_rnd` hijack.** The AVX-512 errcheck macro reads `base[0]`, `baseinv[1]`, `wts_mult[1]` and `inv_mult[0]` out of `half_arr-0x40 .. -0x28`, which is exactly `sse2_rnd->d0..d3`. Both files unconditionally wrote `crnd` there. Without the hijack: `ERROR: iter = 1; nonzero exit carry`.

**2. `jhi_wrap_mers`.** The Mersenne wraparound-carry cleanup pass was hardcoded to 8 words; the AVX-512 stride-16 loop needs 16. Without it: `ERROR: iter = 6; nonzero exit carry`.

`half_arr` sizing and its offsets needed no change — verified independently rather than assumed.

## The divisibility invariant, again

The LOACC chunking requires `incr | nloop`, the same invariant whose violation #204 fixes on the AVX side. It applies afresh to the new arm with different numbers, so each new chain length carries a compile-time `#error` guard. `incr` tops out at 7 (radix1008) and 8 (radix4032) because `nloop` = 126 and 504 have no larger admissible divisor ≤ 8 — inherent to `ODD_RADIX == 63`, not a tuning choice.

## Verification

Every AVX-512 row is under Intel SDE (`sde64 -skx`), compared against references computed **by different code paths** — this tree's `nosimd` and AVX2 builds — *and* against the neighbouring power-of-two FFT length, which shares no radix code. `AvgMaxErr` is ignored throughout; only residues are compared.

* **All six in-scope radix sets**: 1008K rs0/rs1, 2016K rs0, 4032K rs0/rs1/rs2 — both leading radices.
* **All four `USE_SHORT_CY_CHAIN` settings** (long / med / short / hiacc; `incr` = 7/6/3/2 and 8/6/4/2).
* **1000 iterations** at 1008K and **500** at 4032K, plus a run with `-shift 987654`.
* **Fermat regression clean** (F25 @ 2016K, F26 @ 4032K rs0/rs2) — the cell most at risk from the `sse2_rnd` change.
* **gcc 16.1.1 and clang 22.1.8** both correct.
* A **preprocessor diff** showing zero semantic change outside `USE_AVX512` in all four other build modes — stronger than spot-checking residues.

### Negative controls

Five, each shown to fail *before* being relied on:

| control | result |
|---|---|
| no AVX-512 carry at all (#204 as-is) | memcheck assert at `radix1008…c:1589` |
| carry present, memcheck no-op arm not yet added | assert at `:1597` — which is why that arm is a separate, final commit |
| `jhi_wrap_mers` forced back to 7 | `nonzero exit carry`, iter 6 |
| `sse2_rnd` hijack removed | `nonzero exit carry`, iter 1 |
| the four `d4`–`d7` weight blocks deleted | **`Res64: 0000000000000002`, `AvgMaxErr = 0.000000003`** |

The last one is worth pausing on: a garbage residue reported with a *better* roundoff figure than the correct run (`AvgMaxErr = 0.000468`). That is the same blindness behind the original silent-zero defects — `fracmax` measures distance from the nearest integer, and small integers look perfect.

Two of these were not hypothetical. The `sse2_rnd` and `jhi_wrap_mers` controls are the two bugs actually hit while building this, in that order.

## The memcheck no-op arm is the last commit, deliberately

`radix1008_ditN_cy_dif1.c` / `radix4032_ditN_cy_dif1.c` reach a thread-local `half_arr` memcheck that reads `#ifdef USE_AVX`; since `USE_AVX512` implies `USE_AVX`, an AVX-512 build probes AVX offsets `+40/+56` and aborts. radix960 has the missing `#ifdef USE_AVX512` no-op arm.

Adding that arm before the carry existed would have converted a loud abort into a silently wrong run, so it is committed **last**, only after residues were verified correct. #204 makes the same point in the opposite direction, as its reason for leaving the abort in place.

## Performance

Measured as SDE global dynamic instruction count at two iteration counts so start-up cancels: AVX-512 executes **1.90× fewer instructions per LL iteration than AVX2** (36.5M vs 69.6M at 1008K) — essentially the full 2× from the wider vectors, so nothing is falling back to a slow path.

## Consequence for #175

Once this lands, the Mersenne guard in `mers_mod_square.c` can drop its AVX-512 special case entirely, leaving `if(radix0 == 63)`. radix63 itself is unaffected by this PR and still needs rejecting — its carry step is entirely scalar and shares none of this machinery.

**Do not relax that guard before this merges.**

## Separate pre-existing bug found while testing — not addressed here

**radix1008/4032 Mersenne is broken multithreaded, at every SIMD level, on stock `main`.** Reproduced on unpatched `upstream/main` @ `47d75d3`: radix4032 at 2 threads gives a roundoff error at iteration 12 and halts. radix960 at 4 threads and `nosimd` at 4 threads are clean controls, and AVX-512 and AVX2 fail at the *same iteration with bit-identical maxerr* — which points at a thread-partitioning problem rather than anything ISA-specific.

This is not caused by #204 or by this PR, and it is not covered by either. Every verification run above is single-threaded, as was #204's, so this is genuinely uncovered ground and deserves its own investigation. I would not widen #175's guard to paper over it.

