### PR TITLE
radix24/radix40: hoist the repeated #ifndef MULTITHREAD in the declaration block (follow-up to #126)

### DIFF
--- a/src/radix24_ditN_cy_dif1.c
+++ b/src/radix24_ditN_cy_dif1.c
@@ -235,18 +235,12 @@ int radix24_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	int n_div_nwt;
   #ifndef MULTITHREAD
 	int col,co2,co3;
-  #endif
-  #ifdef USE_AVX512
-   #ifndef MULTITHREAD
+   #ifdef USE_AVX512
 	double t0,t1,t2,t3;
 	static struct uint32x8 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
-   #endif
-  #elif defined(USE_AVX)
-   #ifndef MULTITHREAD
+   #elif defined(USE_AVX)
 	static struct uint32x4 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
-   #endif
-  #else
-   #ifndef MULTITHREAD
+   #else
 	int n_minus_sil,n_minus_silp1,sinwt,sinwtm1;
 	double wtl,wtlp1,wtn,wtnm1;	/* Mersenne-mod weights stuff */
    #endif

--- a/src/radix40_ditN_cy_dif1.c
+++ b/src/radix40_ditN_cy_dif1.c
@@ -232,18 +232,12 @@ int radix40_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	int n_div_nwt;
   #ifndef MULTITHREAD
 	int col,co2,co3;
-  #endif
-  #ifdef USE_AVX512
-   #ifndef MULTITHREAD
+   #ifdef USE_AVX512
 	double t0,t1,t2,t3;
 	static struct uint32x8 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
-   #endif
-  #elif defined(USE_AVX)
-   #ifndef MULTITHREAD
+   #elif defined(USE_AVX)
 	static struct uint32x4 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
-   #endif
-  #else
-   #ifndef MULTITHREAD
+   #else
 	int n_minus_sil,n_minus_silp1,sinwt,sinwtm1;
 	double wtl,wtlp1,wtn,wtnm1;	/* Mersenne-mod weights stuff */
    #endif


### PR DESCRIPTION
## Summary

Follow-up to #126, addressing the review suggestion left there:

> Lines 236-253 could replaced with a single outer `#ifndef MULTITHREAD` instead of repeating that in each inner block, but yes, this could be addressed in a follow up

The carry-variable declaration block repeated `#ifndef MULTITHREAD` four times — once around `int col,co2,co3;` and once inside each arm of the `USE_AVX512` / `USE_AVX` / scalar chain. Every declaration in the block is MULTITHREAD-gated, so one outer guard says the same thing:

```c
  #ifndef MULTITHREAD
	int col,co2,co3;
   #ifdef USE_AVX512
	double t0,t1,t2,t3;
	static struct uint32x8 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
   #elif defined(USE_AVX)
	static struct uint32x4 *n_minus_sil,*n_minus_silp1,*sinwt,*sinwtm1;
   #else
	int n_minus_sil,n_minus_silp1,sinwt,sinwtm1;
	double wtl,wtlp1,wtn,wtnm1;	/* Mersenne-mod weights stuff */
   #endif
  #endif
```

Purely cosmetic — no preprocessor branch changes membership.

## Scope

**radix24 and radix40 are the only two files in the tree with this shape.** A scan for any `USE_AVX512` / `USE_AVX` / `else` chain in which *every* arm's whole body is wrapped in `#ifndef MULTITHREAD` finds exactly these two, and both also carry the `int col,co2,co3;` preamble in its own guard.

Worth noting why this is a narrow change rather than a sweep: the wider declaration region in these files interleaves MULTITHREAD-gated and non-gated declarations, so it cannot be wrapped wholesale. The suggestion above picks out precisely the sub-block where every declaration *is* gated, which is what makes the hoist safe.

## Verification

Preprocessed both files before and after in all ten combinations of `{nosimd, sse2, avx, avx2, avx512}` × `{single-threaded, -DMULTITHREAD -DUSE_PTHREAD}`, and diffed:

**0 semantic differences in 20 of 20 cases.**

The only textual differences are `__LINE__` values baked into `ASSERT`/`WARN` call sites further down each file — e.g.

```
- WARN(355, "radix24_ditN_cy_dif1.c", "radix24_ditN_cy_dif1: No AVX-512 support; Skipping this leading radix.", "", 1);
+ WARN(349, "radix24_ditN_cy_dif1.c", "radix24_ditN_cy_dif1: No AVX-512 support; Skipping this leading radix.", "", 1);
```

Every such shift is exactly **6**, the number of lines removed. (Checked mechanically: the set of distinct shifts across all 20 preprocessed pairs is `{6}`.)

Two notes on the method, since a naive version of this check is misleading. Comparing raw `cpp` output shows every case as differing, because removing lines renumbers every `#line` marker — those have to be stripped first. And after stripping them, the `__LINE__`-in-diagnostics differences remain and must be normalised in both spellings the codebase uses: the line number appears *after* the filename in `ASSERT`, and *before* it in `WARN`.
