### PR TITLE
radix1008/radix4032: fix wrong Mersenne residues with multiple carry threads

### DIFF
--- a/src/dft_macro.c
+++ b/src/dft_macro.c
@@ -3445,6 +3445,14 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 				VEC_DBL_INIT(cc3m1, c3m1);	VEC_DBL_INIT(ss3, s3);
 				VEC_DBL_INIT(cc4  , c4  );	VEC_DBL_INIT(ss4, s4);
 			/* Move on to next thread's local store */
+				// *** two,one must be advanced here along with everything else: without this, all
+				// max_threads passes of this loop wrote 2.0/1.0 into thread 0's pair of slots and
+				// left threads 1..N-1 with whatever ALLOC_VEC_DBL returned (0.0 in practice).
+				// 'two' is a live operand of the FMA form of SSE2_RADIX_07_DFT below, so every
+				// carry thread but thread 0 computed a garbage radix-63 DFT in any build that
+				// defines USE_AVX2 (i.e. AVX2, AVX-512, ARMv8) - the radix1008/radix4032
+				// multithreaded wrong-residue/roundoff-halt bug. ***
+				two   += 152;			one += 152;
 				cc1   += 152;			dc0 += 152;
 				ss1   += 152;			ds0 += 152;
 				cc2   += 152;			dc1 += 152;
@@ -3696,6 +3704,14 @@ in the same order here as DIF, but the in-and-output-index offsets are BRed: j1 
 				VEC_DBL_INIT(cc3m1, c3m1);	VEC_DBL_INIT(ss3, s3);
 				VEC_DBL_INIT(cc4  , c4  );	VEC_DBL_INIT(ss4, s4);
 			/* Move on to next thread's local store */
+				// *** two,one must be advanced here along with everything else: without this, all
+				// max_threads passes of this loop wrote 2.0/1.0 into thread 0's pair of slots and
+				// left threads 1..N-1 with whatever ALLOC_VEC_DBL returned (0.0 in practice).
+				// 'two' is a live operand of the FMA form of SSE2_RADIX_07_DFT below, so every
+				// carry thread but thread 0 computed a garbage radix-63 DFT in any build that
+				// defines USE_AVX2 (i.e. AVX2, AVX-512, ARMv8) - the radix1008/radix4032
+				// multithreaded wrong-residue/roundoff-halt bug. ***
+				two   += 152;			one += 152;
 				cc1   += 152;			dc0 += 152;
 				ss1   += 152;			ds0 += 152;
 				cc2   += 152;			dc1 += 152;

--- a/src/radix8_dif_dit_pass.c
+++ b/src/radix8_dif_dit_pass.c
@@ -139,7 +139,12 @@ void radix8_dif_pass(double a[], int n, struct complex rt0[], struct complex rt1
 		  #endif
 			VEC_DBL_INIT(one  , 1.0);
 			VEC_DBL_INIT(two  , 2.0);
-			isrt2 += 36;	/* Move on to next thread's local store */
+			// sqrt2 was omitted from this list, leaving threads 1..N-1 with an uninitialized copy.
+			// Latent rather than live - the SSE2_RADIX8_D{IF,IT}_TWIDDLE asm reaches its consts via
+			// the isrt2 pointer and never reads the sqrt2 slot below it - but fix it anyway, since
+			// the identical omission in dft_macro.c's SSE2_RADIX_63_D{IF,IT} was a live wrong-answer bug.
+			sqrt2 += 36;	/* Move on to next thread's local store */
+			isrt2 += 36;
 			one   += 36;
 			two   += 36;
 		}
@@ -609,7 +614,12 @@ void radix8_dit_pass(double a[], int n, struct complex rt0[], struct complex rt1
 		  #endif
 			VEC_DBL_INIT(one  , 1.0);
 			VEC_DBL_INIT(two  , 2.0);
-			isrt2 += 36;	/* Move on to next thread's local store */
+			// sqrt2 was omitted from this list, leaving threads 1..N-1 with an uninitialized copy.
+			// Latent rather than live - the SSE2_RADIX8_D{IF,IT}_TWIDDLE asm reaches its consts via
+			// the isrt2 pointer and never reads the sqrt2 slot below it - but fix it anyway, since
+			// the identical omission in dft_macro.c's SSE2_RADIX_63_D{IF,IT} was a live wrong-answer bug.
+			sqrt2 += 36;	/* Move on to next thread's local store */
+			isrt2 += 36;
 			one   += 36;
 			two   += 36;
 		}


### PR DESCRIPTION
## Summary

`radix1008` and `radix4032` compute **wrong Mersenne residues whenever more than one carry thread is used**, in any build that defines `USE_AVX2` — that is AVX2, AVX-512 and ARMv8. The symptom is a roundoff-error halt a dozen iterations in, so it fails loudly rather than silently, but it fails on a default multithreaded run at FFT lengths users select.

Reproduces on unmodified `main`:

```
$ ./Mlucas -m 72123137 -fftlen 4032 -radset 0 -shift 0 -iters 100 -cpu 0:1
  Roundoff warning on iteration 13 ... halting
$ ./Mlucas -m 72123137 -fftlen 4032 -radset 0 -shift 0 -iters 100 -cpu 0
  Res64: 99D05C8A80D2C4AB          <- correct, single-threaded
```

## Root cause

`src/dft_macro.c`, in the per-thread constant-init loops of `SSE2_RADIX_63_DIF` and
`SSE2_RADIX_63_DIT`. Each loop walks `max_threads` local stores, initialising the shared constants
and then advancing every pointer by the 152-`vec_dbl` per-thread stride — `cc1`, `ss1`, `cc2`, `ss2`,
`cc3m1`, `ss3`, `cc4`, `ss4`, `dc0`–`dc3`, `ds0`–`ds3`, sixteen of them.

**`two` and `one` were not advanced.** So every pass of the loop rewrote *thread 0's* pair of slots,
and threads 1..N−1 kept whatever `ALLOC_VEC_DBL` left there — 0.0 in practice:

```
SSE2_RADIX_63_DIT thr_id=0  two=2  one=1  dc0=0.76604444311897801
SSE2_RADIX_63_DIT thr_id=1  two=0  one=0  dc0=0.76604444311897801
```

`dc0` lives in the same block and *is* advanced, which pins the fault to those two missing
increments rather than to the allocation or the stride.

`two` is a live operand of the FMA form of `SSE2_RADIX_07_DFT`, taken under
`#if defined(USE_AVX2) || defined(USE_ARM_V8_SIMD)`. So every carry thread except thread 0 computed
its radix-63 DFT with 2.0 replaced by 0.0.

Blast radius is exactly the two affected radices: only `radix1008` and `radix4032` call these
macros, and `radix63_ditN_cy_dif1.c` `#undef`s `MULTITHREAD`.

The "iteration 13" threshold is not meaningful in itself — it is simply when the growing LL residue
first reaches thread 1's words. `-shift 1000000` moves the failure to iteration 1.

## The fix

One line per site — `two += 152; one += 152;` — plus a comment recording why it matters.

Also advances `sqrt2` in the identically-shaped loop in `radix8_dif_dit_pass.c`. That one is
**latent**: the radix-8 twiddle asm reaches its constants through the `isrt2` pointer and never reads
the `sqrt2` slot. Fixed anyway, since the next person to use that slot would inherit the bug.

## How it was localised

By falsification rather than inspection, because the obvious hypotheses were all wrong:

* **Not a race.** Serialising the dispatch reproduces it bit-identically.
* **Not the work partitioning.** Per-thread `jstart`, `jhi`, `khi`, `col`, `co2`, `co3`, `bjmodn` and
  `bjmodnini` are identical to the single-threaded `k=2` pass. The `_jstart`/`_col`/`_co2`/`_co3` and
  `_bjmodnini` setup code is correct.
* **Not the local-store allocation.** Forcing thread 1 to use thread 0's `ditN` local store changed
  nothing; forcing `thr_id = 0` made the 2-thread run return the 1-thread residue exactly.

## Verification

Residues only — `AvgMaxErr` is not used as a health signal anywhere here. Base and fix are the same
binary with a runtime switch, so the comparison cannot be confounded by a stale build.

| case | threads | AVX2 base | AVX2 fixed | AVX (base ≡ fix) | nosimd |
|---|---|---|---|---|---|
| M72123137 @ 4032K | 1 | `99D0…C4AB` | `99D0…C4AB` | `99D0…C4AB` | `99D0…C4AB` |
| | 2 | **ROE it.13** | **`99D0…C4AB`** | `99D0…C4AB` | `99D0…C4AB` |
| F24 @ 1008K | 1 | `DB9F…DC8B` | `DB9F…DC8B` | `DB9F…DC8B` | `DB9F…DC8B` |
| | 2/4/8 | **ROE it.12/11/10** | **`DB9F…DC8B`** | `DB9F…DC8B` | ROE it.5 — separate bug, see below |
| M @ 1024K, M @ 960K | 1/2/4 | unchanged | unchanged | — | unchanged |

Every reference is cross-validated two ways: against a `nosimd` build, and across FFT lengths
(1008K vs 1024K vs 960K agree at the same exponent). Confirmed on a from-scratch rebuild of the
committed tree with all instrumentation removed.

## Which ISAs are affected

Only builds that define `USE_AVX2` — AVX2, AVX-512 (`platform.h:244` makes `USE_AVX512` imply it),
and ARMv8. **Plain AVX is measurably immune**: base ≡ fix in every cell, because the non-FMA arm of
`SSE2_RADIX_07_DFT` does not read `two`. SSE2 is immune by the same argument.

AVX-512 cells cannot be exercised on `main` today — the Mersenne carry for these radices is
unimplemented, and Fermat dies at iteration 1 from a separate defect.

## Scope beyond these radices

A re-runnable scan for the same shape — a per-thread init loop that advances some pointers into a
local store but not others — finds exactly three sites tree-wide: the two fixed here, the latent
`radix8_dif_dit_pass.c` one (also fixed), and one false positive in `radix16_dif_dit_pass.c`. The
script is kept with the working notes.

## A second, independent MT defect, already fixed elsewhere

While verifying, scalar (`nosimd`) **Fermat** at 1008K/4032K was found to fail from 2 threads at
iteration 5, while `nosimd` Mersenne MT is clean and `nosimd` Fermat at 1024K/960K is clean. That is
a different bug and it is **already fixed** by the existing `% nwt16` → `% nwt` change in the scalar
arm of the per-thread `icycle` simulation. I verified that patch clears all six affected cells
rather than assuming it, and have not duplicated it here.

**This PR plus that change together clear every reachable radix1008/4032 multithreaded cell** not
already blocked by a known single-threaded defect.
