### PR TITLE
radix32_wrapper_square: declare the r11/r12/r13 clobbers in the AVX-512 DIT macro

### DIFF
--- a/src/radix32_wrapper_square_gcc64.h
+++ b/src/radix32_wrapper_square_gcc64.h
@@ -4583,7 +4583,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 
@@ -5343,7 +5343,7 @@ NOTE: Twiddles here shared between DIF/DIT portions, laid out like DIF, i.e. sli
 		 ,[__c10] "m" (Xc10)\
 		 ,[__c12] "m" (Xc12)\
 		 ,[__c1A] "m" (Xc1A)\
-		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
+		: "cc","memory","rax","rbx","rcx","rdx","rdi","rsi","r10","r11","r12","r13","xmm0","xmm1","xmm2","xmm3","xmm4","xmm5","xmm6","xmm7","xmm8","xmm9","xmm10","xmm11","xmm12","xmm13","xmm14","xmm15","xmm16","xmm17","xmm18","xmm19","xmm20","xmm21","xmm22","xmm23","xmm24","xmm25","xmm26","xmm27","xmm28","xmm29","xmm30","xmm31"	/* Clobbered registers */\
 	);\
 	}
 


### PR DESCRIPTION
## Summary

The AVX-512 variant of `SSE2_RADIX32_WRAPPER_DIT` in `src/radix32_wrapper_square_gcc64.h` writes
`%r11`, `%r12` and `%r13` but declares only `%r10` among the extended GPRs. `r12`/`r13` are
callee-saved in the SysV ABI, so a compiler may keep long-lived locals in them across an asm
statement. clang does; gcc 16.1.1 happens not to. **That is the entire compiler dependence — there is
nothing clang-specific about the defect.**

Two lines: add `"r11","r12","r13"` to that clobber list and to its IMCI512 twin. No instruction
changes.

**This is the root cause of the corruption contained by #162.** See "Relationship to #162" below —
that guard turns out to be both wider and narrower than it needs to be.

## Reproducer

```bash
git worktree add wt --detach upstream/main          # 418f365
cd wt && rm -rf obj_avx512
CC=clang CFLAGS="-Wall -g -O3 -std=gnu99" bash ./makemake.sh avx512
sde64 -skx -- ./obj_avx512/Mlucas -fftlen 176 -radset 0 -iters 100 -nthread 1
```

Exponent **p = 3571153** (Mlucas's own default self-test exponent for 176 Kdbl); radices 176/16/32,
so the trailing 32 selects `radix32_wrapper_square`. Reproduces on **clang 22.1.8 and clang 18.1.3**;
gcc 16.1.1 with identical flags is correct (`Res64: A016F25779902477`).

**The failure is ASLR-dependent** — the same binary alternates between

```
SDE ERROR: Could not read memory at location 0x7f34031af340 nbytes= 64
```
and
```
M3571153 Roundoff warning on iteration 1, maxerr = 0.498822212219
```

These are not two bugs and the roundoff form is not a milder outcome — it is the same corruption
landing on a mapped page. Note also that `sde64 -ptr-check` reliably converts the crash into the
roundoff form, because it perturbs the address space, so **`-ptr-check` is useless as a probe here**.
Use the plain run and treat ROE-at-iteration-1 as a positive.

## Why this is the cause, not a lucky reallocation

An instrumented build printing `j1, j2, j1pad, j2pad, n, i, m, blocklen` at the loop head:

```
DBG jump_in:  j1=1024      j2=1984  n=180224     i=4 m=0  blocklen=256
DBG jump_new: j1=1024      j2=1984  j1pad=1032 j2pad=1992  SIMD
DBG jump_in:  j1=319899968 j2=1728  n=319904320  i=4 m=64 blocklen=256   <-- corrupt
```

`n` is a plain `int` **parameter** that this function never writes, and it is corrupted too, while
`j2`, `i`, `m` and `blocklen` stay correct. That is a register kill, not a memory overwrite.

DWARF for the same TU says which registers:

```
DEBUG_VALUE: radix32_wrapper_square:j1 <- $r12d     (19 sites)
DEBUG_VALUE: radix32_wrapper_square:n  <- $r13d     ( 7 sites)
```

The two undeclared registers, and no others.

**The garbage values check out in closed form.** After the DIT macro, `r12 = add6 + 0x180` and
`r13 = add7 + 0x180` (three `addq $0x80` each); the loop tail then does `j1 += stride`
(`addl $256,%r12d`). So

```
printed n − printed j1 = (add7 − add6) − 256
add7 − add6 = 8 * ((j2pad−192) − (j1pad+192)) = 8 * (1992−192−1032−192) = 4608
expected difference     = 4608 − 256 = 4352
observed                = 0x13115a40 − 0x13114940 = 4352     exact
```

The corrupted values are the leftover pointers, to the byte.

This also resolves the question the earlier investigation of this corruption was stuck on — *"`j1`,
a plain stack int, goes wildly out of range partway through a call, with no assignment to it in the
intervening ~4000 lines of macro-expanded asm."* There is no corrupting write. `j1` was never in
memory.

## Scope

The IMCI512 variant of the same macro (`#define` 3811, clobber list 4586) has the identical
omission and is fixed too. The AVX-512 **DIF** macro (2408 / 2964) declares `r10`–`r13` correctly, so
this is DIT-only. A full-tree audit found no other 64-bit macro with an undeclared GPR.

## Relationship to #162

#162 contains this corruption by rejecting every radix set with trailing radix 32 under AVX-512. With
the actual cause fixed, that guard is unnecessary — and it also has a gap worth knowing about
independently:

**#162's guard is in `mers_mod_square`, but the same macro is reached from the Fermat-mod path** via
`radix32_dyadic_square.c:1231` ← `fermat_mod_square.c:1831`, which is unguarded. Measured with
clang 18 under SDE on unfixed `main`:

| case | unfixed | with this fix |
|---|---|---|
| F20 @ 64K radset 1 `{64,16,32}` | `ERROR ERROR...Halting test of F20` | `64629CED6E218018` |
| F20 @ 64K radset 2 `{32,32,32}` | `ERROR ERROR...Halting test of F20` | `64629CED6E218018` |

So #162 simultaneously over-restricts (disables a path that works once this lands) and under-protects
(misses Fermat entirely). I have not closed or modified #162 — that is the maintainers' call, but it
should probably be withdrawn in favour of this.

## Verification

Every trailing-radix-32 set that previously failed now passes and matches the gcc result: 16K
`{16,16,32}`, 18K `{36,8,32}`, 32K `{32,16,32}` and `{16,32,32}`, 144K `{144,16,32}`, 176K
`{176,16,32}`, plus 128/160/192/208/224/240K `{*,16,32}` in a full `-s tiny` sweep — which covers the
240K case #162 also lists.

ASan was deliberately not used as a probe: the clang AVX-512 + ASan build is numerically broken
independently of this defect (it fails at iteration 1 on radix960 and radix1024 too, while a plain
clang AVX-512 build of the same source is correct), so neither a clean nor a dirty ASan result would
mean anything here.

## Side observations, recorded but not addressed

* `radix_prim[-1]` is read at `radix32_wrapper_ini.c:103`, `radix16_wrapper_ini.c:102` and
  `radix16_pairFFT_mul.c:1652`; the two `_wrapper_square.c` siblings guard against it.
* An undeclared `%rdx` in the experimental asm at `util.c:3112`.
* Two gcc "Excessive roundoff" rejections during the sweep turned out benign — correct `Res64` with a
  single `maxerr = 0.4375` spike. Worth not collapsing ROE into one FAIL bucket in sweep scripts.
