### PR TITLE
radix32: declare cy_i and addi to match their unconditional use — build regression from 2bf9930

### DIFF
--- a/src/radix32_ditN_cy_dif1.c
+++ b/src/radix32_ditN_cy_dif1.c
@@ -198,8 +198,8 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	static double radix_inv, n2inv;
   #ifndef MULTITHREAD
 	double *addr;
-	double *addi;	// v21 build fix: must exist in SSE2 builds too - the MODULUS_TYPE_GENFFTMUL
-					// branch of radix32_main_carry_loop.h dereferences it unconditionally (regression from 2bf9930)
+	double *addi;	// Declared unconditionally: the MODULUS_TYPE_GENFFTMUL branch of
+					// radix32_main_carry_loop.h assigns and increments it in every build.
 	double temp,frac;
   #endif
 	double scale, dtmp, maxerr = 0.0;
@@ -255,8 +255,8 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 		,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 		,*cy_r	// Need RADIX slots for sse2 carries, RADIX/2 for avx
-		,*cy_i	// v21 build fix: must exist in SSE2/MULTITHREAD builds too - radix32_main_carry_loop.h's
-				// MODULUS_TYPE_GENFFTMUL branch dereferences it unconditionally (regression from 2bf9930)
+		,*cy_i	// Declared unconditionally: radix32_main_carry_loop.h's MODULUS_TYPE_GENFFTMUL
+				// branch reads it in every build.
 		;
   #ifdef USE_AVX
 	static vec_dbl *base_negacyclic_root;
@@ -1994,7 +1994,7 @@ void radix32_dit_pass1(double a[], int n)
 			,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 			,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 			,*cy_r
-			,*cy_i	// v21 build fix: see the same declaration in radix32_ditN_cy_dif1() above
+			,*cy_i	// Declared unconditionally - see the same declaration in radix32_ditN_cy_dif1() above
 			;
 	  #ifdef USE_AVX
 		vec_dbl *base_negacyclic_root;

--- a/src/radix32_ditN_cy_dif1.c
+++ b/src/radix32_ditN_cy_dif1.c
@@ -198,9 +198,8 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	static double radix_inv, n2inv;
   #ifndef MULTITHREAD
 	double *addr;
-   #ifndef USE_SSE2
-	double *addi;
-   #endif
+	double *addi;	// v21 build fix: must exist in SSE2 builds too - the MODULUS_TYPE_GENFFTMUL
+					// branch of radix32_main_carry_loop.h dereferences it unconditionally (regression from 2bf9930)
 	double temp,frac;
   #endif
 	double scale, dtmp, maxerr = 0.0;
@@ -256,9 +255,8 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 		,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 		,*cy_r	// Need RADIX slots for sse2 carries, RADIX/2 for avx
-	  #if !defined(MULTITHREAD) && defined(USE_AVX)
-		,*cy_i
-	  #endif
+		,*cy_i	// v21 build fix: must exist in SSE2/MULTITHREAD builds too - radix32_main_carry_loop.h's
+				// MODULUS_TYPE_GENFFTMUL branch dereferences it unconditionally (regression from 2bf9930)
 		;
   #ifdef USE_AVX
 	static vec_dbl *base_negacyclic_root;
@@ -551,7 +549,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 96 vec_dbl for Mersenne-mod, and 3.5*RADIX[avx] | RADIX[sse2] for Fermat-mod */
 	  #else
-		cy_r = tmp;	/* cy_i = tmp+0x10; */	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+		cy_r = tmp;	cy_i = tmp+0x10;	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
 		max_err = tmp + 0x00;
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 32 x 16 bytes for Mersenne-mod, 2 for Fermat-mod */
@@ -1996,9 +1994,7 @@ void radix32_dit_pass1(double a[], int n)
 			,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 			,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 			,*cy_r
-		#ifdef USE_AVX
-			,*cy_i
-		#endif
+			,*cy_i	// v21 build fix: see the same declaration in radix32_ditN_cy_dif1() above
 			;
 	  #ifdef USE_AVX
 		vec_dbl *base_negacyclic_root;
@@ -2143,7 +2139,7 @@ void radix32_dit_pass1(double a[], int n)
 		half_arr= tmp + 0x02;	/* This table needs 68 vec_dbl for Mersenne-mod, and 3.5*RADIX[avx] | RADIX[sse2] for Fermat-mod */
 		base_negacyclic_root = half_arr + RADIX;	// Only used for Fermat-mod
 	  #else
-		cy_r = tmp;	/* cy_i = tmp+0x10; */	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+		cy_r = tmp;	cy_i = tmp+0x10;	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
 		max_err = tmp + 0x00;
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 20 x 16 bytes for Mersenne-mod, 2 for Fermat-mod */


### PR DESCRIPTION
**This is a build regression in merged code**, from `2bf9930a` ("radix32: restore the addi carry pointer instead of leaving it dangling"), which arrived via #126. That commit restored the unconditional `addi = (double *)cy_i` and the four `++addi` increments in the `MODULUS_TYPE_GENFFTMUL` branch of `radix32_main_carry_loop.h`, but left the matching declarations in `radix32_ditN_cy_dif1()` behind guards that exclude those builds. Nothing about it is specific to v21.

**Nor is it specific to SSE2.** `cy_i` is declared under `#ifdef USE_AVX`, so every non-AVX SIMD build fails identically — ARM ASIMD included, which is why `main` does not currently compile on Apple Silicon. Reported independently on the forum against `418f365`.

**Verified on real ARM hardware** (Raspberry Pi 4, aarch64, gcc 12.2.0):

| tree | `makemake.sh asimd` |
|---|---|
| `main` @ `418f365` | rc=1 — `radix32_main_carry_loop.h:62: 'cy_i' undeclared` |
| `main` + this PR | **rc=0**, binary builds, `-s tt` self-test runs |

Identical error and identical fix at `makemake.sh sse2` on x86, which is the cheap way to reproduce without ARM hardware.

CI caught the regression at the time — all five macOS jobs went from green on the preceding run to red on #126 — so re-running those legs here is the definitive check for anything macOS-specific behind it.

---

## The break

Mlucas does not compile at `sse2` on **either gcc or clang** — the main binary, not Mfactor:

```
$ gcc -Wall -g -O3 -std=gnu99 -D_GNU_SOURCE -c -DUSE_SSE2 -msse2 src/radix32_ditN_cy_dif1.c
src/radix32_main_carry_loop.h:62:47: error: 'addi' undeclared (first use in this function)
src/radix32_main_carry_loop.h:62:64: error: 'cy_i' undeclared (first use in this function)
```

clang 22.1.8 gives the same at `:62:50`. Without `-DUSE_SSE2` the file compiles clean.

## Cause

Both names are the same regression, from `2bf9930`. That commit restored an unconditional

```c
addi = (double *)cy_i;
```

in the `MODULUS_TYPE_GENFFTMUL` branch of `radix32_main_carry_loop.h`, but left the two declarations in `radix32_ditN_cy_dif1()` behind guards that exclude non-AVX SIMD builds — `cy_i` declared only under `USE_AVX`, and `addi` under `#ifndef USE_SSE2`. The multithreaded sibling `cy32_process_chunk()` already declares both unconditionally, which is why only the single-threaded entry point broke.

## Fix

Declare both unconditionally in `radix32_ditN_cy_dif1()`, matching `cy32_process_chunk()`. One file, +7/−11. No functional change to any build that already compiled.

**Deliberately not touched:** `carry.h`'s V1/V2 GENFFTMUL macro split. It carries a comment warning that "fixing" the unused-`cy` warning by dropping the caller's `cy_i` setup *silently breaks the V1 variant*. This change restores the caller-side declarations only.

## Verification

| | gcc 16.1.1 | clang 22.1.8 |
|---|---|---|
| `radix32_ditN_cy_dif1.c` at `-DUSE_SSE2`, before | 1 error | 1 error |
| same, after | **0** | **0** |
| full `rm -rf obj_sse2 && bash ./makemake.sh sse2` | **clean** | **clean** |

No further rotted files turned up behind this one. `./obj_sse2/Mlucas -s tt` runs to completion, with `Res64` matching an `obj_nosimd` build of the same tree at every FFT length both reach.

(Unrelated, noted so it isn't mistaken for fallout: the nosimd log reports some "N of M radix-sets passed — skipping it" warnings at 14K/15K. That is the separately-tracked nosimd scalar-radix issue, which #152 addresses.)

## Why this went unnoticed

There is no gcc/clang `sse2` job for the **Mlucas** target in CI — the sse2 coverage that exists is for other targets. This is the seventh build configuration found rotted in this campaign.


