### PR TITLE
radix63: carry loop must visit every SIMD lane, and size the wraparound pass by RE_IM_STRIDE

### DIFF
--- a/src/radix63_ditN_cy_dif1.c
+++ b/src/radix63_ditN_cy_dif1.c
@@ -47,6 +47,18 @@ int radix63_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 !   storage scheme, and radix8_ditN_cy_dif1 for details on the reduced-length weights array scheme.
 */
 	const char func[] = "radix63_ditN_cy_dif1";
+	// v21 bugfix: the wraparound-carry mini-pass and the radix_inv rescale that follows it walk *physical*
+	// array indices, so the number of them that spans the first 4 complex data of a block is 2*RE_IM_STRIDE-1,
+	// not a constant 7. Under AVX-512 (RE_IM_STRIDE == 8) the old hardcoded 7 covered only the 8 real parts
+	// re0..re7 and none of the imaginary parts, so the mini-pass and the rescale disagreed about which data
+	// they had touched. Same constants as every SIMD-aware sibling, cf. radix64_ditN_cy_dif1.c:185-191.
+  #ifdef USE_AVX512
+	const int jhi_wrap_mers = 15;
+	const int jhi_wrap_ferm = 15;
+  #else
+	const int jhi_wrap_mers =  7;
+	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
+  #endif
 	int NDIVR,i,j,j1,j2,jt,jp,jstart,jhi,full_pass,k,khi,l,ntmp,outer;
 
 	// Need these both in scalar mode and to ease the SSE2-array init...dimension = ODD_RADIX;
@@ -551,7 +563,7 @@ for(outer=0; outer <= 1; outer++)
 		{
 			_jstart[ithread] = ithread*NDIVR/CY_THREADS;
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 7;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
@@ -571,7 +583,7 @@ for(outer=0; outer <= 1; outer++)
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 15;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_ferm;	/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + n_div_nwt/CY_THREADS;
 		}
@@ -823,11 +835,11 @@ for(outer=0; outer <= 1; outer++)
 	*/
 	if(TRANSFORM_TYPE == RIGHT_ANGLE)
 	{
-		j_jhi =15;
+		j_jhi = jhi_wrap_ferm;
 	}
 	else
 	{
-		j_jhi = 7;
+		j_jhi = jhi_wrap_mers;
 	}
 
 	for(ithread = 0; ithread < CY_THREADS; ithread++)

--- a/src/radix63_ditN_cy_dif1.c
+++ b/src/radix63_ditN_cy_dif1.c
@@ -47,7 +47,6 @@ int radix63_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 !   storage scheme, and radix8_ditN_cy_dif1 for details on the reduced-length weights array scheme.
 */
 	const char func[] = "radix63_ditN_cy_dif1";
-	const int stride = (int)RE_IM_STRIDE << 1;	// main-array loop stride = 2*RE_IM_STRIDE
 	int NDIVR,i,j,j1,j2,jt,jp,jstart,jhi,full_pass,k,khi,l,ntmp,outer;
 
 	// Need these both in scalar mode and to ease the SSE2-array init...dimension = ODD_RADIX;
@@ -495,7 +494,7 @@ int radix63_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 				jstart = 0;
 				jhi = NDIVR/CY_THREADS;	// The earlier setting = NDIVR/CY_THREADS/2 was for simulating bjmodn evolution, must double that here
 				// khi = 1 for Fermat-mod, thus no outer loop needed here
-				for(j = jstart; j < jhi; j += stride)
+				for(j = jstart; j < jhi; j += 2)	// v21: logical stride 2, matching the main carry loop
 				{
 					for(i = 0; i < ODD_RADIX; i++) {
 						icycle[i] += wts_idx_incr;		icycle[i] += ( (-(int)((uint32)icycle[i] >> 31)) & nwt);
@@ -942,8 +941,10 @@ void radix63_dif_pass1(double a[], int n)
 
 	for(j = 0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
-		j1 = (j & mask02) + br8[j&7];
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];	// v21: this arm was missing - USE_AVX512 implies USE_AVX
+	#elif defined(USE_AVX)					// (platform.h), so AVX-512 builds silently took the 4-complex
+		j1 = (j & mask02) + br8[j&7];		// br8 arm while RE_IM_STRIDE == 8.
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
 	#else
@@ -1093,8 +1094,10 @@ void radix63_dit_pass1(double a[], int n)
 
 	for(j = 0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
-		j1 = (j & mask02) + br8[j&7];
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];	// v21: this arm was missing - USE_AVX512 implies USE_AVX
+	#elif defined(USE_AVX)					// (platform.h), so AVX-512 builds silently took the 4-complex
+		j1 = (j & mask02) + br8[j&7];		// br8 arm while RE_IM_STRIDE == 8.
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
 	#else

--- a/src/radix63_main_carry_loop.h
+++ b/src/radix63_main_carry_loop.h
@@ -25,9 +25,29 @@
 
 for(k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 {
-	for(j = jstart; j < jhi; j += stride)
+	// v21 bugfix: radix-63 has no SIMD code path - the DIT, the carry step and the DIF below are all
+	// scalar, one complex datum per loop pass. The loop must therefore advance one *complex datum* at a
+	// time (logical stride 2) and map the logical index into the SIMD-interleaved physical layout
+	// [RE_IM_STRIDE reals | RE_IM_STRIDE imags] with the same br4/br8/br16 scramble radix63_dif_pass1 /
+	// radix63_dit_pass1 use. The former 'j += stride' (= 2*RE_IM_STRIDE) with j1 = j advanced by a whole
+	// SIMD block per pass but only ever touched a[j1] and a[j1+RE_IM_STRIDE] - i.e. lane 0 - so in any
+	// SIMD build all but 1 of every RE_IM_STRIDE complex data were never transformed, never squared-back
+	// [the wrapper/square step does see them] and never carry-normalized. Those words then simply kept
+	// getting re-squared every iteration, doubling in size until they tripped a roundoff/carry error.
+	// It also mis-stepped the per-datum weight indices: the Mersenne branch's l = j & (nwt-1) and the
+	// Fermat branch's root index l = (j + idx_offset)>>1 (cf. fermat_carry_norm_errcheckB, carry.h) both
+	// key off the *logical* j, so they must see every value of j, not every RE_IM_STRIDE'th.
+	for(j = jstart; j < jhi; j += 2)
 	{
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
+		j1 = (j & mask02) + br8[j&7];
+	#elif defined(USE_SSE2)
+		j1 = (j & mask01) + br4[j&3];
+	#else
 		j1 =  j;
+	#endif
 		j1 = j1 + ( (j1 >> DAT_BITS) << PAD_BITS );	/* padded-array fetch index is here */
 		j2 = j1 + RE_IM_STRIDE;
 


### PR DESCRIPTION
## Summary

Two defects in radix63's carry step, both SIMD-specific. Together with **#152** (see dependencies)
they make radix63 correct at every SIMD level for both moduli.

Worth stating up front what radix63 is *not*: despite sharing `ODD_RADIX == 63` with radix1008 and
radix4032, **its carry step is entirely scalar** — `radix63_main_carry_loop.h` contains no SIMD carry
macro, only `cmplx_carry_norm_errcheck*` and `fermat_carry_norm_errcheckB`. It shares none of the
machinery repaired in #204, and these are not those bugs.

## Defect 1 — the carry loop visited only lane 0

`radix63_main_carry_loop.h` stepped `j += stride` (`2*RE_IM_STRIDE`) while touching only `a[j1]` and
`a[j1+RE_IM_STRIDE]`. In a SIMD build that is lane 0 alone: **all but one of every `RE_IM_STRIDE`
complex data were never DIT'd, carried or DIF'd**, while the SIMD wrapper kept squaring them, so they
doubled in magnitude every iteration until the roundoff check fired.

Fixed by walking logical data (`j += 2`) with the `br4`/`br8`/`br16` scramble that
`radix63_dif_pass1`/`dit_pass1` already use. This also adds the missing `#ifdef USE_AVX512` /
`br16[j&15]` arm to those two routines, which otherwise fall through to the `br8` arm — and that arm
is not a bijection on a 16-real block: it re-reads slots 8-11, writes into 16-19 of the next block,
and never touches 4-7 or 12-15.

## Defect 2 — wraparound mini-pass length hardcoded

The Mersenne wraparound-carry cleanup pass used a literal `7` where it needs `2*RE_IM_STRIDE-1`. The
Fermat arm already used `15`, which is precisely why AVX-512 Fermat came good with defect 1 fixed and
AVX-512 Mersenne did not. Replaced with the `jhi_wrap_mers`/`jhi_wrap_ferm` constants that every
SIMD-aware sibling radix uses.

## Dependencies

**This PR needs #152 to make radix63 Mersenne correct.** Investigating defect 1 turned up a third,
larger problem that is *not* radix63's and is already fixed there:

`mers_mod_square.c:244` computes `nchunks = radix0>>1`, but the work-unit loop at `:1272` is
`for(ii = 0; ii < radix0; ii += 2)`. For **even** `radix0` those agree. For **odd** `radix0` the loop
runs `(radix0+1)/2` times while only `(radix0-1)/2` tasks are dispatched (`pool_work_units = nchunks`
at `:1365`, dispatch at `:1799`), so **the last work chunk never runs** — its data blocks skip the
forward-FFT, the wrapper/square and the DIT on every iteration. That affects every odd leading radix
(5, 7, 9, 11, 13, 15, 63), in any build with `MULTITHREAD` compiled in, *including* at `-cpu 0`.
The warning text at `:1363` calls `nchunks` "radix0/2", which is only true for even radices.

#152 fixes it with `nchunks = (radix0+1)>>1`. Nothing of that fix is duplicated here.

This defect also **masked** defect 1 for Mersenne, which is why radix63's Mersenne `maxerr` looked
bit-identical across ISAs and appeared architecture-independent — it was, but for that reason, not
because defect 1 was absent.

Merge order: **#152 first, then this.** On SSE2 you will also want **#209**, without which
`makemake.sh sse2` does not compile at all on `main`.

## Verification

Residues only — `AvgMaxErr` is not used as a health signal, since a zeroed or doubled residue can
report a perfect roundoff. References are `nosimd` values cross-checked by agreement across radix
sets at the same FFT length. Negative controls were run before each stage.

| cell | nosimd | SSE2 | AVX | AVX2 | AVX-512 (SDE) |
|---|---|---|---|---|---|
| M60000011 @ 4032K rs3 `{63,32,32,32}` | pass | pass | pass | pass | not run |
| F26 @ 4032K rs3 | pass | pass | pass | pass | not run |
| M18776473 @ 1008K rs2 `{63,16,16,32}` | pass | pass | pass | pass | pass |
| F24 @ 1008K rs2 | pass | pass | pass | pass | pass |

Controls on unfixed code: AVX2 Mersenne exit-carry at iteration 6, Fermat ROE at 17; AVX-512
exit-carry at 4 and 14. With defect 1 fixed but not defect 2, AVX-512 Mersenne still fails at
iteration 6 — which is how defect 2 was isolated. Non-radix63 regression cells are unchanged.

## Consequence for #175

#175's guard rejects `radix0 == 63` at every SIMD level for both moduli. With this PR and #152
merged, that can be narrowed substantially — see the note added to #175's description.


## Verification of the pass-1 `br16` arms

The carry-loop change is measured above. The two pass-1 arms can be isolated too, once radix63 runs to
completion at all — which needs the odd-`radix0` work-chunk fix from #152 (63 is odd) on top of this PR.

Tree: `upstream/main` @ `418f365` + #152's `mers_mod_square: dispatch the final work chunk for odd leading
radices` + this PR's two commits. gcc 16.1.1, `makemake.sh avx512`, run under `sde64 -skx --`.

```
./obj_{nosimd,avx512}/Mlucas -m 18776473 -fftlen 1008 -radset 2 -iters 100 -shift 0 -cpu 0
```

radset 2 at 1008K is `63 16 16 32`, i.e. leading radix 63.

| build | result |
|---|---|
| nosimd (reference) | `Res64: CA7D81B22AE24935`, AvgMaxErr `0.066828265` |
| AVX-512, this PR + #152 | `Res64: CA7D81B22AE24935`, AvgMaxErr `0.070251465` |
| AVX-512, **only the two pass-1 `br16` arms reverted** | `510056 of 1032192 out-of-range output digits`, `max_fp = 3.66e+110`, `ERR_ASSERT` |

The third row is the same tree as the second with nothing changed but those four lines — the carry-loop
`br16` arm and the `jhi_wrap_*` commit both stay in place. Roughly half the output digits are destroyed,
which is what the non-bijective `br8` map predicts: it re-reads block slots 8-11 as real parts, reaches
into slots 16-19 of the next block, and never touches slots 4-7 or 12-15 of the current one.

Without #152 this cannot be shown: radix63 aborts at iteration 1 in *every* build (nosimd, AVX2, and
AVX-512 both with and without this fix all give maxerr `0.492078993056`, identical to 12 digits), and an
index permutation of the near-uniform iteration-1 DFT output is invisible.

#211 fixes the identical gap in `radix8`, the only other file whose affected routines an AVX-512 build can
reach.
