### PR TITLE
Close the br8/br16 AVX-512 gap tree-wide: fix radix8's wrong residue, and add the missing arm at every remaining site

### DIFF
--- a/src/pairFFT_mul.c
+++ b/src/pairFFT_mul.c
@@ -679,7 +679,9 @@ void pairFFT_mul(double x[], double y[], double z[], int n, int INIT_ARRAYS, int
 	double atmp, frac_fp, max_fp = 0.0;
 	for(i=0; i < n; i++)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j = (i & mask03) + br16[i&15];
+	#elif defined(USE_AVX)
 		j = (i & mask02) + br8[i&7];
 	#elif defined(USE_SSE2)
 		j = (i & mask01) + br4[i&3];

--- a/src/radix104_ditN_cy_dif1.c
+++ b/src/radix104_ditN_cy_dif1.c
@@ -118,7 +118,9 @@ void radix104_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -273,7 +275,9 @@ void radix104_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix112_ditN_cy_dif1.c
+++ b/src/radix112_ditN_cy_dif1.c
@@ -129,7 +129,9 @@ void radix112_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -301,7 +303,9 @@ void radix112_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix120_ditN_cy_dif1.c
+++ b/src/radix120_ditN_cy_dif1.c
@@ -130,7 +130,9 @@ void radix120_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -303,7 +305,9 @@ void radix120_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix12_ditN_cy_dif1.c
+++ b/src/radix12_ditN_cy_dif1.c
@@ -1500,7 +1500,9 @@ void radix12_dif_pass1(double a[], int n)
 
       for(j=0; j < n12; j += 2)
       {
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -1765,7 +1767,9 @@ void radix12_dit_pass1(double a[], int n)
 
       for(j=0; j < n12; j += 2)
       {
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix20_ditN_cy_dif1.c
+++ b/src/radix20_ditN_cy_dif1.c
@@ -1700,7 +1700,9 @@ void radix20_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -1823,7 +1825,9 @@ void radix20_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix28_ditN_cy_dif1.c
+++ b/src/radix28_ditN_cy_dif1.c
@@ -2185,7 +2185,9 @@ void radix28_dif_pass1(double a[], int n)
 
 	for(j = 0; j < n28; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -2321,7 +2323,9 @@ void radix28_dit_pass1(double a[], int n)
 
 	for(j=0; j < n28; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix512_ditN_cy_dif1.c
+++ b/src/radix512_ditN_cy_dif1.c
@@ -149,7 +149,9 @@ void radix512_dif_pass1(double a[], int n)
 
 	for(j = 0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -451,7 +453,9 @@ void radix512_dit_pass1(double a[], int n)
 
 	for(j = 0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix72_ditN_cy_dif1.c
+++ b/src/radix72_ditN_cy_dif1.c
@@ -113,7 +113,9 @@ void radix72_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -255,7 +257,9 @@ void radix72_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix80_ditN_cy_dif1.c
+++ b/src/radix80_ditN_cy_dif1.c
@@ -127,7 +127,9 @@ void radix80_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -293,7 +295,9 @@ void radix80_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix88_ditN_cy_dif1.c
+++ b/src/radix88_ditN_cy_dif1.c
@@ -121,7 +121,9 @@ void radix88_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -275,7 +277,9 @@ void radix88_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix8_ditN_cy_dif1.c
+++ b/src/radix8_ditN_cy_dif1.c
@@ -38,6 +38,13 @@ int radix8_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[], 
 !   storage scheme, and radix8_ditN_cy_dif1 for details on the reduced-length weights array scheme.
 */
 	static int n8;
+  #ifdef USE_AVX512
+	const int jhi_wrap_mers = 15;
+	const int jhi_wrap_ferm = 15;
+  #else
+	const int jhi_wrap_mers =  7;
+	const int jhi_wrap_ferm = 15;	// For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
+  #endif
 	int i,j,j1,j2,jstart,jhi,full_pass,k1,k2,k,khi,l,outer;
 	// For some reason GCC treats these as possibly-uninited in cmplx_carry_norm_pow2_errcheck(), so init = 0;
 	int bjmodn0 = 0,bjmodn1 = 0,bjmodn2 = 0,bjmodn3 = 0,bjmodn4 = 0,bjmodn5 = 0,bjmodn6 = 0,bjmodn7 = 0;
@@ -319,7 +326,7 @@ for(outer=0; outer <= 1; outer++)
 
 			_jstart[ithread] = ithread*n8/CY_THREADS;
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 7;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_mers;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + nwt-1;
 
@@ -339,7 +346,7 @@ for(outer=0; outer <= 1; outer++)
 			For right-angle transform need *complex* elements for wraparound, so jhi needs to be twice as large
 			*/
 			if(!full_pass)
-				_jhi[ithread] = _jstart[ithread] + 15;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
+				_jhi[ithread] = _jstart[ithread] + jhi_wrap_ferm;		/* Cleanup loop assumes carryins propagate at most 4 words up. */
 			else
 				_jhi[ithread] = _jstart[ithread] + n_div_nwt/CY_THREADS;
 		}
@@ -738,11 +745,11 @@ for(outer=0; outer <= 1; outer++)
 	*/
 	if((MODULUS_TYPE == MODULUS_TYPE_GENFFTMUL) || (TRANSFORM_TYPE == RIGHT_ANGLE))
 	{
-		j_jhi =15;
+		j_jhi = jhi_wrap_ferm;
 	}
 	else
 	{
-		j_jhi = 7;
+		j_jhi = jhi_wrap_mers;
 	}
 
     for(ithread = 0; ithread < CY_THREADS; ithread++)

--- a/src/radix8_ditN_cy_dif1.c
+++ b/src/radix8_ditN_cy_dif1.c
@@ -391,7 +391,9 @@ for(outer=0; outer <= 1; outer++)
 		{
 			for(j = jstart; j < jhi; j += 2)	/* Each inner loop execution processes (radix(1)*nwt) array data.	*/
 			{
-			#ifdef USE_AVX
+			#ifdef USE_AVX512
+				j1 = (j & mask03) + br16[j&15];
+			#elif defined(USE_AVX)
 				j1 = (j & mask02) + br8[j&7];
 			#elif defined(USE_SSE2)
 				j1 = (j & mask01) + br4[j&3];
@@ -830,7 +832,9 @@ void radix8_dif_pass1(double a[], int n)
 
     for(j = 0; j < n8; j += 2)
     {
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -948,7 +952,9 @@ void radix8_dit_pass1(double a[], int n)
 
     for(j=0; j < n8; j += 2)
     {
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix96_ditN_cy_dif1.c
+++ b/src/radix96_ditN_cy_dif1.c
@@ -114,7 +114,9 @@ void radix96_dif_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -333,7 +335,9 @@ void radix96_dit_pass1(double a[], int n)
 
 	for(j=0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/radix992_ditN_cy_dif1.c
+++ b/src/radix992_ditN_cy_dif1.c
@@ -2077,7 +2077,9 @@ void radix992_dif_pass1(double a[], int n)
 
 	for(j = 0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];
@@ -2521,7 +2523,9 @@ void radix992_dit_pass1(double a[], int n)
 
 	for(j = 0; j < NDIVR; j += 2)
 	{
-	#ifdef USE_AVX
+	#ifdef USE_AVX512
+		j1 = (j & mask03) + br16[j&15];
+	#elif defined(USE_AVX)
 		j1 = (j & mask02) + br8[j&7];
 	#elif defined(USE_SSE2)
 		j1 = (j & mask01) + br4[j&3];

--- a/src/util.c
+++ b/src/util.c
@@ -7873,7 +7873,9 @@ ftmp0 = ftmp;
 			for(j1 = 0, j2 = 0; j1 < dim; j1 += stride, j2 += 8)	// j2 is base-index into ran[] input array
 			{
 		/* The normal index-munging takes way too many cycles in this context, so inline it via 8-way loop unroll:
-			#ifdef USE_AVX
+			#ifdef USE_AVX512
+				j1 = (j & mask03) + br16[j&15];
+			#elif defined(USE_AVX)
 				j1 = (j & mask02) + br8[j&7];
 			#elif defined(USE_SSE2)
 				j1 = (j & mask01) + br4[j&3];
@@ -8172,7 +8174,9 @@ printf("DIF: nerr = %u, ",nerr);
 			for(j1 = 0, j2 = 0; j1 < dim; j1 += stride, j2 += 8)	// j2 is base-index into ran[] input array
 			{
 		/* The normal index-munging takes way too many cycles in this context, so inline it via 8-way loop unroll:
-			#ifdef USE_AVX
+			#ifdef USE_AVX512
+				j1 = (j & mask03) + br16[j&15];
+			#elif defined(USE_AVX)
 				j1 = (j & mask02) + br8[j&7];
 			#elif defined(USE_SSE2)
 				j1 = (j & mask01) + br4[j&3];


### PR DESCRIPTION
Closes the `br8`/`br16` AVX-512 gap across the whole tree: one measured wrong-answer fix, plus the mechanical work that stops the same defect coming back.

## The defect

`platform.h:239-246` makes `USE_AVX512` imply `USE_AVX`. So a pass-1 index scramble written as

```c
#ifdef USE_AVX
	j1 = (j & mask02) + br8[j&7];
#elif defined(USE_SSE2)
	...
```

silently takes the **`br8`** arm in an AVX-512 build, while `RE_IM_STRIDE` is already 8.

That is not a different-but-consistent permutation. With `br8 = {0,4,1,5,2,6,3,7}`, `mask02 = ~7` and `j` stepping by 2 across one 16-real block:

| `j` | 0 | 2 | 4 | 6 | 8 | 10 | 12 | 14 |
|---|---|---|---|---|---|---|---|---|
| wrong `j1` (`br8`) | 0 | 1 | 2 | 3 | **8** | **9** | **10** | **11** |
| wrong `j2 = j1+8` | 8 | 9 | 10 | 11 | **16** | **17** | **18** | **19** |
| correct `j1` (`br16`) | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
| correct `j2 = j1+8` | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 |

The `br8` arm **is not a bijection on the block**: it re-reads slots 8-11 as real parts, reaches into slots 16-19 of the *next* block, and never touches slots 4-7 or 12-15 of the current one. It does not cancel between `dif_pass1` and `dit_pass1` — the forward-weight loop (`mers_mod_square.c:1730ff`) and the unweight loop (`:2085ff`) both already use the correct arm.

## Commits 1-2 — radix8, the one live wrong-answer case

`radix0 = 8` is reachable at **2K, 4K and 8K**. (An earlier revision of this description said 2K and 4K were soft-skipped by the `n/radix0 >= 2^DAT_BITS` gate in `mers_mod_square.c:325`. That was wrong: the whole gate sits inside `if(DAT_BITS < 31)` and `Mlucas.c:1380` sets `DAT_BITS = 31` for every length ≤ 32K, so it cannot fire there.) `radix8_ditN_cy_dif1.c` has no SIMD carry code, so its *scalar* carry loop needs the arm just as `dif_pass1`/`dit_pass1` do — three sites.

Commit 1 alone was necessary but not sufficient: 8K/rs2 merely moved from "ROE at iteration 1" to "nonzero exit carry at iteration 7", because radix8 also hardcodes the cleanup-pass wraparound extents as `7`/`15` instead of parameterising them. Commit 2 adds the `jhi_wrap_mers`/`jhi_wrap_ferm` block, byte-identical to the one already in radix16/32/56/60/64/128/224/240/256/960/1024.

Runs are `-iters 100 -nthread 1 -shift 0` (radix < 16 rejects shifted residues), AVX-512 under `sde64 -skx`, gcc 16.1.1:

| build | 8K rs0 (`32 8 16`, control) | 8K rs2 (`8 32 16`) |
|---|---|---|
| nosimd / AVX2 reference | `85301536E4CA9B11` | `85301536E4CA9B11`, AvgMaxErr `0.244768415` |
| **AVX-512, unfixed** | `85301536E4CA9B11` | **ROE iteration 1, maxerr 0.5 → radix set rejected** |
| AVX-512, commit 1 only | `85301536E4CA9B11` | **`ERR_CARRY`, iteration 7** |
| **AVX-512, both** | `85301536E4CA9B11` | **`85301536E4CA9B11`**, AvgMaxErr `0.244768415` |

The AvgMaxErr matching AVX2 bit-for-bit is a stronger statement than the residue alone: the two builds are walking the same data.

Regression check: 8K rs0, 16K rs0/rs1 and 32K rs0 all match their nosimd references before and after.

## Commit 3 — pairFFT_mul

Same gap at `pairFFT_mul.c:683`. Real, but **not reachable**: `pairFFT_mul()` has no caller in anything the build compiles. Its only caller anywhere is `src/gcd_lehmer.c.txt`, whose `.txt` extension keeps it out of `makemake.sh`'s glob and out of `OBJS`. (`pairFFT_mul.o` *is* compiled and linked; nothing invokes it.) Internally its radix-32 branches are commented out and `radix32_pairFFT_mul` does not exist. Fixed anyway, so the file is not a trap for whoever revives it.

## Commit 4 — the remaining 26 sites, so this cannot recur

A tree-wide scan finds **108** `mask02 + br8` scramble sites. Before this PR, 32 lacked the AVX-512 arm. Commit 4 adds it at the 26 not covered above, in 13 files, leaving the invariant *"every such site has a matching `USE_AVX512`/`mask03`+`br16` arm"* true tree-wide and checkable with one grep. After this PR the scan reports 106 of 108; the two exceptions are radix63's, which **#210** owns.

None of the 26 can change behaviour in any build that exists today — which is exactly why they are a separate commit from the measured fix:

* **radix12 / 20 / 28** — carry routines return `ERR_RADIX0_UNAVAILABLE` behind a hard `"No AVX-512 support; Skipping this leading radix"` guard, so pass-1 is never reached under AVX-512. **These are the ones that matter:** lifting such a guard would otherwise silently reintroduce a wrong-residue bug in the same motion.
* **radix72 / 80 / 88 / 96 / 104 / 112 / 120 / 512** — never a leading radix at any FFT length in any SIMD mode, so `dif1_dit1_func_name()` never installs their pass-1 routines. They serve as *intermediate* radices, through the separate `radixN_dif_dit_pass.c` machinery.
* **radix992** — `#undef`s `USE_SSE2/AVX/AVX2/AVX512` at `:26-31`, so the new arm is preprocessed away.
* **util.c** — inside `test_radix16_dft()`, whose sole call site is both gated behind an undefined `TEST_SIMD` and commented out.

Commit 4 is purely additive: no existing arm is altered, so every currently-reachable configuration preprocesses to exactly what it did before.

## Method note

Liveness was established from **preprocessed output**, not by reading `#ifdef`s — `gcc -E -DUSE_AVX512 -mavx512…` and counting surviving `br8[`/`br16[` sites — cross-checked against a histogram of surviving `rvec[0] = N` assignments in a preprocessed `get_fft_radices.c`, which is the complete leading-radix set since `-radset` is validated against that same table (`Mlucas.c:4193`). The naive `grep -l 'br8\[' | xargs grep -L 'br16\['` is both too wide (8 of its 10 hits are unreachable) and too narrow (it misses radix12/20/28/992, which contain `br16[tidx_mod_stride]` elsewhere).

## Verification

All 15 touched files compile clean at `nosimd`, `sse2`, `avx`, `avx2` and `avx512` — 75 compiles, 0 failures. Merges clean with #210.

## Unrelated pre-existing failures seen while testing

Neither is touched by this PR; both fail identically on the unfixed binary.

* **8K rs3 (`8 16 32`)** and **4K rs1 (`8 16 16`)** — wrong residue after these commits. Note 4K rs1 contains no radix 32 at all, so this is *not* the trailing-radix-32 path. Both are an **exactly-zero twiddle cosine** fed to the AVX-512 tangent-DFT inversion in `radix16_dif_dit_pass.c`: `VRCP14PD(0) = Inf`, then `2 - 0*Inf = NaN`, and the whole 512-double block is NaN. Fixed by the companion PR for that defect, not here — with both applied, 2K rs0, 4K rs1, 8K rs1, 8K rs2 and 8K rs3 all match their nosimd references.
* **16K rs2 (`16 16 32`)** — roundoff warning at iteration 21, still failing with these commits and the cosine fix applied. This one *is* consistent with the `radix32_wrapper_square` AVX-512 defect that #68 fixes, which lists 16K `{16,16,32}` among the sets it repairs. Not re-measured here.

