### PR TITLE
radix16 AVX-512: an exactly-zero twiddle cosine NaNs a whole data block via the tangent-DFT inversion

### DIFF
--- a/src/radix16_dif_dit_pass.c
+++ b/src/radix16_dif_dit_pass.c
@@ -37,6 +37,30 @@
 #define HIACC 1
 #define EPS	1e-10
 
+/* The AVX2/AVX-512 tangent-based radix-16 DFT (the RADIX16_COMPUTE_FMA_SINCOS_DI[FT] macros) needs the
+multiplicative inverse of each of the 16 twiddle cosines c0-15, which it computes via a SIMD Newton-iterative
+inversion. For those (FFT length, radix set) combos in which one of the block twiddles is an exact odd multiple
+of pi/2 - e.g. leading radix 16 at FFT length 8K, where the index[]-value-8 data block has iroot = (n/2)/32 and
+thus twiddle #8 = exp(I*pi/2) - the roots tables return a cosine of exactly +-0. The AVX-512 flavor of the
+inversion then does VRCP14PD(0) = Inf followed by the Newton update (2 - d*ainv) = (2 - 0*Inf) = NaN, and every
+datum in the affected block comes out NaN. [The AVX2 flavor's VCVTPD2PS/VRCPPS/VCVTPS2PD sequence is likewise
+Inf-then-NaN, but AVX2 builds default to the non-tangent REFACTOR_4DFT_3TWIDDLE DFT and so never hit this.]
+
+The tangent scheme computes each twiddle-multiply as c*(x + (s/c)*y), so perturbing an exactly-0 cosine to a
+tiny nonzero value of the same sign leaves the result unchanged except for an added c*x term, i.e. a relative
+perturbation of order the substituted value - 14 orders of magnitude below double-precision roundoff for the
+1e-30 used here - while keeping 1/c and (s/c) comfortably in-range. Note the singularity is strictly an
+exact-zero one: e.g. FFT length 16K/radix set 0 hits the same pi/2 twiddle but with a roots-table cosine of
+2.4e-35 rather than 0, and computes the correct residue.
+*/
+#define AVOID_EXACT_ZERO_TWIDDLE_COSINES(Xcc0)\
+{\
+	double *_cptr = (double *)(Xcc0);	int _i;\
+	for(_i = 0; _i < 16; _i++) {\
+		if(_cptr[_i] == 0.0) _cptr[_i] = copysign(1e-30, _cptr[_i]);\
+	}\
+}
+
 #ifdef USE_AVX512
 	#define DFT_V1
 #elif defined(USE_AVX2) && !defined(REFACTOR_4DFT_3TWIDDLE)
@@ -1031,6 +1055,7 @@ notation below is low-to-high-[byte|word] within xmm-regs; '|' denotes dword bou
 
 		// This places us at add0 == c8 and add1 = c12.
 		ASSERT(add0 == (double *)cc0+16 && add1 == (double *)cc0+32 && add2 == (double *)cc0+44, "add0,1,2 checksum failed in AVX2 sincos inits!");
+		AVOID_EXACT_ZERO_TWIDDLE_COSINES(cc0);
 		/*
 		At this point, the 11 ymm-sized [32-byte] chunks starting at &cc0 contain the following scalar-double data:
 
@@ -2463,6 +2488,7 @@ void radix16_dit_pass	(double a[],             int n, struct complex rt0[], stru
 
 		// This places us at add0 == c8 and add1 = c12.
 		ASSERT(add0 == (double *)cc0+16 && add1 == (double *)cc0+32, "add0,1 checksum failed in AVX2 DIT sincos inits!");
+		AVOID_EXACT_ZERO_TWIDDLE_COSINES(cc0);
 		/*
 		At this point, the 8 ymm-sized [32-byte] chunks starting at &cc0 contain the following scalar-double data:
 


### PR DESCRIPTION
An exactly-zero twiddle cosine turns an entire 512-double data block into NaN in AVX-512 builds, silently producing a wrong residue at several small FFT lengths.

## The defect

AVX-512 is the only build that uses the **tangent-based** radix-16 DFT: the auto-define at the top of `radix16_dif_dit_pass.c` — `#if defined(USE_SSE2) && (defined(USE_IMCI512) || !defined(USE_AVX512))` → `#define REFACTOR_4DFT_3TWIDDLE` — gives sse2/avx/avx2/ASIMD the non-tangent variant instead. The tangent scheme inverts all 16 twiddle cosines with a SIMD Newton iteration.

At 8K/radset 1, the `index[]`-value-8 data block has `iroot = (n/2)/32`, so twiddle #8 is `exp(I·pi/2)` **exactly** and the roots tables return a cosine of exactly `-0.0`. The AVX-512 inversion in `RADIX16_COMPUTE_FMA_SINCOS_DIF` (the `#elif defined(USE_AVX512)` arm of `radix16_dif_dit_pass_asm.h`, the `VRCP14PD` + Newton-update version) then evaluates

```
VRCP14PD(0)   = +Inf
2 - 0*Inf     = NaN
```

and every one of the 512 doubles in that block comes out NaN. The `nonzero exit carry in radix16_ditN_cy_dif1` that the run reports is downstream noise, not the fault.

## Evidence

* Permutation-invariant checksums of `a[]` showed NaN already present **pre-carry** at iteration 1.
* A per-stage NaN scan pinned it to the first `radix16_dif_pass(&a[512],…)`.
* A cosine probe reported `slot=8 val=-0.000e+00` at 8K/rs1 **and 4K/rs1**.
* **Control:** the same pi/2 twiddle at 16K/rs0 has cosine `2.407e-35` — nonzero, and that cell works. So the singularity is strictly `d == 0`, not "tiny cosine". That distinction is what rules out a tolerance-based explanation.

## Fix

A new `AVOID_EXACT_ZERO_TWIDDLE_COSINES(cc0)` macro, called at the two sites that fill `cc0[0..15]` before `RADIX16_COMPUTE_FMA_SINCOS_DIF/DIT`, replacing an exactly-zero cosine with `copysign(1e-30, c)`.

The tangent scheme computes `c*(x + (s/c)*y)`, so this introduces a spurious `eps*x` term — a **1e-30 relative perturbation, fourteen orders of magnitude below double roundoff** — while keeping both `1/c` and `s/c` in range.

A real fix rather than a soft-skip: 8K/rs1 is one of only four radix sets at that length, and a skip would leave the same NaN trap armed for any future cell that lands on an odd multiple of pi/2. 26 lines, one file.

## Measurements

AVX-512 via `sde64 -skx`, reference is a `nosimd` build of the same tree, `-iters 100 -nthread 1 -shift 0`.

**8K rs1 (`16 16 16`): `ERROR iter=1 nonzero exit carry` → `85301536E4CA9B11`**, matching nosimd. Also correct at 1000 iters, with `-shift 12345`, and at `-nthread 4`.

Stacked with #211 (which fixes the separate radix8 AVX-512 index-scramble gap), **every** small-length cell that was failing now matches its nosimd reference:

| cell | radices | AVX-512, #211 only | AVX-512, #211 + this |
|---|---|---|---|
| 2K rs0 | `8 8 16` | `C15789922E67B055` ✓ | `C15789922E67B055` ✓ |
| 4K rs1 | `8 16 16` | `7FFFFBFFFFDFFFFF` ✗ | **`7AFD2F95BF1D2361`** ✓ |
| 8K rs1 | `16 16 16` | exit carry ✗ | **`85301536E4CA9B11`** ✓ |
| 8K rs2 | `8 32 16` | `85301536E4CA9B11` ✓ | `85301536E4CA9B11` ✓ |
| 8K rs3 | `8 16 32` | `7FFFFBFFFFDFFFFE` ✗ | **`85301536E4CA9B11`** ✓ |

Worth noting for anyone tracking the trailing-radix-32 AVX-512 defect: **8K rs3 was previously attributed to it and that was wrong.** 4K rs1 (`8 16 16`) contains no radix 32 at all, yet fails in exactly the same way and is fixed by exactly the same change. Both cells were this bug.

*(Correcting an earlier revision of this description, which offered 8K rs2 as the counterexample on the grounds that it "also has a trailing 32". It does not: 8K rs2 is `8 32 16`, so its trailing radix is 16 and it selects `radix16_wrapper_square` — the wrapper routine is chosen by `RADIX_VEC[NRADICES-1]`. The argument rests on 4K rs1, which is unaffected by the slip.)

## Negative controls

1. Pre-fix and post-fix binaries are **bit-identical** (Res64 and AvgMaxErr) on 4K rs0, 8K rs0, 16K rs0/rs1, 32K rs0/rs3.
2. Rebuilt `nosimd` and `avx2` reproduce their exact pre-fix numbers — the path is not compiled there.
3. Both diagnostic probes were validated against the unfixed tree first, and were silent on passing cells.

Regression: 64K rs0-3, 128K rs0-3, 256K rs0 all match nosimd. Fermat `-f 16 -fft 8` unchanged.

## Not verified

No AVX-512 hardware here — everything via SDE. ASan was unavailable: `-fsanitize=address` on an avx512 build fails to compile (`sse2_macro_gcc64.h:4313: 'asm' operand has impossible constraints`) at both -O1 and -O3, so the out-of-bounds-read question was settled by index arithmetic plus the direct cosine probe instead. Lengths hitting an exact-zero cosine were swept exhaustively over 2K-32K and partially over 64K-256K; the fix itself is unconditional. `sse2` is independently broken on `main` (`radix32_main_carry_loop.h:62: 'cy_i' undeclared`, which #209 fixes) so it was not measured. DFT_V2 is covered by the fix's placement but was not built.

## Still failing, not this bug

**16K rs2 (`16 16 32`)** — roundoff warning at iteration 21, with this fix and #211 both applied. Consistent with the `radix32_wrapper_square` AVX-512 defect, which #68 fixes and whose description lists 16K `{16,16,32}` among the sets it repairs. Not re-measured here. **2K rs1 (`32 32`)** also still fails, while 32K rs1/rs2 — also final-radix-32 — pass, so that one is not simply explained by the trailing radix either.

