### PR TITLE
MULH192_FAST: make the 192-bit MULH exact, and add the self-test coverage that catches it

### DIFF
--- a/src/factor_test.h
+++ b/src/factor_test.h
@@ -2060,6 +2060,74 @@ if((q128.d1 >> 14) == 0) {
 
 #if(defined(P3WORD) || defined(P4WORD))
 
+	/* Test <= 96-bit factors using the 192-bit modmul routines.
+	This is NOT redundant with the 96- and 128-bit testing above, and it is the only coverage the
+	192-bit q-pipelined routines get below 2^90. A P3WORD build of factor.c feeds *every* candidate
+	to twopmodq192_q4 (factor.c:3599), including sub-2^64 ones - the runtime bit-length narrowing
+	which would hand those off to a narrower modpow is commented out at factor.c:3667-3671 - so
+	twopmodq192_q4 has to be correct for small q, not just for q near 2^128.
+	Before this loop existed the only twopmodq192_q4 coverage in test_fac() was the fac128x2 loop
+	below (q = 90...127 bits); the fac160/fac192 loops further down cannot supply any, since all of
+	their entries have k >= 2^64 and those routines take a 64-bit k. The carry-layer approximation
+	that MULH192_FAST used to apply on every non-x86_64-GCC platform lost 1458 of 1742 known
+	Mersenne factors that way, and passed the self-test unnoticed. fac96[] spans q = 60...96 bits,
+	with 158 entries at 65-66 bits, which is exactly where such small-q breakage shows up first;
+	build with -DPIPELINE_MUL192=1 to route these through the q-pipelined MUL macros. */
+#ifdef FACTOR_STANDALONE
+	printf("Testing 96-bit factors using the 192-bit modmul routines...\n");
+#endif
+	for(i = 0; fac96[i].p != 0; i++)
+	{
+		p64 = fac96[i].p;
+		p192.d0 = p64;	p192.d1 = p192.d2 = 0;		ADD192(p192, p192, two_p192);
+		q192.d2 = 0;	q192.d1 = (uint64)fac96[i].d1;	q192.d0 = fac96[i].d0;
+
+		// Compute k = (q-1)/2p, while verifying that q%2p = 1:
+		mi64_div((uint64*)&q192, (uint64*)&two_p192, 3,3, (uint64*)&x192, (uint64*)&res192);	// x192 contains k
+		if(!CMPEQ192(res192, ONE192))
+		{
+			fprintf(stderr,"ERROR : (p, q) = ( %s, %s ) : q mod (2p) = %s != 1!\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)],
+					&cbuf2[convert_uint192_base10_char(cbuf2, res192)]);
+			ASSERT(0,"0");
+		}
+		/* A handful of the fac96 entries have p > 2^32 and k >= 2^64; the q-pipelined routines
+		take a 64-bit k, so those simply are not expressible as inputs to them: */
+		if(x192.d2 != 0 || x192.d1 != 0)
+			continue;
+
+		res192 = twopmodq192(p192, q192);
+		if(!CMPEQ192(res192, ONE192))
+		{
+			fprintf(stderr,"ERROR: twopmodq192( %s, %s ) returns non-unity result %s\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)],
+					&cbuf2[convert_uint192_base10_char(cbuf2, res192)]);
+			ASSERT(0,"0");
+		}
+
+	#if(TRYQ == 4)
+		res64 = twopmodq192_q4((uint64*)&p192,x192.d0,x192.d0,x192.d0,x192.d0);
+		if(res64 != 15)
+		{
+			fprintf(stderr,"ERROR: twopmodq192_q4( %s, %s x 4 ) failed to find factor, res = %#1X.\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)], (uint32)res64);
+			ASSERT(0,"0");
+		}
+	#elif(TRYQ == 8)
+		res64 = twopmodq192_q8((uint64*)&p192,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0);
+		if(res64 != 255)
+		{
+			fprintf(stderr,"ERROR: twopmodq192_q8( %s, %s x 8 ) failed to find factor, res = %#2X.\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)], (uint32)res64);
+			ASSERT(0,"0");
+		}
+	#endif
+	}
+
 	/* Test 128-bit factors using the 160 and 192-bit modmul routines */
 #ifdef FACTOR_STANDALONE
 	printf("Testing 128x2-bit factors using 160 and 192-bit modmul routines...\n");

--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -7225,7 +7225,33 @@ simply add 1 to the approximate-computed carry to obtain the correct result.
 		__hi.d0 = __w3;	__hi.d1 = __w4;	__hi.d2 = __w5;\
     }
 
-  #if 0
+/* Jul 2026: Default MULH192_FAST to the exact MULH192 on *all* platforms, not just the x86_64-GCC
+one which already did so via the YES_ASM arm below.
+
+The carry-layer approximation in the #else arm is only sound under the assumption stated in the
+comment block above, that the discarded low-half bits are "presumably quasirandom". In the
+Montgomery-mul usage that assumption is false: Montgomery guarantees (q*lo) mod 2^192 = x^2 mod
+2^192, so the w2 layer of the product - the one whose carry-out the approximation predicts - is
+exactly (x^2 >> 128). For x < q < 2^96 that is pinned near zero, i.e. permanently adjacent to the
+carry boundary rather than uniform over it. Measured carry-mispredict rate is 4.9e-1 per call at
+q = 66 bits, 1.7e-1 at 70 bits, 1.3e-2 at 74 bits, falling to zero only above ~86 bits; feeding the
+known Mersenne factors in fac_test_dat{64,96,128}.h through twopmodq192_q4 recognises only 284 of
+1742 of them with the approximation, vs 1742 of 1742 with the exact macro.
+
+Small q really do reach here: factor.c's P3WORD arm has no runtime bit-length narrowing (the
+narrowing is commented out at factor.c:3667-3671), so 60-bit candidates go through the 192-bit
+modpow. And the precondition the comment above names - "should only ever be used with spot-checking
+enabled" - cannot be met: factor.c's SPOT_CHECK is hardwired to 0 and both its use sites guard
+nothing but a printf. (The one thing that keeps this latent today is that MULH192_q4/_q8 sit behind
+#if PIPELINE_MUL192 in twopmodq192.c, and makemake.sh passes -DP3WORD only to factor.c, so
+PIPELINE_MUL192 is 0 there and the exact MULH192 gets used. Anyone building with
+-DPIPELINE_MUL192=1 - which factor.h:48 documents as the P3WORD default - gets the bug.)
+
+Cost of exactness, measured with callgrind over the above known-factor workload: +9.3% instructions
+on the generic C compiled for x86_64, +5.5% on a real 32-bit x86 build; wall clock within noise.
+Build with -DMULH192_FAST_APPROX to get the old approximate version back for timing comparisons
+(on x86_64-with-YES_ASM that arm was already exact, so the opt-in is a no-op there). */
+  #ifndef MULH192_FAST_APPROX
 
     #define MULH192_FAST(__x, __y, __hi)	MULH192(__x, __y, __hi)
 
@@ -7371,6 +7397,13 @@ simply add 1 to the approximate-computed carry to obtain the correct result.
 		__hi.d0 = __w3;	__hi.d1 = __w4;	__hi.d2 = __w5;\
     }
 
+#endif
+
+/* The MUL_LOHI64_SUBROUTINE arm of the selection logic above has no #else, so configurations which
+define MUL_LOHI64_SUBROUTINE but not YES_ASM (SunC on x86_64) fall through it without defining
+MULH192_FAST at all. Supply the exact macro rather than leaving that a link-time-looking mystery: */
+#ifndef MULH192_FAST
+    #define MULH192_FAST(__x, __y, __hi)	MULH192(__x, __y, __hi)
 #endif
 
     /* 4-operand-pipelined version: */


### PR DESCRIPTION
`MULH192_FAST` uses a floating-double **approximation** whose stated precondition has never been satisfiable, and which returns the wrong answer on a reachable input range. This makes it exact, and adds the self-test coverage that would have caught it.

## Severity, stated up front

The defect is real and reproducible, but **it is latent in shipped builds, not live.** `MULH192_q4` sits behind `#if PIPELINE_MUL192` (`twopmodq192.c:675`); `PIPELINE_MUL192` is set in `factor.h:47-51` only `#ifdef P3WORD`; and `makemake.sh:553` passes `$WORDS` **only to the `factor.o` rule** — line 555's generic `%.o` rule does not. From the real build log:

```
cc ... -c -DUSE_THREADS ../src/twopmodq192.c                                  <-- no -DP3WORD
cc ... -c -DUSE_THREADS -DFACTOR_STANDALONE -DP3WORD -DTRYQ=4 ../src/factor.c
```

Measured: `twopmodq192.c` preprocessed with the real flags contains `__fprod` **0** times (72 with `-DP3WORD` added), and the 32-bit object has no FP instructions in `twopmodq192_q4`.

So this affects anyone building `-DPIPELINE_MUL192=1`, which `factor.h:48` presents as a user-tunable option, but not a stock `Mfactor_3word`. That build-flag inconsistency is a separate problem and is deliberately **not** fixed here — wiring `$WORDS` through the generic rule switches on never-shipped pipelined paths across the board.

## The defect

The approximation's justification is that the lower bits are "presumably quasirandom". They are not. Montgomery guarantees `(q·lo) mod 2^192 = x² mod 2^192`, so the w2-layer residue **is** `x²>>128` — and for `x < q < 2^96` that is pinned near zero, permanently adjacent to the carry boundary.

Mispredict rate per `MULH192` call, by q size:

| q bits | 66 | 70 | 74 | 78 | 82 | 86–122 |
|---|---|---|---|---|---|---|
| rate | **0.49** | 0.17 | 1.3e-2 | 6.3e-4 | 3.5e-5 | **0** in 1.27e6 calls |

Mean `|delta|` is flat (~600, max 6890 over 3M+ samples), so the blow-up is the non-uniformity, not floating-point accuracy.

Feeding the repo's own known-factor tables to `twopmodq192_q4` exactly as `factor.c:3599` does: **284/1742 found with the approximation, 1742/1742 exact.** (1742 rather than 1785 because the 43 `fac128x2` entries have a 128-bit `p`; per-bucket miss counts match an earlier independent run.)

**The stated precondition is unsatisfiable.** `imul_macro1.h:7015` says the approximation "should only ever be used with spot-checking enabled" — but `factor.c:152` is `#define SPOT_CHECK 0` with **no `#ifndef`**, so `-DSPOT_CHECK=1` cannot even be passed, and both use sites (`factor.c:3392`, `:3416`) wrap **nothing but a `printf`**. Enabling it changes no logic and verifies nothing.

And the failure is invisible: false positives are caught by the `mi64_twopmodq` re-check at `factor.c:3780`; **false negatives — missed factors — have no detection mechanism anywhere.**

## The fix

`imul_macro1.h:7228`, `#if 0` → `#ifndef MULH192_FAST_APPROX`: promotes the exact alias that was already sitting dead behind `#if 0` to the default on all platforms, with an opt-out. Plus an `#ifndef MULH192_FAST` fallback after the selection block, which closes the SunC/x86_64 hole where `7078-7118` has no `#else`.

No size-based condition. A per-call bit-length test inside the modpow loop would cost more than the 5–9% it saves, and `factor.c` runs 60-bit candidates through the 192-bit modpow anyway (the narrowing is commented out at `factor.c:3667-3671`), so the small-q regime is reachable in production.

**Measured cost:** +9.31% instructions (generic C, x86-64) and +5.53% (real i386), Ir in `twopmodq192_q4`. Wall clock is noise-dominated (−4.5 / +2.2 / −3.3% over three interleaved best-of-15 rounds).

## Self-test coverage

`test_fac()` passed cleanly while this was losing 83% of known factors, so the fix includes coverage that fails without it.

Note the obvious approach does not work: `test_fac()`'s 40 `fac160`/`fac192` entries are skipped by `k < 2^64` guards, but those guards are **correct** — 0 of 21 `fac160` and 0 of 5 `fac192` entries have `k < 2^64`, and `twopmodq192_q4` takes a 64-bit `k`, so relaxing them would pass a truncated `k`. Those q are also 129–187 bits, i.e. the regime where the approximation is exact, so a "repaired" test there would pass either way.

Instead this adds a `fac96[]` loop — 458 usable entries, q = 60…96 bits, 158 of them at 65–66 bits — using `factor.c:3599`'s exact call shape. Validated failing-direction-first on real `gcc -m32` builds with `-DPIPELINE_MUL192=1`:

| | result |
|---|---|
| stock test + buggy macro | **passes** (this is the gap) |
| repaired test + buggy macro | **fails on the first entry** |
| repaired test + fix | passes |

Self-test cost: 2.346 s → 2.305 s, i.e. noise.

## Collisions — checked, none

`imul_macro1.h` is touched by #167, #173, #198, #199, #200, #201, #202, #212 and #213. Rather than trusting line-distance arithmetic, each of the nine merged trees was materialised and checked that both this PR's markers **and** every line that PR adds to these files survive: **9/9 clean, 0 missing.** For #213 the merged tree was also extracted and compiled. No ordering constraint.

## Also found, not fixed here

* `test_fac()` still has no `twopmodq192_q4` coverage above 128 bits; constructed vectors are needed, since `q > 2^128` with `k < 2^64` forces `p > 2^64` and no catalogued Mersenne factor has that.
* `-DTRYQ=8` does not compile on `main` — three `incompatible type for argument 1 of 'twopmodq192_q8'` (a `uint192` passed by value where a `uint64 *` is wanted). The arm added here is correctly typed; the three pre-existing ones are left alone.
* Build trap worth knowing: `makemake.sh mfac 1word` then `mfac 3word` reuse the same `obj_mfac_<mode>/`, and make's timestamp check silently relinks the *1word* `factor.o` while reporting success.
