### PR TITLE
Fermat PRP-CF: stop the Pépin random bits from overwriting the modpow bits

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2306,8 +2306,15 @@ READ_RESTART_FILE:
 		/*...reset loop parameters and begin next iteration cycle...	*/
 		ilo = ihi;
 		ihi = ilo+ITERS_BETWEEN_CHECKPOINTS;
-		// If Fermat-mod-with-residue-shift, re-init the random-offset-bit array:
-		if(MODULUS_TYPE == MODULUS_TYPE_FERMAT && update_shift) {
+		/* If Pépin-test-with-residue-shift, re-init the random-offset-bit array. Note the TEST_TYPE clause: the
+		random-bit scheme (residue *= 2 whenever the shift update picks up a 1 bit) exists only for the Pépin test,
+		where PRP_BASE is set to 2 for exactly that purpose. A Fermat-mod *PRP* test - i.e. the PRP phase of a
+		PRP-CF run - shares this code path but has its own, unrelated use for BASE_MULTIPLIER_BITS (the LR-modpow
+		multiply-by-base bits), which the TEST_TYPE_PRP clause far above deliberately zeroes because the G-check
+		needs an all-squarings chain. Without the clause, this refill overwrote those zeros from the second
+		checkpoint interval on, and the carry step then multiplied the residue by PRP_BASE - 3 for a 3-PRP test -
+		while the shift bookkeeping credited it with a factor of 2, silently corrupting the residue: */
+		if(MODULUS_TYPE == MODULUS_TYPE_FERMAT && TEST_TYPE == TEST_TYPE_PRIMALITY && update_shift) {
 			j = ((ITERS_BETWEEN_CHECKPOINTS+63) >> 6);
 			for(i = 0; i < j; i++) { BASE_MULTIPLIER_BITS[i] = rng_isaac_rand(); }; i = ITERS_BETWEEN_CHECKPOINTS&63;	// i = #low bits used in high limb
 		//	fprintf(stderr,"Iter %u: random-bit-array popcount = %u\n",ilo,mi64_popcount(BASE_MULTIPLIER_BITS,j) - popcount64(BASE_MULTIPLIER_BITS[j-1] >> i));


### PR DESCRIPTION
A Fermat-mod PRP test — the PRP phase of a PRP-CF (Suyama cofactor) run — and a Pépin test both use the global `BASE_MULTIPLIER_BITS`, for entirely unrelated purposes:

* **Pépin** uses one random bit per iteration: "residue `*= 2` and shift `+= 1` when the bit is set", which keeps the shift from mod-doubling its way down to 0. `PRP_BASE` is set to 2 for exactly this.
* **PRP** uses it for the LR-modpow multiply-by-base bits, which the `TEST_TYPE_PRP` clause at `Mlucas.c:1476-1479` deliberately zeroes, because the Gerbicz check needs an all-squarings chain.

The per-checkpoint refill of the random-bit array was keyed only on `MODULUS_TYPE == MODULUS_TYPE_FERMAT && update_shift`, with no `TEST_TYPE` test:

```c
// If Fermat-mod-with-residue-shift, re-init the random-offset-bit array:
if(MODULUS_TYPE == MODULUS_TYPE_FERMAT && update_shift) {
```

So on a Fermat-mod PRP run it overwrote those zeros from the second checkpoint interval onwards. The carry step then multiplied the residue by `PRP_BASE` — **3** for the default 3-PRP test, not 2 — while the shift bookkeeping credited the iteration with a factor of 2. The residue is wrong from that point on.

`update_shift` is true whenever the shift is nonzero, and the shift is randomized by default, so **this is the default behaviour of a Fermat PRP-CF run**; only an explicit `-shift 0` avoided it.

## Impact

Wrong, but caught rather than reported: `DO_GCHECK` is unconditionally true for `TEST_TYPE_PRP` (`Mlucas.c:1462-1463`), so the G-check fails at the first check and the assignment is dropped from the workfile. The run produces no result at all. The corruption is genuinely upstream of the check, not a check artifact.

## Verification

Reproduced at F16 with scaled G-check intervals (L = 100, check every 10000). The shift-removed `Res64` at iteration 2000 is `FB35E07B369CFAA3` with the default shift, versus `F47EB37AC9583912` with `-shift 0` — the latter being the correct Pépin-chain value.

After the fix, the F16 PRP-CF run with the default shift produces a residue sequence byte-identical to the `-shift 0` run and passes all 6 G-checks.

## Notes for review

* Restricting the refill to `TEST_TYPE_PRIMALITY` restores the intent of the zeroing at `:1478`: the bits stay 0, the shift mod-doubles down to 0 within *m* iterations for F*m*, and the chain is pure squarings again.
* One line of code; the rest of the diff is a comment explaining why the two uses of the global collide, since the collision is not obvious from either site alone.
* Both fixed and unfixed runs then hit a pre-existing, unrelated assertion in `Suyama_CF_PRP` — "Fermat-mod cofactor-PRP test requires p-1 mod-squarings!" — which reproduces identically on unmodified main with `-shift 0`. That is a separate problem and is not addressed here.
* Independent of the Fermat-mod Gerbicz-check shift work in the companion PR; either can merge first.
