### PR TITLE
Fermat-mod Gerbicz check: make it work with a nonzero residue shift

### DIFF
--- a/docs/Fermat-testing.md
+++ b/docs/Fermat-testing.md
@@ -96,15 +96,14 @@ to be composite. However, the character of their cofactors is unknown so a Pépi
 necessary prerequisite for testing them; and as for _F_<sub>33</sub>, this is yet to be 
 tested for primality.
 
-The Pépin test uses Gerbicz error checking (GEC) to assure the reliability of the computation, however 
-residue shifting is not implemented for Fermat modular squaring with GEC. Thus when invoking Mlucas the 
-flag `-shift 0` _must_ be added to the Mlucas command line:
-```
-./Mlucas -shift 0
-```
-If non-zero residue shifting is used, the Pépin test will not be able to progress beyond the millionth 
-iteration (the default interval for GEC) as error checking will be unable to confirm whether or not the 
-computation is correct.
+The Pépin test uses Gerbicz error checking (GEC) to assure the reliability of the computation. Up to and 
+including v21.0.2, GEC and a nonzero residue shift were incompatible: the check applied a correction 
+factor that is only valid for the Mersenne-mod pure-shift-doubling case, so a Pépin test run with the 
+default (randomly chosen, nonzero) shift failed its first GEC at the millionth iteration and the 
+assignment was abandoned; `-shift 0` therefore had to be added to the command line. That restriction has 
+been lifted - the Fermat-mod GEC now maintains its own correction accumulator - and `-shift 0` is no 
+longer needed for GEC. It is still required for FFT lengths whose leading radix is less than 16 (see the 
+small-FFT note below) and for p-1 runs.
 
 ## Cofactor compositeness testing: Suyama’s test
 Suyama’s test is a Fermat probable primality test on the cofactor of a Fermat number. As a prerequisite, 

--- a/src/Mdata.h
+++ b/src/Mdata.h
@@ -262,6 +262,12 @@ extern uint64 PMAX;	/* maximum exponent allowed */
 extern uint64 RES_SHIFT, GCHECK_SHIFT;
 // Feb 2020: added a uint32 to keep track of the shifted-residue sign, needed for rotated residue Fermat-mod arithmetic:
 extern uint32 RES_SIGN;
+/* Fermat-mod Pépin test only: the random-bit residue-doubling that accompanies the 'shift = 2*shift + randbit'
+update is a property of the *shift-carrying main residue chain*, not of the modulus. Set FALSE by
+fermat_mod_square() while it is squaring/multiplying one of the Gerbicz-check auxiliary arrays (which do not
+carry a shift), so that the carry routines skip the doubling for those. Cf. the prp_mult gate in the
+radix*_ditN_cy_dif1() routines and the update_shift arg of fermat_mod_square(). */
+extern int FERMAT_RANDBIT_MULT;
 extern uint64 *BIGWORD_BITMAP;	/* Needed for fast how-many-residue-bits-up-to-this-array-word lookup, which the carry routines
 								use to figure out where to inject the -2 in a rotated-residue LL test using Crandall/Fagin IBDWT.
 								A 1-bit means a bigword (p/n+1 bits); 0 means a smallword (p/n bits), where p/n is integer-div. */

--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -147,6 +147,7 @@ const char *err_code[ERR_MAX] = {
 uint64 RES_SHIFT = 0xFFFFFFFFFFFFFFFFull;	// 0 is a valid value here, so init to UINT64_MAX, which value is treated as "uninited"
 uint64 GCHECK_SHIFT = 0ull;
 uint32 RES_SIGN = 0;	// Feb 2020: uint32 to keep track of shifted-residue sign flips, needed for rotated residue Fermat-mod arithmetic.
+int FERMAT_RANDBIT_MULT = TRUE;	// Fermat-mod Pépin: apply the random-bit residue-doubling? Only for the shift-carrying main chain; cf. Mdata.h.
 uint64 *BIGWORD_BITMAP = 0x0;
 uint32 *BIGWORD_NBITS = 0x0;
 
@@ -1574,7 +1575,13 @@ READ_RESTART_FILE:
 			}
 			// v19: G-check residue - we only create savefile for PRP-phase of any PRP-CF run, i.e. always expect a G-check residue:
 		  if(DO_GCHECK) {
-			if(!convert_res_bytewise_FP((uint8 *)e_uint64_ptr, b, n, p)) {
+			// Cf. the matching comment at the convert_res_FP_bytewise(b,...) write call: the G-check product
+			// carries no residue shift, so read it back without applying one (Fermat-mod only - see there):
+			uint64 sv_shift = RES_SHIFT; uint32 sv_sign = RES_SIGN;
+			if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) { RES_SHIFT = 0ull; RES_SIGN = 0; }
+			i = convert_res_bytewise_FP((uint8 *)e_uint64_ptr, b, n, p);
+			RES_SHIFT = sv_shift; RES_SIGN = sv_sign;
+			if(!i) {
 				snprintf(cbuf,sizeof(cbuf), "ERROR: convert_res_bytewise_FP Failed on Gerbicz-check residue read from savefile %s!\n",g_cstr);
 				mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
 			} else {
@@ -1672,10 +1679,11 @@ READ_RESTART_FILE:
 			ASSERT((itmp64 & 255) < ceil((double)p/n), "Return value of shift_word(): bit-in-array-word value out of range!");
 		}
 	} else if(DO_GCHECK) {
-		if(MODULUS_TYPE == MODULUS_TYPE_FERMAT && TEST_TYPE == TEST_TYPE_PRIMALITY && !INTERACT) {	// Allow shift in timing-test mode
-			ASSERT(RES_SHIFT == 0ull, "Shifted residues unsupported for Pépin test with Gerbicz check!\n");
-			// exit(1);
-		}
+		/* v21: The "Shifted residues unsupported for Pépin test with Gerbicz check!" assertion that used to sit
+		here is gone: the Fermat-mod G-check now carries its own (mod 2p) power-of-2 correction accumulator, so a
+		nonzero shift works. Note the assertion only ever guarded the *resume* path anyway (a from-scratch Pépin
+		run happily picked a random nonzero shift and then failed its first G-check), so it turned "wrong check"
+		into "cannot resume", rather than preventing the combination. */
 		memcpy(d, b, nbytes);	// If doing a PRP test, init redundant copy d[] Gerbicz residue-product accumulator b[].
 	}
 
@@ -1837,8 +1845,6 @@ READ_RESTART_FILE:
 		if(MLUCAS_KEEP_RUNNING && (ihi-ilo) >= ITERS_BETWEEN_GCHECK_UPDATES) {
 			i = ilo;	tdiff = 0.0;	// Need 2 timers here - tdif2 for the individual func_mod_square calls, accumulate in tdiff
 			while(!ierr && MLUCAS_KEEP_RUNNING && i < ihi) {
-				// See G-check code for why this logfile-print of initial-G-check-update residue shift value is needed in Fermat-mod case:
-				if(i == ITERS_BETWEEN_GCHECK_UPDATES) { sprintf(cbuf,"At iter ITERS_BETWEEN_GCHECK_UPDATES = %u: RES_SHIFT = %" PRIu64 "\n",i,RES_SHIFT); mlucas_fprint(cbuf,1); }
 				/* If restart-after-interrupt and thus ilo neither a non-multiple of ITERS_BETWEEN_CHECKPOINTS nor of
 				ITERS_BETWEEN_GCHECK_UPDATES, round first i-update > ilo to nearest multiple of ITERS_BETWEEN_GCHECK_UPDATES:
 				*/
@@ -1924,6 +1930,28 @@ READ_RESTART_FILE:
 					}
 				}
 			//	fprintf(stderr,"FFT(b)*FFT(c), mode = %u\n",mode_flag);
+				/* v21: Fermat-mod accumulation of the Gerbicz-check power-of-2 correction. With x_i the shifted
+				residue after i squarings, u_i = 3^(2^i) (mod Fm) the true one and s_i = RES_SHIFT, we have
+					x_i = (-1)^q_[i-1] . u_i . 2^s_i (mod Fm),  q_[i-1] = [s_[i-1] >= p/2] = RES_SIGN,
+				and the check-product b, which starts at the *unshifted* seed 3 and is multiplied by x_[kL] at
+				each of the check-product updates k = 1,2,3,..., therefore satisfies
+					b = 3 . [prod_k u_[kL]] . (-1)^[sum_k q_[kL-1]] . 2^[sum_k s_[kL]] .
+				The check squares an L-iterations-older copy of b L times, which - since 2^(2^L) == 1 (mod Fm)
+				for L >= m+1, i.e. with vast margin at the L = 1000 default - kills every one of those powers of
+				2 and leaves exactly [prod_k u_[kL]]. So the correction needed to bring the two sides back
+				together is 2^GCHECK_SHIFT with GCHECK_SHIFT the running sum below, taken (mod 2p) since
+				2^(2p) == 1 (mod Fm), and with the sign flips folded in via -1 == 2^p (mod Fm).
+				Contrast the Mersenne-mod case, where all q = 0 and s_[kL] = 2^L.s_[(k-1)L] (mod p) makes the sum
+				telescope down to the single term s_L - which is what the ihi == ITERS_BETWEEN_GCHECKS branch of
+				the check code below recovers, and which is *not* correct for Fermat-mod, because there the
+				shift update is 'mod-double *and add a random bit*' and thus does not telescope: */
+				if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
+					// RES_SIGN is only maintained while the shift is being updated; with shift 0 there are no sign
+					// flips at all, and gating on update_shift also stops a stale 1 left over by a preceding shifted
+					// assignment of a multi-exponent run from perturbing an unshifted one:
+					GCHECK_SHIFT += RES_SHIFT + ((update_shift && RES_SIGN) ? p : 0ull);
+					GCHECK_SHIFT %= (p << 1);
+				}
 				// If not going to proceed to actual Gerbicz-check, save a post-updated copy of the checkproduct,
 				// in order to guard against single-bit or other data corruption in b[] (h/t George Woltman):
 				if(i % ITERS_BETWEEN_GCHECKS != 0) {
@@ -2034,7 +2062,19 @@ READ_RESTART_FILE:
 		// G-check residue...must not touch i1,i2,i3 again until ensuing write_ppm1_savefiles call!
 		if(DO_GCHECK) {
 			e_uint64_ptr[j-1] = 0ull;
+			/* The G-check product is *not* a shifted residue - it is a plain product (mod N) - so it must
+			round-trip through the savefile unchanged. convert_res_[FP_bytewise|bytewise_FP] read the shift
+			from the RES_SHIFT global, and in the Fermat-mod case they are not mutually inverse when it is
+			nonzero: the write does an lcshift by (p - RES_SHIFT) and a RES_SIGN-conditioned negation, the read
+			an lcshift by RES_SHIFT, composing to a full p-bit negacyclic rotation, i.e. multiplication by
+			2^p == -1 (mod Fm). For the main residue a[] that sign error is harmless (the next mod-squaring
+			wipes it), but b[] is compared, not squared, so it would corrupt the check on every resume.
+			Mersenne-mod is left alone: there 2^p == +1, the round-trip is exact as-is, and changing what goes
+			in the file would break every in-progress PRP savefile with a nonzero shift. */
+			uint64 sv_shift = RES_SHIFT; uint32 sv_sign = RES_SIGN;
+			if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) { RES_SHIFT = 0ull; RES_SIGN = 0; }
 			convert_res_FP_bytewise(b, (uint8 *)e_uint64_ptr, n, p, &i1,&i2,&i3);
+			RES_SHIFT = sv_shift; RES_SIGN = sv_sign;
 		}
 
 		// In interactive-timing-test (e.g. self-tests) mode, do immediate-exit-sans-savefile-write on signal:
@@ -2111,58 +2151,60 @@ READ_RESTART_FILE:
 			j = (p+63)>>6;	/*** Jun 2021: cf. convert_res_FP_bytewise() for why we don't include the extra Fermat-modulus bit here ***/
 			c_uint64_ptr[j-1] = 0ull;
 			// [1] Convert b[],d[] to bytewise form, former assumed already in e[] doubles-array, latter into currently-unused c[] doubles-array:
-			convert_res_FP_bytewise(d, (uint8 *)c_uint64_ptr, n, p, 0x0,0x0,0x0);
-			// Only need to compute this for initial interval - after that the needed adjustment-shift remains constant
-			if(ihi == ITERS_BETWEEN_GCHECKS && RES_SHIFT) {
-				if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
-					/* d[] needs initial-shift applied prior to final scalar multiply, but don't explicitly,
-					store the initial shift, so need to recompute it from a current value s at iteration i:
-						s = s0.2^i (mod p)
-					Repeatedly div-by-2 (mod p) of y = 2.x (mod p):
-						y even: y = y>>1
-						y odd : y = (y+p)>>1
-					*/
-					itmp64 = RES_SHIFT;
-					for(i = ITERS_BETWEEN_GCHECK_UPDATES; i < ITERS_BETWEEN_GCHECKS; i++) {	// Recover shift at initial ITERS_BETWEEN_GCHECK_UPDATES-iteration subinterval from that at initial savefile-checkpoint
-						if(itmp64 & 1)	// y odd
-							itmp64 = (itmp64+p)>>1;
-						else			// y even
-							itmp64 >>= 1;
-					}
-				} else {
-					// In Fermat-mod case, with its random-bit shift offset, simple repeated-mod-halving does not work,
-					// need to also account for the said per-iter offset ... but that's no good either, since only store
-					// the random-offset bits for latest ITERS_BETWEEN_CHECKPOINTS iters in BASE_MULTIPLIER_BITS. So instead
-					// must write RES_SHIFT value at iter = ITERS_BETWEEN_GCHECKS to logfile and read back here:
-				#if 1
-					if(filegrep(STATFILE,"ITERS_BETWEEN_GCHECK_UPDATES",cbuf,0)) {
-						char_addr = strstr(cbuf,"RES_SHIFT = ") + 12;	// Skip ahead by length of search-substring
-						itmp64 = strtoull(char_addr, &cptr, 10);
-						ASSERT(itmp64 != -1ull, "strtoull() overflow detected.");
-					}
-				#else
-					itmp64 = RES_SHIFT;
-					// Unlike Mers-mod case, need to run this loop in reverse in order to duplicate
-					// the actual iteration counts and their corr. random-bit shift offsets:
-					for(i = ITERS_BETWEEN_GCHECKS; i >= ITERS_BETWEEN_GCHECK_UPDATES; i--) {	// Recover shift at initial ITERS_BETWEEN_GCHECK_UPDATES-iteration subinterval from that at initial savefile-checkpoint
-						uint32 nhalvings,curr_bit = ((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1);	// No mod needed on this add, since result of pvs line even and < p, which is itself even in the Fermat-mod case (p = 2^m)
-						// If current random-offset bit = 1, do 2 mod-halvings; otherwise do just one:
-						for(nhalvings = 0; nhalvings <= curr_bit; nhalvings++) {
-							if(itmp64 & 1)	// y odd
-								itmp64 = (itmp64+p)>>1;
-							else			// y even
-								itmp64 >>= 1;
-						}
-					}
-				#endif
+			// d[] holds the L-times-squared G-check product, which carries no residue shift - so, exactly as for the
+			// b[] savefile round-trip above, keep convert_res_FP_bytewise() from applying the main chain's shift and
+			// sign to it. (Mersenne-mod is deliberately left alone: there the shift removal is a plain cyclic
+			// rotation applied to b[] and d[] alike, so it cancels between the two sides of the comparison below,
+			// and suppressing it would change what goes into every in-progress PRP savefile.)
+			{
+				uint64 sv_shift = RES_SHIFT; uint32 sv_sign = RES_SIGN;
+				if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) { RES_SHIFT = 0ull; RES_SIGN = 0; }
+				convert_res_FP_bytewise(d, (uint8 *)c_uint64_ptr, n, p, 0x0,0x0,0x0);
+				RES_SHIFT = sv_shift; RES_SIGN = sv_sign;
+			}
+			/* Mersenne-mod: the correction is the single power of 2 whose exponent is the residue shift at the
+			ITERS_BETWEEN_GCHECK_UPDATESth iteration (see the derivation at the GCHECK_SHIFT update above), and since
+			that value is not stored explicitly we recover it from the current shift. Only need to compute this for
+			the initial interval - after that the needed adjustment-shift remains constant.
+			Fermat-mod: GCHECK_SHIFT is instead the running (mod 2p) accumulator maintained at each check-product
+			update, which genuinely changes from one check interval to the next, so nothing to do here. */
+			if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE && ihi == ITERS_BETWEEN_GCHECKS && RES_SHIFT) {
+				/* d[] needs initial-shift applied prior to final scalar multiply, but don't explicitly,
+				store the initial shift, so need to recompute it from a current value s at iteration i:
+					s = s0.2^i (mod p)
+				Repeatedly div-by-2 (mod p) of y = 2.x (mod p):
+					y even: y = y>>1
+					y odd : y = (y+p)>>1
+				*/
+				itmp64 = RES_SHIFT;
+				for(i = ITERS_BETWEEN_GCHECK_UPDATES; i < ITERS_BETWEEN_GCHECKS; i++) {	// Recover shift at initial ITERS_BETWEEN_GCHECK_UPDATES-iteration subinterval from that at initial savefile-checkpoint
+					if(itmp64 & 1)	// y odd
+						itmp64 = (itmp64+p)>>1;
+					else			// y even
+						itmp64 >>= 1;
 				}
 				fprintf(stderr,"Recovered initial shift %" PRIu64 "\n",itmp64);
 				ASSERT((itmp64>>32) == 0ull,"Shift must be < 2^32!");
 				GCHECK_SHIFT = itmp64;
 			}
-			mi64_shlc(c_uint64_ptr, c_uint64_ptr, (uint32)p, (uint32)GCHECK_SHIFT, j, (MODULUS_TYPE == MODULUS_TYPE_FERMAT));
+			/* Apply the 2^GCHECK_SHIFT correction. In the Fermat-mod case GCHECK_SHIFT lives (mod 2p) rather than
+			(mod p), the high half encoding a sign flip via 2^p == -1 (mod Fm), so split it accordingly: */
+			itmp64 = GCHECK_SHIFT;	i = 0;	// i = "needs explicit negation" flag
+			if(MODULUS_TYPE == MODULUS_TYPE_FERMAT && itmp64 >= p) { itmp64 -= p; i = 1; }
+			ASSERT((itmp64>>32) == 0ull,"Shift must be < 2^32!");
+			mi64_shlc(c_uint64_ptr, c_uint64_ptr, (uint32)p, (uint32)itmp64, j, (MODULUS_TYPE == MODULUS_TYPE_FERMAT));
 			/*** Now that have undone shift, include extra modulus bit for Fermat-mod case ***/
-			if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) { c_uint64_ptr[j++] = 0ull; }
+			if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
+				// Negation (mod Fm) is Fm - c = ~c + 2 over the low p bits; the add can only carry out in the
+				// c == 1 case, whose negative 2^p is then exactly represented by the extra high bit:
+				if(i) {
+					for(i = 0; i < j; i++) { c_uint64_ptr[i] = ~c_uint64_ptr[i]; }
+					c_uint64_ptr[j] = mi64_add_scalar(c_uint64_ptr, 2ull, c_uint64_ptr, j);
+					j++;
+				} else {
+					c_uint64_ptr[j++] = 0ull;
+				}
+			}
 			// Use mi64 routines to compute d[]*PRP_BASE and do ensuing equality check:
 			itmp64 = ((MODULUS_TYPE == MODULUS_TYPE_FERMAT) ? 3ull : (uint64)PRP_BASE);	// Fermat-mod uses PRP_BASE to store 2 for random-shift-offset scheme
 			c_uint64_ptr[j] = mi64_mul_scalar(c_uint64_ptr, itmp64, c_uint64_ptr, j);

--- a/src/fermat_mod_square.c
+++ b/src/fermat_mod_square.c
@@ -1376,6 +1376,13 @@ for(iter=ilo+1; iter <= ihi && MLUCAS_KEEP_RUNNING; iter++)
 	if(fwd_fft == 1)
 		return 0;	// Skip carry step [and preceding inverse-FFT] in this case
 
+	/* The Pépin-test random-bit residue-doubling done by the carry routines is the multiplicative partner of the
+	'shift = 2*shift + randbit' update just below: it belongs to the shift-carrying main residue chain and to nothing
+	else. Tell the carry routines whether the array we are about to process is that chain. Without this, the doubling
+	also gets applied to the Gerbicz check-product update and to the check's squaring chain - neither of which carries
+	a shift - which multiplies those by unaccounted-for powers of 2 and makes the Gerbicz check fail: */
+	FERMAT_RANDBIT_MULT = update_shift;
+
 	// Update RES_SHIFT via mod-doubling, *** BUT ONLY IF IT'S AN AUTOSQUARE ***:
 	if(update_shift) {
 		/* Update RES_SHIFT via mod-doubling-and-add-random-bit. If initial RES_SHIFT = 0 the 'random' bit array = 0, so RES_SHIFT remains 0:

--- a/src/radix1008_ditN_cy_dif1.c
+++ b/src/radix1008_ditN_cy_dif1.c
@@ -467,7 +467,7 @@ int radix1008_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix1024_ditN_cy_dif1.c
+++ b/src/radix1024_ditN_cy_dif1.c
@@ -399,7 +399,7 @@ int radix1024_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix128_ditN_cy_dif1.c
+++ b/src/radix128_ditN_cy_dif1.c
@@ -392,7 +392,7 @@ int radix128_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix16_ditN_cy_dif1.c
+++ b/src/radix16_ditN_cy_dif1.c
@@ -396,7 +396,7 @@ int radix16_ditN_cy_dif1		(double a[],             int n, int nwt, int nwt_bits,
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix224_ditN_cy_dif1.c
+++ b/src/radix224_ditN_cy_dif1.c
@@ -529,7 +529,7 @@ int radix224_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix240_ditN_cy_dif1.c
+++ b/src/radix240_ditN_cy_dif1.c
@@ -518,7 +518,7 @@ int radix240_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix256_ditN_cy_dif1.c
+++ b/src/radix256_ditN_cy_dif1.c
@@ -429,7 +429,7 @@ int radix256_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix28_ditN_cy_dif1.c
+++ b/src/radix28_ditN_cy_dif1.c
@@ -569,7 +569,7 @@ int radix28_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix32_ditN_cy_dif1.c
+++ b/src/radix32_ditN_cy_dif1.c
@@ -317,7 +317,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix4032_ditN_cy_dif1.c
+++ b/src/radix4032_ditN_cy_dif1.c
@@ -425,7 +425,7 @@ int radix4032_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix56_ditN_cy_dif1.c
+++ b/src/radix56_ditN_cy_dif1.c
@@ -488,7 +488,7 @@ int radix56_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix60_ditN_cy_dif1.c
+++ b/src/radix60_ditN_cy_dif1.c
@@ -506,7 +506,7 @@ int radix60_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix63_ditN_cy_dif1.c
+++ b/src/radix63_ditN_cy_dif1.c
@@ -193,7 +193,11 @@ int radix63_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	col=co2=co3=-1;
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
-	if((TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
+	// v18: If use residue shift in context of Pepin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]'
+	// update of the residue shift has a set random bit. radix63 was missing this Fermat arm entirely - see #232, which
+	// adds it against main; the FERMAT_RANDBIT_MULT gate is this PR's, matching the 15 sibling routines swept below.
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
+	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)
 			prp_mult = PRP_BASE;

--- a/src/radix64_ditN_cy_dif1.c
+++ b/src/radix64_ditN_cy_dif1.c
@@ -414,7 +414,7 @@ int radix64_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix960_ditN_cy_dif1.c
+++ b/src/radix960_ditN_cy_dif1.c
@@ -523,7 +523,7 @@ int radix960_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)

--- a/src/radix992_ditN_cy_dif1.c
+++ b/src/radix992_ditN_cy_dif1.c
@@ -335,7 +335,7 @@ int radix992_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
 	// v18: If use residue shift in context of Pépin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]' update gets a 1-bit in the random slot
-	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT && FERMAT_RANDBIT_MULT)
 	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)


### PR DESCRIPTION
A Pépin test picks a random nonzero residue shift unless the user passes `-shift 0`, and the Gerbicz check is on by default — but the two did not work together. The run failed its first G-check (iteration 1000000 by default), the assignment was dropped from the workfile with no result, and any attempt to resume from the leftover checkpoint aborted on

```c
ASSERT(RES_SHIFT == 0ull, "Shifted residues unsupported for Pépin test with Gerbicz check!")
```

Worth noting that assertion sat in the **resume** branch of `if(ilo == 0)`, so it never prevented the combination from being *started* — it only turned "wrong check" into "cannot resume". A from-scratch Pépin run picked a random nonzero shift and proceeded straight past it.

## Three defects

**1. The `prp_mult` gate applied the Pépin random-bit doubling to every array the carry routines process.** That doubling is the multiplicative partner of the `shift = 2*shift + randbit` update, so it belongs to the shift-carrying main residue chain alone. Applying it to the G-check product update and to the check's L-fold squaring chain — both called with `update_shift = FALSE` — multiplied those by unaccounted-for powers of 2. Fixed with a `FERMAT_RANDBIT_MULT` global, set from `update_shift` on entry to `fermat_mod_square()` and required in the Fermat clause of the gate.

**2. The correction factor `2^{s_L}` is the Mersenne answer.** Writing `x_i` for the shifted residue after *i* squarings, `u_i = 3^(2^i) (mod Fm)` for the true one, `s_i` for `RES_SHIFT` and `q_i = [s_i >= p/2]` for `RES_SIGN`:

```
x_i = (-1)^q_[i-1] . u_i . 2^s_i
```

so the check product `b = 3 . prod_k x_[kL]` satisfies

```
b = 3 . d^(2^L) . 2^E,    E = sum_k (s_[kL] + q_[kL-1].p)   (mod 2p)
```

since `2^(2^L) == 1 (mod Fm)` for `L >= m+1` kills the powers of 2 the d-chain squaring would otherwise carry. In the **Mersenne** case all `q = 0` and `s_[kL] = 2^L . s_[(k-1)L] (mod p)`, so that sum telescopes to the single term `s_L` — which is what the code computed, **for both moduli**. The Fermat-mod shift update is "mod-double *and add a random bit*", so it does not telescope, and `E` genuinely changes from one check interval to the next. `GCHECK_SHIFT` now maintains that running `(mod 2p)` sum, folding sign flips in via `-1 == 2^p (mod Fm)`, and splits it at check time into a negacyclic rotation plus an explicit negation when it lands in the upper half.

This also retires the `filegrep(STATFILE, "ITERS_BETWEEN_GCHECK_UPDATES", ...)` workaround that recovered the old (wrong) correction by parsing the logfile, and the logfile line that existed only to feed it. That hack left `itmp64` unset if the grep missed.

**3. Restart safety.** The G-check product is not a shifted residue, but `convert_res_FP_bytewise` / `convert_res_bytewise_FP` applied `RES_SHIFT` and `RES_SIGN` to it from the globals. For Fermat-mod the two are **not** mutually inverse — write rotates by `(p - shift)` and conditionally negates, read rotates by `shift`, composing to multiplication by `2^p == -1` — so `b[]` could come back from a savefile negated. The shift is now suppressed for the `b[]` and `d[]` conversions in the Fermat-mod case only. Mersenne-mod keeps its current behaviour: there the rotation is cyclic and cancels between the two sides of the comparison, and changing it would alter every in-progress PRP savefile.

## Savefile compatibility

`GCHECK_SHIFT` is already an 8-byte field at a fixed offset, and every existing Fermat savefile has `RES_SHIFT == 0` and `GCHECK_SHIFT == 0`, for which an accumulator starting from 0 stays 0. The Mersenne-mod semantics of the field are untouched.

## Verification (AVX2, gcc 16.1.1)

* **F16** at scaled intervals (L = 100, check every 10000), shifts 0 / 1 / 12345 / 33333 / 65432 / 65535: **6 of 6 G-checks pass in every case**, and the final `Res64,Res35m1,Res36m1 = 40ABB0C5BFF05CB5,173595305,65390296136` matches an independent GMP Pépin computation (and a separate pure-Python one). Before this change every nonzero shift failed the first check; shift 0 is bit-identical to before.
* **F20 at the production intervals** (L = 1000, check at 1000000), shift 654321: `At iteration 1000000, shift = 630647: Gerbicz check passed`, same final residue as the shift-0 run, matching a 53-minute GMP run of the same exponent. Before: `Gerbicz check iteration 1000000 failed!` and the assignment abandoned.
* **Restart coverage**: kill/resume across a checkpoint at iteration 24000 with shift 12345, and a forced G-check failure at 30000 (rollback to the `.G` savefile, which mod-doubles `RES_SHIFT`). Both recover and finish with the correct residue; both abort on the assertion before this change.
* **No-regression**: `-s tt` gives 13K=`E3BC90B0E652C7C0` 14K=`DB8E39C67F8CCA0A` 15K=`B3C5A1C03E26BB17`; a Mersenne 3-PRP of M86243 with G-checks produces **byte-identical** `p86243` and `p86243.G` savefiles and an identical statfile (bar the deleted log line); Fermat self-tests F14–F17 over several FFT lengths are unchanged at shift 0 and give the same residues at shift 12345. Compiles clean at nosimd/avx/avx2/avx512.

## Relationship to issue #99

Addresses the Fermat-number half of #99: a Pépin test with the Gerbicz check no longer requires `-shift 0`. The FFT-length half of that issue (moduli larger than 2^32 bits) is not touched here, so this deliberately does **not** say "fixes #99".

**This must land together with #190.** Measured on `main` + this PR alone: the Gerbicz check passes, but the run still reports a genuine Fermat prime as *composite* at 5 of 6 nonzero shifts and still returns the +2-wrong residue — strictly worse than the current behaviour of refusing to run. `main` + #190 alone still fails the first G-check. Together: 13/13 correct prime verdicts across shifts spanning `RES_SIGN` flips, against 1/13 on `main`.

One limitation neither PR removes: a nonzero shift still fails at iteration 0 when the leading FFT radix is < 16, which the stock `fermat.cfg` selects at 4K (`8 16 16`). That is #119 / PR #146.

## Relationship to other PRs

* **Supersedes #122**, which addressed the same failure by forcing `RES_SHIFT = 0` for this combination. This removes the restriction instead, so nonzero shifts work rather than being disallowed. #122 has been closed.
* No overlapping hunks with **#190**. This change actually *removes* two `mi64_shlc(sign_flip=1)` calls from the G-check path, reducing exposure to the bug #190 fixes.

## Deliberately left alone

* `mi64_shlc_bits_align` is still cyclic-only. With the G-check path no longer calling it in the negacyclic case that is a diagnostic gap rather than a correctness one, but it is still a gap.
* Fermat PRP-CF runs hit a pre-existing, unrelated `Suyama_CF_PRP` assertion ("requires p-1 mod-squarings!") that reproduces on unmodified main. Separate problem, not addressed here.

