### PR TITLE
makemake.sh: pass $WORDS to every Mfactor TU, not just factor.o

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
                 echo -e "\nMfactor $word\n"
                 bash -e -o pipefail -- makemake.sh mfac $word $mode || true
                 (
-                    cd obj_mfac${mode:+_$mode}
+                    cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
@@ -112,7 +112,7 @@ jobs:
                 echo -e "\nMfactor $word\n"
                 bash -e -o pipefail -- makemake.sh mfac $word $mode || true
                 (
-                    cd obj_mfac${mode:+_$mode}
+                    cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
@@ -195,7 +195,7 @@ jobs:
                 echo -e "\nMfactor $word\n"
                 bash -e -o pipefail -- makemake.sh mfac $word $mode || true
                 (
-                    cd obj_mfac${mode:+_$mode}
+                    cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
                 )
@@ -367,7 +367,7 @@ jobs:
                 echo -e "\nMfactor $word\n"
                 bash -e -o pipefail -- makemake.sh mfac $word $mode || true
                 (
-                    cd obj_mfac${mode:+_$mode}
+                    cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
@@ -421,7 +421,7 @@ jobs:
                 echo -e "\nMfactor $word\n"
                 bash -e -o pipefail -- makemake.sh mfac $word $mode || true
                 (
-                    cd obj_mfac${mode:+_$mode}
+                    cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
@@ -548,7 +548,7 @@ jobs:
                 echo -e "\nMfactor $word\n"
                 bash -e -o pipefail -- makemake.sh mfac $word $mode || true
                 (
-                    cd obj_mfac${mode:+_$mode}
+                    cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
                     mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
                 (
                     cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
-                    mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
@@ -114,7 +113,6 @@ jobs:
                 (
                     cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
-                    mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
@@ -197,7 +195,6 @@ jobs:
                 (
                     cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
-                    mv -v build.log build_${word}.log
                 )
             done
         done
@@ -369,7 +366,6 @@ jobs:
                 (
                     cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
-                    mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
@@ -423,7 +419,6 @@ jobs:
                 (
                     cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
-                    mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done
@@ -550,7 +545,6 @@ jobs:
                 (
                     cd obj_mfac${word:+_$word}${mode:+_$mode}
                     make clean
-                    mv -v build.log build_${word}.log
                     [[ ! -x Mfactor${word:+_$word} ]] || ./Mfactor${word:+_$word} -h
                 )
             done

--- a/makemake.sh
+++ b/makemake.sh
@@ -223,10 +223,22 @@ if [[ -n $WORDS ]]; then
 		fi
 		Mfactor+="_$arg"
 		TARGET=$Mfactor
+		# The word-size macro is a property of the whole build, not just factor.c: factor.h keys
+		# PIPELINE_MUL192 and the TRYQ default off it, and Mdata.h keys MAX_BITS_P|Q off it. Pass it
+		# to every translation unit (see WORDS_TU below), and give each word-variant its own object
+		# directory so a mode switch cannot silently relink objects built for a different variant.
+		DIR+="_$arg"
 	else
 		echo "Error: The argument '$WORDS' requires 'mfac'." >&2
 		exit 1
 	fi
+fi
+
+# Macros that must be seen by *every* Mfactor translation unit, not just factor.c. Mdata.h rejects
+# the PxWORD/NWORD macros unless FACTOR_STANDALONE is also set, so the two travel together.
+WORDS_TU=''
+if [[ -n $WORDS ]]; then
+	WORDS_TU="$WORDS -DFACTOR_STANDALONE"
 fi
 
 if [[ $OSTYPE == msys || $OSTYPE == cygwin ]]; then
@@ -552,7 +564,7 @@ $Mfactor: \$(OBJS_MFAC)
 factor.o: ../src/factor.c
 	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS -DTRYQ=4 \$<
 %.o: ../src/%.c
-	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} \$<
+	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} $WORDS_TU \$<
 clean:
 	rm -f \$(OBJS) \$(OBJS_MFAC)
 

--- a/makemake.sh
+++ b/makemake.sh
@@ -224,21 +224,15 @@ if [[ -n $WORDS ]]; then
 		Mfactor+="_$arg"
 		TARGET=$Mfactor
 		# The word-size macro is a property of the whole build, not just factor.c: factor.h keys
-		# PIPELINE_MUL192 and the TRYQ default off it, and Mdata.h keys MAX_BITS_P|Q off it. Pass it
-		# to every translation unit (see WORDS_TU below), and give each word-variant its own object
-		# directory so a mode switch cannot silently relink objects built for a different variant.
+		# PIPELINE_MUL192 and the TRYQ default off it, and Mdata.h keys MAX_BITS_P|Q off it. It is
+		# passed to every translation unit by the %.o rule below - together with FACTOR_STANDALONE,
+		# without which Mdata.h rejects the PxWORD/NWORD macros - and each word-variant gets its own
+		# object directory so a mode switch cannot silently relink objects built for another variant.
 		DIR+="_$arg"
 	else
 		echo "Error: The argument '$WORDS' requires 'mfac'." >&2
 		exit 1
 	fi
-fi
-
-# Macros that must be seen by *every* Mfactor translation unit, not just factor.c. Mdata.h rejects
-# the PxWORD/NWORD macros unless FACTOR_STANDALONE is also set, so the two travel together.
-WORDS_TU=''
-if [[ -n $WORDS ]]; then
-	WORDS_TU="$WORDS -DFACTOR_STANDALONE"
 fi
 
 if [[ $OSTYPE == msys || $OSTYPE == cygwin ]]; then
@@ -564,7 +558,7 @@ $Mfactor: \$(OBJS_MFAC)
 factor.o: ../src/factor.c
 	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS -DTRYQ=4 \$<
 %.o: ../src/%.c
-	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} $WORDS_TU \$<
+	\$(CC) \$(CFLAGS) \$(CPPFLAGS) -c ${ARGS[@]} ${WORDS:+$WORDS -DFACTOR_STANDALONE} \$<
 clean:
 	rm -f \$(OBJS) \$(OBJS_MFAC)
 


### PR DESCRIPTION
> **Merge order: #167 → #215 → this.** Both are correctness fixes to code this change makes reachable. Details at the bottom.

`makemake.sh` passes `$WORDS` only to the `factor.o` rule, not to the generic `%.o` rule:

```make
552: factor.o: ../src/factor.c
553:    $(CC) $(CFLAGS) $(CPPFLAGS) -c ${ARGS[@]} -DFACTOR_STANDALONE $WORDS -DTRYQ=4 $<
554: %.o: ../src/%.c
555:    $(CC) $(CFLAGS) $(CPPFLAGS) -c ${ARGS[@]} $<          <-- no $WORDS
```

So for `mfac 3word avx`, `factor.o` sees `-DFACTOR_STANDALONE -DP3WORD -DTRYQ=4` and **every other translation unit sees none of the three**. `factor.h` keys several decisions off those macros, so `factor.c` and the `twopmodq*.c` routines it calls disagree about which configuration they are part of.

## What that costs today

`factor.h:47-51` sets `PIPELINE_MUL192` only `#ifdef P3WORD`. Since the `twopmodq*.c` TUs never see `P3WORD`, **all pipelined 192-bit `_q4`/`_q8` paths are dead in every shipped build.** Confirmed by preprocessing: `twopmodq192.c` with the real flags contains `__fprod` 0 times; 72 times with `-DP3WORD` added.

`factor_test.h:309-312` then prints `PIPELINE_MUL192 = 1` in the startup banner — **the binary's self-description is false.**

Two further disagreements, both benign today but recorded in the audit: `TRYQ` resolves to 8 in the TUs versus 4 in `factor.c` (`factor.h:53` recomputes it, and `factor.o` is additionally hardwired to 4), and `MAX_BITS_P|Q` to 57/96 versus 178/192. `factor.h:44` defaults to `P1WORD` when nothing is defined, which is silently what every `twopmodq*.c` TU gets regardless of the word-variant being built.

## Why the obvious objection turns out to be backwards

The natural worry is that switching `$WORDS` on activates a large body of pipelined code that has never been compiled into a shipped binary — and in this codebase, never-compiled code has repeatedly turned out to be broken (#213 retires an entire configuration that never compiled on any compiler generation).

**Measured, the opposite holds here: the pipelined macros are the correct ones and the scalar macros that ship today are wrong.**

`SQR_LOHI192` — the macro used by the shipped `PIPELINE_MUL192`-off path — drops a cross-term carry and is wrong for **25% of full-width 192-bit inputs**, in both its portable-C and x86_64-asm bodies. Cross-checked against GMP and against the in-tree `MULH192(x,x)` over 2.4M operand sets: 150,268 mismatches for the scalar macro, **0** for `SQR_LOHI192_q4`/`_q8`.

The consequence is not theoretical. Two genuine Mersenne factors were constructed with 64-bit `k` (`q` = 190 and 188 bits):

| build | `twopmodq192_q4` | `_q8` |
|---|---|---|
| stock `mfac 3word` | `0x0` | `0x00` |
| same, `-DPIPELINE_MUL192=1` | `0xF` | `0xFF` |

So deleting the dead pipelined code — the other candidate resolution — would have removed the only exact 192-bit squaring in the tree and cemented the bug.

**That root cause is #167**, arrived at independently here. This PR does not fix it; it removes the second, separate path to the same symptom.

## The change

`makemake.sh` only, +13/−1:

* the generic `%.o` rule gains `$WORDS -DFACTOR_STANDALONE` (the latter because `Mdata.h` carries `#error PxWORD requires FACTOR_STANDALONE`, which is what blocks the naive one-line version);
* the objdir name gains the word-variant. This is not cosmetic: `makemake.sh mfac 1word` followed by `mfac 3word` currently reuse the same `obj_mfac_<mode>/`, and make's timestamp check silently relinks the *1word* `factor.o` while reporting success. Once every object is variant-dependent, that stale-relink trap turns from a testing annoyance into a correctness hazard.

Verified across 15 build combinations: all build clean with identical warning profiles and pass `test_fac()`.

## Merge order

* **After #167** — it fixes `SQR_LOHI192`. Merging this first would leave the scalar path wrong *and* switch on the pipelined one, which is not harmful but muddies attribution.
* **After #215** — `MULH192_q4`/`_q8` are built on `MULH192_FAST`, whose approximate body is live for non-`YES_ASM` targets. (Note: on x86_64-gcc `MULH192_FAST` is exact in every flag combination tried, so an earlier claim that this configuration reaches the approximation on this platform does not reproduce. The constraint stands for other targets.)

## Also found, deliberately not fixed here

`-DTRYQ=8` does not compile on `main`: three "incompatible type for argument 1 of `twopmodq192_q8`" errors from `factor_test.h:2126/2226/2342`, where `uint192` is passed by value to a `uint64*` parameter. The sibling `TRYQ==4` arms already do it correctly and #215 adds a fourth correct one, so this is a fix rather than a deletion — but low priority, since `factor.o` is hardwired to `-DTRYQ=4` and the path is unreachable through the supported build.
