### PR TITLE
test_fac: cover twopmodq192_q4 above 128 bits with constructed vectors

### DIFF
--- a/src/fac_test_dat192.h
+++ b/src/fac_test_dat192.h
@@ -122,4 +122,67 @@
 		{0,0ull,0ull,0ull}
 	};
 
+#if(defined(P3WORD) || defined(P4WORD))	// only the 192-bit modpow consumes these
+	/* Constructed (p,k) vectors giving q = 2.k.p+1 > 2^128, for the q-pipelined twopmodq192_q4/_q8.
+
+	Those routines take a *64-bit* k together with a 192-bit exponent p, and form q themselves. No
+	catalogued Mersenne factor can reach q > 2^128 under that signature: q = 2.k.p+1 with k < 2^64
+	forces p > 2^64, and no known Mersenne exponent is anywhere near that big. (That is also why the
+	fac160[]/fac192[] loops in factor_test.h guard their q4 call on k < 2^64 and, correctly, skip
+	every one of their entries.) So the only way to exercise the routines above 2^128 - the size
+	range they exist for - is to construct vectors, which is what these are.
+
+	Each entry is one exponent p plus the four k of a single q4/q8 call. For the lanes flagged in
+	.res, p is prime, q = 2.k.p+1 is prime, and 2^p == 1 (mod q), i.e. q genuinely divides 2^p-1;
+	the remaining lanes are verified non-factors, so .res is a non-trivial mask and lane crosstalk
+	cannot hide. Several non-factor lanes carry k near its 64-bit ceiling, which drives q to just
+	under 2^192 and exercises the full-width q = 2.k.p+1 formation.
+
+	Only a lane whose q really is a factor can detect a wrong answer: the routines return one
+	divisibility bit per lane, so on a non-factor q a corrupted residue still reads "not a factor".
+	Measured on a build independently shown to mishandle 28 of 144 genuine factors above 2^128, a
+	random-k differential test against an arbitrary-precision oracle flagged 5 of 16000 lanes; these
+	vectors flag 19% of theirs. Hence genuine factors, not random q.
+
+	Construction: pick a prime p of the wanted size, then the smallest k for which q = 2.k.p+1 is
+	prime and 2^p == 1 (mod q). That last condition holds with probability 1/(2k), so the search is
+	only tractable for small k - which is why every p here is within a few bits of its q, and why
+	there is no entry with both a small p and a large k. Every lane was re-verified with GMP. */
+	struct testFac192p {
+		uint64 p2,p1,p0;	// exponent p, 192 bits, low word last
+		uint64 k[4];		// the four trial factors of one q4 call: q_j = 2.k_j.p + 1
+		uint32 res;			// expected q4 return: bit j set iff q_j divides 2^p-1
+	};
+
+	static const struct testFac192p fac192p[] =
+	{
+		{0x0000000000000000ull,0x00213a5cfb4ffaf1ull,0x7fc498a800cedc8full, {                8593ull,15214548644798751000ull,12775845238650594594ull,13075755774346653527ull}, 0x1},	// p 118 bits, q 132/182/182/182 bits
+		{0x0000000000000000ull,0x008fe5d795b4c471ull,0x6d71034ef4524abfull, { 2763321911299042568ull,                3317ull,16679543456978578366ull,14224913552053546146ull}, 0x2},	// p 120 bits, q 182/132/185/184 bits
+		{0x0000000000000000ull,0x0431c9000e2a4606ull,0xd8bfcb23808af8c1ull, {10707202604359032825ull, 4870861780386308287ull,                  72ull, 1324479603544283704ull}, 0x4},	// p 123 bits, q 187/186/130/184 bits
+		{0x0000000000000000ull,0x1700d2cdc47834efull,0x882ea54142645801ull, {15783913230357963913ull,12847826680588602063ull,12904419274851956850ull,                   7ull}, 0x8},	// p 125 bits, q 190/190/190/129 bits
+		{0x0000000000000000ull,0x518bbe5cd5cd507cull,0x692ede0d65b6241dull, {                1488ull, 5759559193453849237ull,15687860524863433765ull, 3693094640594910208ull}, 0x1},	// p 127 bits, q 138/190/192/190 bits
+		{0x0000000000000000ull,0xc9fa05cfdebfd1afull,0x8ce952aa4839afbdull, { 3900782993366110328ull,                 395ull, 2206542630629832720ull, 9303172449162996934ull}, 0x2},	// p 128 bits, q 191/138/190/192 bits
+		{0x0000000000000000ull,0xd2c0c7af7db202adull,0xa9748a1b0b753ee1ull, { 8505764787670883816ull, 8118806472317829564ull,                 267ull, 8060509614542063432ull}, 0x4},	// p 128 bits, q 192/192/137/192 bits
+		{0x0000000000000003ull,0xe0ddc3f674698a89ull,0xd8cf1d4cefe6151full, { 2237421913063066265ull, 1340132015343656597ull,  930454171901463158ull,                 209ull}, 0x8},	// p 130 bits, q 192/192/191/139 bits
+		{0x000000000000003full,0x9f86281a4026e6f7ull,0x8cb149419b2d9c2full, {                  37ull,   96135231250510595ull,   76867814451075485ull,   88800288255623438ull}, 0x1},	// p 134 bits, q 141/192/192/192 bits
+		{0x00000000000003d4ull,0x29a4c79a1055a822ull,0x84d7046e5c9d59a9ull, {    1060076026885497ull,                  12ull,    3653361580340800ull,    8998231113037378ull}, 0x2},	// p 138 bits, q 189/143/191/192 bits
+		{0x00000000000026e3ull,0x10ab923c90aaf476ull,0x2423c06e3f12c2cfull, {     475711864557646ull,     856067926826099ull,                   4ull,     591975508701151ull}, 0x4},	// p 142 bits, q 192/192/145/192 bits
+		{0x0000000000075d26ull,0x20e30535c1a92b94ull,0x8ca3bd247109410dull, {      12957052590606ull,      15022157530405ull,      14212087166057ull,               12420ull}, 0x8},	// p 147 bits, q 192/192/192/162 bits
+		{0x0000000000f49ea5ull,0xb1e494212cb76026ull,0x2ddc435b1584a115ull, {                   3ull,        339195661178ull,        345270076518ull,        389580843610ull}, 0x1},	// p 152 bits, q 155/192/192/192 bits
+		{0x0000000010b355b6ull,0x93a9035cf075506full,0x6d238fa396db6159ull, {          4977490711ull,                1611ull,         18808043090ull,         30858213833ull}, 0x2},	// p 157 bits, q 190/168/192/192 bits
+		{0x00000002ad400816ull,0x5cb3dab219806970ull,0xb380b4ca53beb057ull, {           654612475ull,           230478869ull,               29484ull,           490678292ull}, 0x4},	// p 162 bits, q 192/191/178/192 bits
+		{0x00000044774cf897ull,0xc53d0423917bba5bull,0xb01c3286f1703141ull, {            24992275ull,            26461495ull,             1185738ull,                 911ull}, 0x8},	// p 167 bits, q 192/192/188/177 bits
+		{0x00000e359624b691ull,0x01ce6d2edef1dc07ull,0x1f4c5667cf7e7e93ull, {               22624ull,              365880ull,              558918ull,              481967ull}, 0x1},	// p 172 bits, q 188/192/192/192 bits
+		{0x0001ae2fbb528809ull,0xbdef6b6ed0d0739full,0x3e0ac4b267758513ull, {                2154ull,                   1ull,               10670ull,               19152ull}, 0x2},	// p 177 bits, q 189/178/192/192 bits
+		{0x00139e67d602a053ull,0xec7efb8187dd52d0ull,0x61299dd9913dcf4bull, {                1651ull,                1030ull,                 117ull,                 602ull}, 0x4},	// p 181 bits, q 192/192/189/191 bits
+		{0x01a68f7e96e1ab2eull,0xba58038b9102f259ull,0x4273ea77f1c98e57ull, {                  14ull,                  61ull,                  63ull,                   5ull}, 0x8},	// p 185 bits, q 190/192/192/189 bits
+		{0x0ea3146a17417a61ull,0x0146d76d5e6c30a2ull,0xf48afcb93f22a1e5ull, {                   3ull,                   3ull,                   3ull,                   3ull}, 0xf},	// p 188 bits, q 191/191/191/191 bits
+		{0x330ff598c0b907a2ull,0x0ac9447d0ec04cbdull,0xd75814e2362eb6cbull, {                   1ull,                   1ull,                   1ull,                   1ull}, 0xf},	// p 190 bits, q 191/191/191/191 bits
+		{0x429cd78c5dfb44b0ull,0xbd3d719d6629dd42ull,0xbe7cedeeba47d14full, {                   1ull,                   1ull,                   1ull,                   1ull}, 0xf},	// p 191 bits, q 192/192/192/192 bits
+		{0x6213754c091bd1adull,0x386dc79f173faeb4ull,0x2c491d550c8ca76bull, {                   1ull,                   1ull,                   1ull,                   1ull}, 0xf},	// p 191 bits, q 192/192/192/192 bits
+		{0ull,0ull,0ull, {0ull,0ull,0ull,0ull}, 0}
+	};
+
+#endif	/* #if(defined(P3WORD) || defined(P4WORD)) */
+
 #endif	/* #ifndef fac_test_dat192_included */

--- a/src/factor_test.h
+++ b/src/factor_test.h
@@ -2202,6 +2202,70 @@ if((q128.d1 >> 14) == 0) {
 	#endif
 	}
 
+	/* Test factors > 128 bits using the 192-bit modmul routines.
+
+	This is the only coverage twopmodq192_q4/_q8 get above 2^128, which is the size range the
+	192-bit modpow exists for. The fac128x2 loop just above tops out at q = 127 bits; the fac160
+	and fac192 loops just below contribute nothing, because those routines take a 64-bit k and
+	every fac160/fac192 entry has k >= 2^64. Closing the gap needs constructed vectors - see the
+	fac192p[] comment in fac_test_dat192.h for why no catalogued factor can supply one, and for
+	why the expected result is a per-lane mask rather than the usual all-ones.
+
+	The regimes this reaches and the fac128x2 loop does not: q with a nonzero top word throughout
+	the modmul, exponents p that are themselves multiword (both the pshift.d1 and the pshift.d2
+	arms of the leading-bit extraction above are otherwise never taken - fac128x2's p is 128-bit
+	and everything else here is 64-bit), and q within a few bits of the 2^192 ceiling. */
+#ifdef FACTOR_STANDALONE
+	printf("Testing >128-bit factors using the 192-bit modmul routines...\n");
+#endif
+	for(i = 0; fac192p[i].res != 0; i++)
+	{
+		p192.d2 = fac192p[i].p2;	p192.d1 = fac192p[i].p1;	p192.d0 = fac192p[i].p0;
+		ADD192(p192, p192, two_p192);
+
+		/* Cross-check each lane that is supposed to be a genuine factor against the scalar
+		192-bit modpow, which takes q directly rather than deriving it from k: */
+		for(j = 0; j < 4; j++)
+		{
+			if(((fac192p[i].res >> j) & 1) == 0)	continue;
+			ASSERT(!mi64_mul_scalar((uint64*)&two_p192, fac192p[i].k[j], (uint64*)&q192, 3), "q = 2.k.p+1 must be < 2^192!");
+			q192.d0 += 1;	/* 2.k.p is even, so this cannot carry */
+			res192 = twopmodq192(p192, q192);
+			if(!CMPEQ192(res192, ONE192))
+			{
+				fprintf(stderr,"ERROR: twopmodq192( %s, %s ) returns non-unity result %s\n",
+						&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+						&cbuf1[convert_uint192_base10_char(cbuf1, q192)],
+						&cbuf2[convert_uint192_base10_char(cbuf2, res192)]);
+				ASSERT(0,"0");
+			}
+		}
+
+	#if(TRYQ == 4)
+		res64 = twopmodq192_q4((uint64*)&p192, fac192p[i].k[0],fac192p[i].k[1],fac192p[i].k[2],fac192p[i].k[3]);
+		if(res64 != (uint64)fac192p[i].res)
+		{
+			fprintf(stderr,"ERROR: twopmodq192_q4( %s, k = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 " ) returns %#1X, expected %#1X.\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					fac192p[i].k[0],fac192p[i].k[1],fac192p[i].k[2],fac192p[i].k[3],
+					(uint32)res64, fac192p[i].res);
+			ASSERT(0,"0");
+		}
+	#elif(TRYQ == 8)
+		/* Feed the same four k twice, so the expected mask is simply doubled up: */
+		res64 = twopmodq192_q8((uint64*)&p192, fac192p[i].k[0],fac192p[i].k[1],fac192p[i].k[2],fac192p[i].k[3]
+											 , fac192p[i].k[0],fac192p[i].k[1],fac192p[i].k[2],fac192p[i].k[3]);
+		if(res64 != (uint64)(fac192p[i].res + (fac192p[i].res << 4)))
+		{
+			fprintf(stderr,"ERROR: twopmodq192_q8( %s, k = %" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 " x2 ) returns %#2X, expected %#2X.\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					fac192p[i].k[0],fac192p[i].k[1],fac192p[i].k[2],fac192p[i].k[3],
+					(uint32)res64, fac192p[i].res + (fac192p[i].res << 4));
+			ASSERT(0,"0");
+		}
+	#endif
+	}
+
 	/* Test 160-bit factors using the 160 and 192-bit modmul routines */
 #ifdef FACTOR_STANDALONE
 	printf("Testing 160-bit factors using 160 and 192-bit modmul routines...\n");

--- a/src/factor_test.h
+++ b/src/factor_test.h
@@ -2060,6 +2060,74 @@ if((q128.d1 >> 14) == 0) {
 
 #if(defined(P3WORD) || defined(P4WORD))
 
+	/* Test <= 96-bit factors using the 192-bit modmul routines.
+	This is NOT redundant with the 96- and 128-bit testing above, and it is the only coverage the
+	192-bit q-pipelined routines get below 2^90. A P3WORD build of factor.c feeds *every* candidate
+	to twopmodq192_q4 (factor.c:3599), including sub-2^64 ones - the runtime bit-length narrowing
+	which would hand those off to a narrower modpow is commented out at factor.c:3667-3671 - so
+	twopmodq192_q4 has to be correct for small q, not just for q near 2^128.
+	Before this loop existed the only twopmodq192_q4 coverage in test_fac() was the fac128x2 loop
+	below (q = 90...127 bits); the fac160/fac192 loops further down cannot supply any, since all of
+	their entries have k >= 2^64 and those routines take a 64-bit k. The carry-layer approximation
+	that MULH192_FAST used to apply on every non-x86_64-GCC platform lost 1458 of 1742 known
+	Mersenne factors that way, and passed the self-test unnoticed. fac96[] spans q = 60...96 bits,
+	with 158 entries at 65-66 bits, which is exactly where such small-q breakage shows up first;
+	build with -DPIPELINE_MUL192=1 to route these through the q-pipelined MUL macros. */
+#ifdef FACTOR_STANDALONE
+	printf("Testing 96-bit factors using the 192-bit modmul routines...\n");
+#endif
+	for(i = 0; fac96[i].p != 0; i++)
+	{
+		p64 = fac96[i].p;
+		p192.d0 = p64;	p192.d1 = p192.d2 = 0;		ADD192(p192, p192, two_p192);
+		q192.d2 = 0;	q192.d1 = (uint64)fac96[i].d1;	q192.d0 = fac96[i].d0;
+
+		// Compute k = (q-1)/2p, while verifying that q%2p = 1:
+		mi64_div((uint64*)&q192, (uint64*)&two_p192, 3,3, (uint64*)&x192, (uint64*)&res192);	// x192 contains k
+		if(!CMPEQ192(res192, ONE192))
+		{
+			fprintf(stderr,"ERROR : (p, q) = ( %s, %s ) : q mod (2p) = %s != 1!\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)],
+					&cbuf2[convert_uint192_base10_char(cbuf2, res192)]);
+			ASSERT(0,"0");
+		}
+		/* A handful of the fac96 entries have p > 2^32 and k >= 2^64; the q-pipelined routines
+		take a 64-bit k, so those simply are not expressible as inputs to them: */
+		if(x192.d2 != 0 || x192.d1 != 0)
+			continue;
+
+		res192 = twopmodq192(p192, q192);
+		if(!CMPEQ192(res192, ONE192))
+		{
+			fprintf(stderr,"ERROR: twopmodq192( %s, %s ) returns non-unity result %s\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)],
+					&cbuf2[convert_uint192_base10_char(cbuf2, res192)]);
+			ASSERT(0,"0");
+		}
+
+	#if(TRYQ == 4)
+		res64 = twopmodq192_q4((uint64*)&p192,x192.d0,x192.d0,x192.d0,x192.d0);
+		if(res64 != 15)
+		{
+			fprintf(stderr,"ERROR: twopmodq192_q4( %s, %s x 4 ) failed to find factor, res = %#1X.\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)], (uint32)res64);
+			ASSERT(0,"0");
+		}
+	#elif(TRYQ == 8)
+		res64 = twopmodq192_q8((uint64*)&p192,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0,x192.d0);
+		if(res64 != 255)
+		{
+			fprintf(stderr,"ERROR: twopmodq192_q8( %s, %s x 8 ) failed to find factor, res = %#2X.\n",
+					&cbuf0[convert_uint192_base10_char(cbuf0, p192)],
+					&cbuf1[convert_uint192_base10_char(cbuf1, q192)], (uint32)res64);
+			ASSERT(0,"0");
+		}
+	#endif
+	}
+
 	/* Test 128-bit factors using the 160 and 192-bit modmul routines */
 #ifdef FACTOR_STANDALONE
 	printf("Testing 128x2-bit factors using 160 and 192-bit modmul routines...\n");

--- a/src/imul_macro1.h
+++ b/src/imul_macro1.h
@@ -7225,7 +7225,33 @@ simply add 1 to the approximate-computed carry to obtain the correct result.
 		__hi.d0 = __w3;	__hi.d1 = __w4;	__hi.d2 = __w5;\
     }
 
-  #if 0
+/* Jul 2026: Default MULH192_FAST to the exact MULH192 on *all* platforms, not just the x86_64-GCC
+one which already did so via the YES_ASM arm below.
+
+The carry-layer approximation in the #else arm is only sound under the assumption stated in the
+comment block above, that the discarded low-half bits are "presumably quasirandom". In the
+Montgomery-mul usage that assumption is false: Montgomery guarantees (q*lo) mod 2^192 = x^2 mod
+2^192, so the w2 layer of the product - the one whose carry-out the approximation predicts - is
+exactly (x^2 >> 128). For x < q < 2^96 that is pinned near zero, i.e. permanently adjacent to the
+carry boundary rather than uniform over it. Measured carry-mispredict rate is 4.9e-1 per call at
+q = 66 bits, 1.7e-1 at 70 bits, 1.3e-2 at 74 bits, falling to zero only above ~86 bits; feeding the
+known Mersenne factors in fac_test_dat{64,96,128}.h through twopmodq192_q4 recognises only 284 of
+1742 of them with the approximation, vs 1742 of 1742 with the exact macro.
+
+Small q really do reach here: factor.c's P3WORD arm has no runtime bit-length narrowing (the
+narrowing is commented out at factor.c:3667-3671), so 60-bit candidates go through the 192-bit
+modpow. And the precondition the comment above names - "should only ever be used with spot-checking
+enabled" - cannot be met: factor.c's SPOT_CHECK is hardwired to 0 and both its use sites guard
+nothing but a printf. (The one thing that keeps this latent today is that MULH192_q4/_q8 sit behind
+#if PIPELINE_MUL192 in twopmodq192.c, and makemake.sh passes -DP3WORD only to factor.c, so
+PIPELINE_MUL192 is 0 there and the exact MULH192 gets used. Anyone building with
+-DPIPELINE_MUL192=1 - which factor.h:48 documents as the P3WORD default - gets the bug.)
+
+Cost of exactness, measured with callgrind over the above known-factor workload: +9.3% instructions
+on the generic C compiled for x86_64, +5.5% on a real 32-bit x86 build; wall clock within noise.
+Build with -DMULH192_FAST_APPROX to get the old approximate version back for timing comparisons
+(on x86_64-with-YES_ASM that arm was already exact, so the opt-in is a no-op there). */
+  #ifndef MULH192_FAST_APPROX
 
     #define MULH192_FAST(__x, __y, __hi)	MULH192(__x, __y, __hi)
 
@@ -7371,6 +7397,13 @@ simply add 1 to the approximate-computed carry to obtain the correct result.
 		__hi.d0 = __w3;	__hi.d1 = __w4;	__hi.d2 = __w5;\
     }
 
+#endif
+
+/* The MUL_LOHI64_SUBROUTINE arm of the selection logic above has no #else, so configurations which
+define MUL_LOHI64_SUBROUTINE but not YES_ASM (SunC on x86_64) fall through it without defining
+MULH192_FAST at all. Supply the exact macro rather than leaving that a link-time-looking mystery: */
+#ifndef MULH192_FAST
+    #define MULH192_FAST(__x, __y, __hi)	MULH192(__x, __y, __hi)
 #endif
 
     /* 4-operand-pipelined version: */


### PR DESCRIPTION
> **Merge order: after #142 and #167.** This branch is cut on top of #215 (`fix-mulh192-exact`), so it will show that PR's commits until it lands. The new test **fails** without #142 and #167 — deliberately, see below.

`test_fac()` had **no coverage of `twopmodq192_q4` above 128 bits at all**. Every catalogued Mersenne factor in the 160/192-bit tables lands in the regime where the routine's approximations happen to be exact, so the existing entries could not distinguish a working implementation from a broken one.

Adds 24 constructed entries / 96 lanes / 36 genuine factors: p = 118–191 bits, factor-lane q = 129–192 bits, k spanning 1 … 2^63.9. Runtime cost ~1.0 ms, inside self-test noise.

## Why the coverage gap could not be closed with catalogued data

`q > 2^128` with `k < 2^64` forces `p > 2^64`, and no catalogued Mersenne factor has that. So the vectors have to be constructed.

Note the `k < 2^64` guards in `test_fac()` are **correct** and were left alone — 0 of 21 `fac160` and 0 of 5 `fac192` entries have `k < 2^64`, and `twopmodq192_q4` takes a 64-bit `k`, so "relaxing" them would mean passing a truncated value. It would also have produced a test that passes both with and without the bug, which is the failure mode this work exists to avoid.

## Why genuine factors rather than a cheaper differential

The obvious cheaper design — random `q`, compare against GMP `mpz_powm` — is **nearly blind here**, and that was measured rather than assumed. `twopmodq192_q4` returns one divisibility bit per lane, so on a non-factor `q` almost any corruption still reads "not a factor". On a build independently shown wrong on 28/144 genuine factors:

| probe | detection rate |
|---|---|
| random-`k` differential vs GMP | 5 of 16,000 lanes |
| genuine factors | 19% |

A ~600× sensitivity gap. The API itself is not the obstacle — `p_in` is a `uint64*` and three limbs are read, so `p > 2^64` is fully expressible. The real bound is probabilistic: `P(q | 2^p−1) = 1/(2k)`, so the search only terminates for small `k`, which forces `p` within a few bits of `q`. Large-`k` coverage comes from the non-factor lanes, with `q` pushed to just under 2^192.

## What it catches

Live in stock builds, with no `PIPELINE_MUL192` dependency — `test_fac()` calls `twopmodq192_q4` directly. On `makemake.sh mfac 3word`:

| tree | entries wrong |
|---|---|
| stock `main` | 9 / 24 |
| + #142 | 7 / 24 |
| + #142 + #167 | **0 / 24** |

Validated failing-direction-first four ways; runs A and B fail at *different* entries. A real `Mfactor_3word -m 127` aborts inside the new loop without the fixes and prints "self-tests completed successfully" with them.

**The two prerequisites, and what this adds to each:**

* **#142** (shift-by-64 UB) — its description argues the case on language grounds and notes it is "not triggered by current self-test data". The reachable region is in fact large: `j == 0` for every p with bit 127 set, i.e. 99.6% of exponents in [2^127, 2^128) get a wrong `lead8`. `MM127` and `F127` both escape by luck, which explains the silence.
* **#167** (`SQR_LOHI192` dropped carry) — 26 of 144 constructed genuine factors above 2^128 are silently not found by a stock `Mfactor_3word`, concentrated at q ≳ 184 bits.

## Deliberately orthogonal to #215

An approximate-`MULH192_FAST` build gets all 24 new entries right while missing 202/458 `fac96[]` factors — the control proving that build really is broken. So the approximation does **not** bite above 2^128, and this coverage is complementary to #215 rather than a duplicate of it.

Merges clean with all 8 related branches; both sides' lines verified present in each result.
