### PR TITLE
Free the known-factor mi64 vectors and the GMP gmp_one temporary (part of #96)

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -6411,6 +6411,9 @@ uint32 extract_known_factors(uint64 p, char *fac_start) {
 				}
 			}
 		}
+		// v21: convert_base10_char_mi64() allocs the fac[] vector and hands ownership to us, so release it
+		// before converting the next factor - otherwise each factor of each PRP-CF/p-1 assignment leaks:
+		free((void *)fac);	fac = 0x0;
 		cptr = char_addr+1;	// Advance 1-char past the current , or "
 	}
 	if(char_addr != 0x0) {
@@ -6559,8 +6562,9 @@ gcd_return:
 	clock2 = getRealTime(); tdiff = clock2 - clock1;
 	snprintf(cbuf,sizeof(cbuf),"Time for GCD =%s\n",get_time_str(tdiff));
 	mlucas_fprint(cbuf,1);
-	// Done with the GMP arrays:
-	mpz_clear(gmp_arr1); mpz_clear(gmp_arr2); mpz_clear(gmp_d); mpz_clear(gmp_r); mpz_clear(gmp_q);
+	// Done with the GMP arrays ... note gmp_one is inited via mpz_init_set_ui(), which unlike mpz_init()
+	// does allocate limb storage, thus needs clearing just like the rest:
+	mpz_clear(gmp_arr1); mpz_clear(gmp_arr2); mpz_clear(gmp_one); mpz_clear(gmp_d); mpz_clear(gmp_r); mpz_clear(gmp_q);
 	return retval;
 #endif	// INCLUDE_GMP ?
 }
@@ -6630,8 +6634,8 @@ void modinv(uint64 p, uint64 *vec1, uint64 *vec2, uint32 nlimb) {
 	for(i = inv_limbs; i < nlimb; i++) {
 		vec2[i] = 0ull;
 	}
-	// Done with the GMP arrays:
-	mpz_clear(gmp_arr1); mpz_clear(gmp_arr2);
+	// Done with the GMP arrays ... gmp_one needs clearing as well, cf. the comment in gcd():
+	mpz_clear(gmp_arr1); mpz_clear(gmp_arr2); mpz_clear(gmp_one);
 #endif	// INCLUDE_GMP ?
 }
 


### PR DESCRIPTION
Part of #96. Fixes the two leaks tdulcet reported from a Suyama (PRP-CF) test on 2026-07-18, which the earlier #105 did not touch — that PR fixed the `mers_mod_square.c` re-init leaks, and #96 was correctly reopened for these.

## The repro, since nothing in CI exercises this path

```sh
printf 'PRP=1,2,2063,-1,99,0,3,5,"4127,53639"\n' > worktodo.txt
ASAN_OPTIONS=detect_leaks=1 ./Mlucas
```
against a `nosimd` build with `-fsanitize=address,undefined`. Needs `-fft 1 -iters 100` first to get the cfg entry.

One trap worth recording: **Mlucas empties `worktodo.txt` on success**, so the file has to be rewritten between A/B runs. Skipping that produces a convincing false "clean".

## 1. `convert_base10_char_mi64` — 32 bytes / 2 objects

`convert_base10_char_mi64()` allocates the vector and hands ownership to the caller, freeing only on its own error path. `extract_known_factors()` never released it, so **every known factor of every PRP-CF or p-1 assignment leaked one vector**. tdulcet's 48-byte figure is the same leak with 3-limb factors.

The other four call sites are already correct — `factor.c:1134` frees at `:2521`, and the `factor_test.h` ones free locally. `util.c:172` would leak, but `print_mp_dec()` has no live caller.

## 2. `gmp_one` — 8 bytes / 1 object, and it is a pattern

`gcd()` inits `gmp_one` with `mpz_init_set_ui()` and omits it from the `mpz_clear` list. This is easy to miss because it is the *only* `mpz_t` in the file inited that way: plain `mpz_init()` has not allocated limb storage since GMP 5, but `mpz_init_set_ui()` does.

**The same omission is in `modinv()`**, so that is fixed here too.

Positive control that it is per-call rather than one-time: a p-1 run making two `gcd()` calls leaks 2 objects before the change and 0 after.

## Verification

Both leaks reproduced before and absent after, with residues byte-identical across the A/B pair. `makemake.sh nosimd` builds clean. Also checked that `fac` has no use after the new `free()` — all three reads precede it, and the one that persists the value (`mi64_set_eq` into `KNOWN_FACTORS`) copies rather than aliases.

## Why "part of #96" and not "fixes #96"

Two further reports on that thread, from 2026-07-16, bottom out in `InitializeSwiftDemangler` / `Symbolizer::LateInitialize` and `__ubsan::InitAsStandalone`. **I previously said on the issue that those were sanitizer-internal artifacts already eliminated by #78. The mechanism holds, but "already eliminated" was wrong, because #78 is still open** — I am posting a correction on the issue separately. #96 should close when #78 merges, not when this does.

## Found while here, deliberately not included

* `pm1.c:1163` — `buf` is `calloc`'d and never freed; `:2561` sets it to `0x0` alongside freeing `a_ptmp`. ~16 KB per stage-2 run, scaling with B2. Filed separately.
* `Mlucas.c:3341` — `res_SH(ci,n,...)` passes the FFT length where a limb count belongs, a heap over-read on every Mersenne PRP-CF run. Already fixed by **#183**, which is worth landing before anyone runs this path under a default ASan build; I had to pass `-fsanitize-recover=address` to get past it while producing the repro above.
