### PR TITLE
pm1: free the Stage-2 buf[] pointer array

### DIFF
--- a/src/pm1.c
+++ b/src/pm1.c
@@ -2558,7 +2558,10 @@ S2_RETURN:
 #endif
 ERR_RETURN:
 	// Free the memory:
-	free((void *)a_ptmp); a_ptmp = a = 0x0; buf = 0x0;
+	// v21: buf[] is its own calloc'ed array of pointers - freeing a_ptmp releases the vectors those
+	// pointers address, but not the pointer array itself, which was leaked on every Stage-2 call:
+	free((void *)a_ptmp); a_ptmp = a = 0x0;
+	free((void *)buf); buf = 0x0;
 	free((void *)b); b = 0x0;
 	free((void *)map); map = 0x0;
   #ifdef MULTITHREAD


### PR DESCRIPTION
`pm1_stage2()` allocates `buf[]` as its own array of `num_b*m` `double *` at `pm1.c:1163`, then fills it with addresses pointing into the single large `a_ptmp` allocation:

```c
buf = (double **)calloc(num_b*m,sizeof(double *));
for(i = 0; i < num_b*m; i++) {
    buf[i] = a + i*npad;
    ...
}
```

The cleanup at `ERR_RETURN` frees `a_ptmp` and then merely nulls `buf`:

```c
free((void *)a_ptmp); a_ptmp = a = 0x0; buf = 0x0;
```

That releases the vectors those pointers address, but not the pointer array itself. **Every Stage-2 call leaks it.**

## Size

`num_b*m` pointers, so it scales with B2 and the memory setting rather than being a fixed cost — on the order of 16 KB for a typical run and more for a large one. It accumulates per Stage-2 invocation, including runs that return early through `ERR_RETURN` after a modmul error.

## Why freeing here is safe on every path

`buf` is `static double **buf = 0x0;` at file scope (`pm1.c:1033`) and is reset to `0x0` in this same cleanup, so an error return taken before the `calloc` at `:1163` frees a null pointer. `ERR_RETURN` is the common exit — the banner comment at `:1140` establishes that every error return from that point on routes through it — so no path escapes the free.

The pointers *inside* `buf` must not be freed individually; they alias into `a_ptmp`, which is already freed on the line above.

## Verification

`makemake.sh nosimd` builds clean.

## Relationship to #96 and #225

Found while producing the LeakSanitizer repro for #96, but kept separate: this is a different subsystem and reproduces on **any** p-1 Stage-2 run, not just the PRP-CF cofactor path that #225 addresses. It is not one of the leaks reported on #96, so it does not affect that issue's closure either way.
