### PR TITLE
Include p == 2^32 in the too-large-exponent guard, so F32 gets the message instead of an assert

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -1152,7 +1152,7 @@ with the default #threads = 1 and affinity set to logical core 0, unless user ov
 
 	// Only check production-run exponents here - self-tests already have an iteration limit < 2^32:
 	if(TEST_TYPE == TEST_TYPE_PRIMALITY || TEST_TYPE == TEST_TYPE_PRP) {
-		if(p > (1ull << 32) && !INTERACT) {	// No point emitting the warning for self-tests since those are guaranteed to have (maxiter < MAX_SELFTEST_ITERS)
+		if(p >= (1ull << 32) && !INTERACT) {	// No point emitting the warning for self-tests since those are guaranteed to have (maxiter < MAX_SELFTEST_ITERS)
 			fprintf(stderr,"Full-length LL/PRP/Pepin tests on exponents this large not supported; will exit at self-test limit of %u.\n",MAX_SELFTEST_ITERS);
 			maxiter = MAX_SELFTEST_ITERS;
 		} else
@@ -2280,7 +2280,7 @@ READ_RESTART_FILE:
 		// For Fermats and cofactor-PRP tests of either modulus type, exit only after writing final-residue checkpoint file:
 		if( ihi == maxiter ) break;
 
-		if((TEST_TYPE == TEST_TYPE_PRIMALITY || TEST_TYPE == TEST_TYPE_PRP) && p > (1ull << 32) && ihi >= MAX_SELFTEST_ITERS) {
+		if((TEST_TYPE == TEST_TYPE_PRIMALITY || TEST_TYPE == TEST_TYPE_PRP) && p >= (1ull << 32) && ihi >= MAX_SELFTEST_ITERS) {
 			fprintf(stderr,"Full-length LL/PRP tests on exponents this large not supported; exiting at self-test limit of %u.\n",MAX_SELFTEST_ITERS);
 			exit(0);
 		}


### PR DESCRIPTION
Two guards cap a full-length test at the self-test iteration limit, and both compare strictly:

```c
Mlucas.c:1155   if(p > (1ull << 32) && !INTERACT) { ...; maxiter = MAX_SELFTEST_ITERS; }
                else maxiter = (uint32)p;

Mlucas.c:2283   if((TEST_TYPE == TEST_TYPE_PRIMALITY || TEST_TYPE == TEST_TYPE_PRP)
                   && p > (1ull << 32) && ihi >= MAX_SELFTEST_ITERS) { ...; exit(0); }
```

For a Fermat test of F*m* the exponent is `p = 2^m`, so **F32 gives `p = 2^32` exactly** — which falls through the first guard into `maxiter = (uint32)p`, truncating to **0**.

So instead of the intended message

> Full-length LL/PRP/Pepin tests on exponents this large not supported; will exit at self-test limit of …

the run dies on

```c
Mlucas.c:1802   ASSERT(maxiter > 0,"Require (uint32)maxiter > 0")
```

whose wording rather suggests the truncation was already on the author's mind.

## Why both guards

The second one has the same boundary and matters for the same input. With only the first fixed, `maxiter` would be set correctly but the exit path that actually stops the run at the limit would still never trigger for `p == 2^32`.

## Scope

Nothing below 2^32 changes: `p` in (2^32−64, 2^32) still takes the `else` branch and still fits in a `uint32`. Only the single exact value `p == 2^32` moves from "assert" to "informative message and stop at the self-test limit".

`makemake.sh nosimd` builds clean; `-s tt` is unchanged, and cannot reach this path in any case — the first guard is skipped for self-tests via `!INTERACT`.

## Provenance

Found while triaging #99, which concerns the neighbouring residue-shift limit at `Mlucas.c:1255`. That is a different boundary and a separate defect; this PR does not touch it and does not affect that issue.
