### PR TITLE
Make the Fermat cofactor-PRP path work: it has never completed a run

### DIFF
--- a/src/Mlucas.c
+++ b/src/Mlucas.c
@@ -2484,7 +2484,10 @@ PM1_STAGE2:	// Stage 2 invocation is several hundred lines below, but this needs
 		// v21: PRP-CF: Cofactor-PRP test applies to primality/Fermat (which we follow by 1 additional mod-squaring
 		// to convert the base^((N-1)/2) Pepin/Euler-PRP residue to a base^(N-1) Fermat-PRP one) and PRP/Mersenne residues:
 		if(KNOWN_FACTORS[0])	// This is automatically false for LL-test
-			isprime = Suyama_CF_PRP(p, &Res64, nfac, a,b,arrtmp, ilo, func_mod_square, n, scrnFlag, &tdiff, gcd_str);
+			// v21: hand over the number of mod-squarings actually completed - that is ihi, which the loop
+			// above leaves == maxiter. ilo is only the *start* of the final checkpoint interval (the `ilo = ihi`
+			// update sits after the loop's break), so it carries no information about test completion:
+			isprime = Suyama_CF_PRP(p, &Res64, nfac, a,b,arrtmp, ihi, func_mod_square, n, scrnFlag, &tdiff, gcd_str);
 
 		// JSON-formatted result report for LL/PRP/cofactor-PRP tests of M(p):
 		if(MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {
@@ -3314,12 +3317,12 @@ Example: N = M(109) = 2^109-1 = 745988807.870035986098720987332873; let F = 7459
 	B = 3^(F-1) == 610082383855388688949555345767473 (mod N), and we verify that (A - B) == 0 (mod C), thus C is a PRP.
 Similarly, if we let A' = 3^N == 3.A (mod N) and B' = 3^F == 3.B (mod N), that also satisfies (A' - B') == 0 (mod C).
 */
-uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
+uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 nsq,
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 	int n, int scrnFlag, double *tdiff, char *const gcd_str)
 {
 	uint64 *ai = (uint64 *)a, *bi = (uint64 *)b;	// Handy 'precast' pointers
-	uint32 i,j,k, isprime, ierr = 0, ihi, fbits,lenf;
+	uint32 i,j,k, isprime, ierr = 0, ilo, ihi, fbits,lenf;
 	uint32 kblocks = n>>10, npad = n + ( (n >> DAT_BITS) << PAD_BITS );	// npad = length of padded data array
 	uint64 itmp64, Res35m1, Res36m1;	// Res64 from original PRP passed in via pointer; these are locally-def'd
 	cbuf[0] = '\0';
@@ -3329,14 +3332,32 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	// Pepin-test output = P, vs Mersenne-PRP (type 1) residue = A; thus only need an initial mod-squaring for:
 	// the former. Compute Fermat-PRP residue [A] from Euler-PRP (= Pepin-test) residue via a single mod-squaring:
 	if(MODULUS_TYPE == MODULUS_TYPE_FERMAT) {
-		ASSERT(ilo == p-1, "Fermat-mod cofactor-PRP test requires p-1 mod-squarings!");
-		snprintf(cbuf,sizeof(cbuf),"Doing one mod-%s squaring of iteration-%u residue [Res64 = %016" PRIX64 "] to get Fermat-PRP residue\n",PSTRING,ilo,*Res64);
-		mlucas_fprint(cbuf,1);
-		ilo = 0;	ihi = ilo+1;	// Have checked that savefile residue is for a complete PRP test, so reset iteration counter
-		BASE_MULTIPLIER_BITS[0] = 0ull;
-/*A*/	ierr = func_mod_square(a, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, TRUE, 0x0);
-		convert_res_FP_bytewise(a, (uint8 *)ci, n, p, Res64, &Res35m1, &Res36m1);	// Overwrite passed-in Pepin-Res64 with Fermat-PRP one
-		snprintf(cbuf,sizeof(cbuf),"MaxErr = %10.9f\n",MME); mlucas_fprint(cbuf,1);
+		/* Two entry paths reach here holding different residues, and they differ by exactly one squaring:
+		   o A Pepin test (worktodo "Fermat,Test=m") runs p-1 mod-squarings and leaves the Euler-PRP
+		     residue 3^((N-1)/2); Suyama wants (A) = 3^(N-1), so square once more.
+		   o A Fermat-mod PRP-CF assignment ("PRP=N/A,1,2,2^m,+1,...", the syntax docs/Fermat-testing.md
+		     documents for this test) runs p of them and already holds (A). Squaring again would give
+		     3^(2*(N-1)) and a meaningless cofactor verdict.
+		Prior to v21 this branch asserted the Pepin count and squared unconditionally. The assertion was
+		also testing the wrong quantity - it was handed ilo, the start of the final checkpoint interval,
+		rather than the completed-squaring count - so it fired on every run of either kind. */
+		if(nsq == (uint32)p-1) {
+			snprintf(cbuf,sizeof(cbuf),"Doing one mod-%s squaring of iteration-%u residue [Res64 = %016" PRIX64 "] to get Fermat-PRP residue\n",PSTRING,nsq,*Res64);
+			mlucas_fprint(cbuf,1);
+			ilo = 0;	ihi = ilo+1;	// Residue is for a complete Pepin test, so reset iteration counter
+			BASE_MULTIPLIER_BITS[0] = 0ull;
+/*A*/		ierr = func_mod_square(a, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, TRUE, 0x0);
+			convert_res_FP_bytewise(a, (uint8 *)ci, n, p, Res64, &Res35m1, &Res36m1);	// Overwrite passed-in Pepin-Res64 with Fermat-PRP one
+			snprintf(cbuf,sizeof(cbuf),"MaxErr = %10.9f\n",MME); mlucas_fprint(cbuf,1);
+		} else if(nsq == (uint32)p) {
+			// Already the Fermat-PRP residue, so *Res64 needs no update; only the Selfridge-Hurwitz
+			// companions are unset here, and the report below prints them. res_SH() wants the mi64
+			// limb-count of the packed-bit residue in ci[], ceiling(p/64) - not the FFT length n:
+			res_SH(ci,(p+63)>>6,&itmp64,&Res35m1,&Res36m1);
+		} else {
+			snprintf(cbuf,sizeof(cbuf),"Fermat-mod cofactor-PRP test needs a residue from a complete Pepin (%" PRIu64 " squarings) or PRP (%" PRIu64 ") run; got %u.\n",p-1,p,nsq);
+			mlucas_fprint(cbuf,0); ASSERT(0,cbuf);
+		}
 	} else if (MODULUS_TYPE == MODULUS_TYPE_MERSENNE) {	// Mersenne PRP-CF doesn't have the Res35m1 or Res36m1 values passed in,
 		res_SH(ci,n,&itmp64,&Res35m1,&Res36m1);			// so we refresh these; see https://github.com/primesearch/Mlucas/issues/27
 	} else {
@@ -3380,7 +3401,11 @@ uint32 Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[
 	ilo = 0;	ihi = fbits-1;	// LR modpow; init b[0] = PRP_BASE takes cares of leftmots bit
 	RES_SHIFT = 0ull;	// Zero the residue-shift so as to not have to play games with where-to-inject-the-initial-seed
 	mi64_brev(BASE_MULTIPLIER_BITS,ihi);	// bit-reverse low [ihi] bits of BASE_MULTIPLIER_BITS:
-/*B*/	ierr = func_mod_square(b, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, TRUE, 0x0);
+	// v21: update_shift = FALSE here, not TRUE. This is a fresh modpow chain on a deliberately-unshifted
+	// residue (see the line above); for a Fermat modulus the shift update is "shift = 2*shift + randbit",
+	// so asking for it drives RES_SHIFT off zero on the very first iteration - which contradicts the zeroing
+	// and, for any leading radix < 16, is rejected outright by the carry routines (ERR_ASSERT):
+/*B*/	ierr = func_mod_square(b, (int*)ci, n, ilo,ihi, 0ull, p, scrnFlag, tdiff, FALSE, 0x0);
 	if(ierr) {
 		snprintf(cbuf,sizeof(cbuf),"Error of type[%u] = %s on iteration %u of mod-squaring chain ... aborting\n",ierr,returnMlucasErrCode(ierr),ROE_ITER);
 		mlucas_fprint(cbuf,0); ASSERT(0,cbuf);

--- a/src/Mlucas.h
+++ b/src/Mlucas.h
@@ -87,7 +87,7 @@ int		cfgNeedsUpdating(const char *p_in_line);
 const char *returnMlucasErrCode(uint32 ierr);
 void	printMlucasErrCode(uint32 ierr);
 uint64 	shift_word(double a[], int n, const uint64 p, const uint64 shift, const double cy_in);
-uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 ilo,
+uint32	Suyama_CF_PRP(uint64 p, uint64 *Res64, uint32 nfac, double a[], double b[], uint64 ci[], uint32 nsq,
 	int	(*func_mod_square)(double [], int [], int, int, int, uint64, uint64, int, double *, int, double *),
 	int n, int scrnFlag, double *tdiff, char *const gcd_str);
 int		test_types_compatible(uint32 t1, uint32 t2);


### PR DESCRIPTION
**The Fermat cofactor-PRP path has never completed a run.** A `PRP=N/A,1,2,<2^m>,+1,99,0,3,5,"<factors>"` assignment — the syntax `docs/Fermat-testing.md:117` documents for exactly this test — aborts before producing a result on unmodified `main`, at any shift. Two independent defects, both in `Suyama_CF_PRP()`.

## 1. The completion check tested the wrong variable, and could never pass

```c
ASSERT(ilo == p-1, "Fermat-mod cofactor-PRP test requires p-1 mod-squarings!");
```

`ilo` comes from the main iteration loop, where `ilo = ihi` sits **after** the `if(ihi == maxiter) break;`. So on exit `ilo` still holds the *start of the final checkpoint interval* — 10000 for an F14 run at the default `ITERS_BETWEEN_CHECKPOINTS` — and never the completed-squaring count. The caller now passes `ihi`, which the loop leaves `== maxiter`, and the parameter is renamed `nsq` so it stops reading like a loop bound.

The `p-1` was also too narrow. Two entry paths arrive here holding residues that differ by exactly one squaring:

| entry | squarings | residue held |
|---|---|---|
| Pépin test, `Fermat,Test=m` | p−1 | Euler-PRP `3^((N−1)/2)` |
| Fermat PRP-CF assignment | p | **already** `(A) = 3^(N−1)` |

Measured for F14 (p = 16384) against GMP: the Pépin run ends at iteration 16383 with `CC52BC3C94F9774A` = `3^(2^16383)`; the PRP-CF assignment ends at 16384 with `E110B2DF4898DFD7` = `3^(2^16384)` = `3^(N−1)`.

So squaring unconditionally — as the old code did — would give `3^(2(N−1))` on the PRP path and a meaningless verdict. The branch is now chosen on `nsq`; the PRP path skips the squaring and only needs its Selfridge-Hurwitz companions filled in, which `res_SH()` does. Note that call wants the mi64 limb count `ceil(p/64)`, **not** the FFT length — the same distinction #183 fixes on the Mersenne side.

## 2. The (B) modpow asked for a shift update on a deliberately unshifted residue

Two lines above the call:

```c
RES_SHIFT = 0ull;	// Zero the residue-shift so as to not have to play games with where-to-inject-the-initial-seed
mi64_brev(BASE_MULTIPLIER_BITS,ihi);
ierr = func_mod_square(b, ..., TRUE, 0x0);	// <-- update_shift = TRUE
```

For a Fermat modulus that update is `shift = 2*shift + randbit`, so `RES_SHIFT` leaves zero on the very first iteration — contradicting the zeroing the comment just explained. With any leading radix < 16 the carry routines then reject it outright (`radix8_ditN_cy_dif1.c:84` returns `ERR_ASSERT`), which is what a stock 4K `fermat.cfg` hits, its radix set being `8 8 32`. Instrumented `RES_SHIFT` immediately before the call to confirm it was 0 going in. Changed to `FALSE`.

## Verification

F14 with its known factor now runs to completion (exit 0), and **every value it reports matches an independent GMP computation**:

| quantity | Mlucas | GMP |
|---|---|---|
| A = `3^(N−1) mod N` | `E110B2DF4898DFD7` | `E110B2DF4898DFD7` |
| B = `3^(F−1) mod N` | `96D8E2B802C733B3` | `96D8E2B802C733B3` |
| C = N/F | `922E57BCB3C30001` | `922E57BCB3C30001` |
| (A−B) mod C | `FC6DCDF563F934D2` | `FC6DCDF563F934D2` |

Nonzero, so the cofactor is correctly reported `COMPOSITE [C4880]`, which is the known status of F14's cofactor. The prime-power GCD check that follows also completes.

Repro, for anyone re-checking:

```sh
bash config-fermat.sh -fft 4K            # 1K/2K are unavailable, see #101
printf 'PRP=N/A,1,2,16384,+1,99,0,3,5,"116928085873074369829035993834596371340386703423373313"\n' > worktodo.txt
./Mlucas -fft 4K -shift 0                # -fft needed: F14's default 1K has no cfg entry
```

## Scope

The Mersenne branch is untouched; `nsq` is referenced only inside the Fermat one. A Mersenne PRP-CF control run behaves **identically** before and after this change.

Honest limitation: the Pépin-sourced `nsq == p-1` arm preserves the original behaviour but I have not found a worktodo formulation that drives a Pépin residue into `Suyama_CF_PRP()` — the documented syntax uses the PRP path. That arm is therefore unchanged-but-unexercised rather than verified.
