### PR TITLE
radix20: reset target_idx after the rotated-residue carry injection, fixing wrong residues at 5K

### DIFF
--- a/src/radix20_main_carry_loop.h
+++ b/src/radix20_main_carry_loop.h
@@ -110,6 +110,7 @@ for(int k=1; k <= khi; k++)	/* Do n/(radix(1)*nwt) outer loop executions...	*/
 			int l = target_set&1;	target_set >>= 1;
 			a[j1+poff[target_set>>2]+p0123[target_set&3]+l] += target_cy*(n>>1);
 		#endif
+			target_idx = -1;	// One-shot: the injection must not repeat on a later pass with the same j
 		}
 
 	#ifdef USE_AVX	// AVX: can select between carry macros processing 4 and 8 independent carries in LOACC mode:


### PR DESCRIPTION
`radix20_main_carry_loop.h` injects the shifted-residue seed when the carry loop's block index matches `target_idx`. Every other radix in the family clears `target_idx` immediately afterwards so the injection happens exactly once — **radix20 is the only one of the ~50 `*_main_carry_loop.h` files that does not**:

```
for f in src/radix*_main_carry_loop.h; do ... done
MISSING reset: radix20_main_carry_loop.h
```

Where the same `j` recurs on a later pass, the seed is injected again and the residue is wrong.

## Symptom

A hard self-test failure at FFT length 5K, radix set `(20,8,16)` — `ERR_INCORRECT_RES64`, a residue mismatch against the built-in reference table, not a roundoff skip.

**Single-threaded builds only.** In a threaded build each worker sees its own chunk, so the index does not recur.

**Shift-dependent**, which is why it has gone unnoticed. Driving the same case across shifts before the fix:

| shift | Res64 |
|---|---|
| 0 | `042D725878208D91` |
| 12345 | `B01CA980953F90A7` |
| 73847 | `43530D2B6398F339` ← correct |
| 93237 | `6E42D1439E5C94AB` |

A residue must be invariant under the shift; these are four different answers. Stock `main` passes its self-test only because the shift it happens to draw for 5K is the one that works. After the fix all four shifts give `43530D2B6398F339`.

## Verification

- x86-64 AVX2, single-threaded: before, 3 of 4 shifts wrong; after, all four agree and `./Mlucas -s tt` exits 0 with no residue errors
- threaded `./Mlucas -s tt`: unchanged, still clean — this cannot regress the multithreaded path, which never took the faulty branch
- reproduced identically on aarch64 (Raspberry Pi 4, gcc 12.2) before the fix

## Notes

Found because a merge of the open PR queue shifted the self-test's pseudo-random shift stream (#104 drops 1K from the sweep, #146 forces shift 0 for leading radix < 16), so 5K drew an unlucky shift and the case failed. The defect itself is in `main` and predates all of it.

Building single-threaded on `main` currently requires #209 — `main` does not compile with `-DUSE_THREADS` removed, in any SIMD mode, which is worth knowing when reproducing this.

Unrelated observation while diagnosing: the mismatch diagnostic at `Mlucas.c:2756` prints both residues with `%20.0f` on a `(double)`, so the low ~11 bits are lost and the reported values are not the actual ones. Not touched here.