### PR TITLE
radix63: apply the Pépin random-bit multiplier, fixing wrong Fermat residues at a nonzero shift

### DIFF
--- a/src/radix63_ditN_cy_dif1.c
+++ b/src/radix63_ditN_cy_dif1.c
@@ -193,7 +193,10 @@ int radix63_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	col=co2=co3=-1;
 	// Jan 2018: To support PRP-testing, read the LR-modpow-scalar-multiply-needed bit for the current iteration from the global array:
 	double prp_mult = 1.0;
-	if((TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
+	// v18: If use residue shift in context of Pepin test, need prp_mult = 2 whenever the 'shift = 2*shift + random[0,1]'
+	// update of the residue shift has a set random bit - the Fermat-mod arm below was missing here, cf. radix60/1008.
+	if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
+	|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {	// Mask off low bit to lump together PRP and PRP-C tests
 		i = (iter-1) % ITERS_BETWEEN_CHECKPOINTS;	// Bit we need to read...iter-counter is unit-offset w.r.to iter-interval, hence the -1
 		if((BASE_MULTIPLIER_BITS[i>>6] >> (i&63)) & 1)
 			prp_mult = PRP_BASE;


### PR DESCRIPTION
Every Fermat-capable carry routine sets `prp_mult = PRP_BASE` on the iterations where the residue-shift update `shift = 2*shift + random[0,1]` has a set bit. **radix63 tests only for a PRP test type and omits the Fermat/Pépin arm:**

```c
// radix60, radix1008, radix240, radix960, … :
if((TEST_TYPE == TEST_TYPE_PRIMALITY && MODULUS_TYPE == MODULUS_TYPE_FERMAT)
|| (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {

// radix63:
if(                                  (TEST_TYPE & 0xfffffffe) == TEST_TYPE_PRP) {
```

A Pépin test with a nonzero shift therefore never applies the doubling, and the residue is wrong. At shift 0 the random-bit scheme is inactive, which is why it has gone unnoticed.

## Measurement

F24 at FFT length 1008K. radix63 is compared against the two `radix1008` sets at the same length, which agree with each other:

| | shift 0 | shift 12345 | shift 99999 |
|---|---|---|---|
| before | `DB9F01963ED9DC8B` | `DFEB4DA9F99F04DB` ✗ | — |
| after | `DB9F01963ED9DC8B` | `DB9F01963ED9DC8B` | `DB9F01963ED9DC8B` |

The full 1008K sweep goes from *2 of 3 radix-sets passed*, with a consensus disagreement, to **3 of 3, no disagreements**.

Mersenne is untouched — the added condition is Fermat-only, and the nosimd Mersenne self-test reports the identical 3 pre-existing failures at radices 18/22/26 before and after (a separate defect, not addressed here).

## How it surfaced

CI on the combined-PR integration branch: `./Mlucas exited 1 on F24 at FFT length 1008K` on Windows and Linux alike. It is visible only because of two other queued changes — the cross-radix consensus check, and a self-test that can return a nonzero status at all. On stock `main` this radix set is written into `fermat.cfg` and used, silently.

## Scope note

32 other `radix*_ditN_cy_dif1.c` files also lack this arm. Most are Mersenne-only routines where it is unreachable, so I have not swept them here; the two demonstrated failures are radix63 (this PR) and radix30 (guarded separately, since its Fermat path needs the icycle scheme rather than a one-line condition).