### PR TITLE
radix960: set the serial cy_i carry pointer, fixing a Fermat-mod SIGSEGV at 960K

### DIFF
--- a/src/radix32_ditN_cy_dif1.c
+++ b/src/radix32_ditN_cy_dif1.c
@@ -198,9 +198,8 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 	static double radix_inv, n2inv;
   #ifndef MULTITHREAD
 	double *addr;
-   #ifndef USE_SSE2
-	double *addi;
-   #endif
+	double *addi;	// v21 build fix: must exist in SSE2 builds too - the MODULUS_TYPE_GENFFTMUL
+					// branch of radix32_main_carry_loop.h dereferences it unconditionally (regression from 2bf9930)
 	double temp,frac;
   #endif
 	double scale, dtmp, maxerr = 0.0;
@@ -256,9 +255,8 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 		,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 		,*cy_r	// Need RADIX slots for sse2 carries, RADIX/2 for avx
-	  #if !defined(MULTITHREAD) && defined(USE_AVX)
-		,*cy_i
-	  #endif
+		,*cy_i	// v21 build fix: must exist in SSE2/MULTITHREAD builds too - radix32_main_carry_loop.h's
+				// MODULUS_TYPE_GENFFTMUL branch dereferences it unconditionally (regression from 2bf9930)
 		;
   #ifdef USE_AVX
 	static vec_dbl *base_negacyclic_root;
@@ -551,7 +549,7 @@ int radix32_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[],
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 96 vec_dbl for Mersenne-mod, and 3.5*RADIX[avx] | RADIX[sse2] for Fermat-mod */
 	  #else
-		cy_r = tmp;	/* cy_i = tmp+0x10; */	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+		cy_r = tmp;	cy_i = tmp+0x10;	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
 		max_err = tmp + 0x00;
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 32 x 16 bytes for Mersenne-mod, 2 for Fermat-mod */
@@ -1996,9 +1994,7 @@ void radix32_dit_pass1(double a[], int n)
 			,*r20,*r22,*r24,*r26,*r28,*r2A,*r2C,*r2E
 			,*r30,*r32,*r34,*r36,*r38,*r3A,*r3C,*r3E */
 			,*cy_r
-		#ifdef USE_AVX
-			,*cy_i
-		#endif
+			,*cy_i	// v21 build fix: see the same declaration in radix32_ditN_cy_dif1() above
 			;
 	  #ifdef USE_AVX
 		vec_dbl *base_negacyclic_root;
@@ -2143,7 +2139,7 @@ void radix32_dit_pass1(double a[], int n)
 		half_arr= tmp + 0x02;	/* This table needs 68 vec_dbl for Mersenne-mod, and 3.5*RADIX[avx] | RADIX[sse2] for Fermat-mod */
 		base_negacyclic_root = half_arr + RADIX;	// Only used for Fermat-mod
 	  #else
-		cy_r = tmp;	/* cy_i = tmp+0x10; */	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+		cy_r = tmp;	cy_i = tmp+0x10;	tmp += 0x20;	// RADIX/2 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
 		max_err = tmp + 0x00;
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;	/* This table needs 20 x 16 bytes for Mersenne-mod, 2 for Fermat-mod */

--- a/src/radix960_ditN_cy_dif1.c
+++ b/src/radix960_ditN_cy_dif1.c
@@ -757,12 +757,20 @@ int radix960_ditN_cy_dif1(double a[], int n, int nwt, int nwt_bits, double wt0[]
 		two       = tmp + 0x09;
 		tmp += 0x0a;	// += 0xa => sc_ptr + 0xf46
 	  #ifdef USE_AVX512
-		cy_r = tmp;	/* cy_i = tmp+0x78; */	tmp += 2*0x78;	// RADIX/8 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+		cy_r = tmp;
+	   #ifndef MULTITHREAD
+		cy_i = tmp+0x78;
+	   #endif
+		tmp += 2*0x78;	// RADIX/8 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
 		max_err = tmp + 0x00;
 		sse2_rnd= tmp + 0x01;
 		half_arr= tmp + 0x02;
 	  #elif defined(USE_AVX)
-		cy_r = tmp;	/* cy_i = tmp+0x0f0; */	tmp += 2*0x0f0;	// RADIX/4 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
+		cy_r = tmp;
+	   #ifndef MULTITHREAD
+		cy_i = tmp+0x0f0;
+	   #endif
+		tmp += 2*0x0f0;	// RADIX/4 vec_dbl slots for each of cy_r and cy_i carry sub-arrays
 		max_err = tmp + 0x00;
 		sse2_rnd= tmp + 0x01;	// += 0x1e0 + 2 => sc_ptr += 0x1128
 		// This is where the value of half_arr_offset comes from


### PR DESCRIPTION
radix960's serial setup assigns `cy_r` but leaves `cy_i` commented out:

```c
cy_r = tmp;	/* cy_i = tmp+0x78; */	tmp += 2*0x78;
```

The space is still reserved — `tmp += 2*0x78` — only the pointer assignment is missing, so `cy_i` stays null. Mersenne-mod never touches it. Fermat-mod does, at `radix960_ditN_cy_dif1.c:2066`:

```c
tmp->d0 = _cy_r[l][ithread];   tm2->d0 = _cy_i[l][ithread];   // tm2 = cy_i
```

and the run dies. Reproduced on stock `main` + #209:

```
./Mlucas -f 24 -fft 960 -iters 100      # single-threaded AVX2  ->  SIGSEGV
```

It's the radix set `(960,16,32)` specifically — the other four at that length, `(240,8,16,16)` and the three radix-60 sets, are unaffected. Threaded builds are fine because the worker routine has its own copies of these assignments, already live.

## The fix

Restore the two arms whose declaration guard admits `cy_i`, each wrapped in `#ifndef MULTITHREAD` exactly as **radix240 and radix1024 already do**. The SSE2 arm is deliberately left alone: the declaration at the top of the routine excludes plain SSE2, matching those same siblings.

## Verification

F24 at FFT length 960K, before → after:

| build | before | after |
|---|---|---|
| threaded AVX2 | 5 of 5 radix-sets | 5 of 5 |
| threaded SSE2 | 5 of 5 | 5 of 5 |
| **single-threaded AVX2** | **SIGSEGV** | **5 of 5** |
| single-threaded SSE2 | 5 of 5 | 5 of 5 |

AVX-512 can't be executed on my hardware; under Intel SDE the same case runs to completion without crashing.

## How it surfaced

CI on the combined-PR integration branch, once `config-fermat.sh` started propagating a failing exit status instead of swallowing it. On stock `main` this crash is reachable but silent in that path.