### PR TITLE
mi64: stop viewing uint64 arrays through uint32 pointers (fixes an aarch64/clang+LTO wrong answer)

### DIFF
--- a/src/factor.c
+++ b/src/factor.c
@@ -3409,7 +3409,7 @@ MFACTOR_HELP:
 									l += (pdiff[m] << 1);
 									// Is q % (current small sieving prime) == 0?
 									// Cast-to-32-bit-array means doubling the length argument, but THAT IS DONE AUTOMATICALLY INSIDE THE FUNCTION
-									if(mi64_is_div_by_scalar32((uint32 *)q, l, lenQ)) {
+									if(mi64_is_div_by_scalar32(q, l, lenQ)) {
 									#ifdef MULTITHREAD
 									//	if(tid != 0) break;	// Can make thread-specific by fiddling the rhs of the !=
 										printf("Thread %u, k = %" PRIu64 ": q = ",tid,k);

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -5784,13 +5784,10 @@ static uint32 mi64_word32(const uint64 x[], uint32 i)
 }
 
 /// Fast is-divisible-by-32-bit-scalar using Montgomery modmul and right-to-left modding:
-/*** NOTE *** Routine assumes x[] is a uint64 array cast to uint32[], hence the doubling-of-len
-is done HERE, i.e. user must supply uint64-len just as for the 'true 64-bit' mi64 functions!
-In other words, these kinds of compiler warnings are expected:
-
-	mi64.c: In function ‘mi64_div_y32’:
-	warning: passing argument 1 of ‘mi64_is_div_by_scalar32’ from incompatible pointer type
-	note: expected ‘const uint32 *’ but argument is of type ‘uint64 *’
+/*** NOTE *** len is the uint64 length, just as for the 'true 64-bit' mi64 functions; the
+doubling to a 32-bit word count is done HERE. x[] is read as uint64 throughout and the 32-bit
+words are extracted with mi64_word32(), so there is no uint64-array-viewed-as-uint32[] cast
+and none of the incompatible-pointer warnings that used to be expected here.
 */
 #ifdef __CUDA_ARCH__
 __device__
@@ -5815,7 +5812,7 @@ int mi64_is_div_by_scalar32(const uint64 x[], uint32 q, uint32 len)
 		qinv = qinv*((uint32)2 - q*qinv);
 	}
 	cy = (uint32)0;
-	dlen = len+len;	/* Since are processing a uint64 array cast to uint32[], double the #words parameter */
+	dlen = len+len;	/* Each uint64 limb holds two 32-bit words, so the word loop runs twice the uint64 len */
 	for(i = 0; i < dlen; ++i) {
 		const uint32 xcur = mi64_word32(x,i);
 		tmp  = xcur - cy;
@@ -5838,7 +5835,7 @@ int		mi64_is_div_by_scalar32p(const uint64 x[], uint32 q, uint32 qinv, uint32 le
 
 	ASSERT(qinv == qinv*((uint32)2 - q*qinv), "mi64_is_div_by_scalar32p: bad qinv!");
 	cy = (uint32)0;
-	dlen = len+len;	/* Since are processing a uint64 array cast to uint32[], double the #words parameter */
+	dlen = len+len;	/* Each uint64 limb holds two 32-bit words, so the word loop runs twice the uint64 len */
 	for(i = 0; i < dlen; ++i) {
 		const uint32 xcur = mi64_word32(x,i);
 		tmp  = xcur - cy;
@@ -8083,13 +8080,10 @@ uint64 mi64_div_by_scalar64_u4(uint64 x[], uint64 q, uint32 lenu, uint64 y[])
 // Divide-with-Remainder of x by y, where x is a multiword base 2^64 integer and y a 32-bit unsigned scalar.
 // Returns 32-bit remainder in the function result and (optionally, if q-array pointer != 0) quotient x/y in q[].
 // Allows division-in-place, i.e. x == q.
-/*** NOTE *** Routine assumes x[] is a uint64 array cast to uint32[], hence the doubling-of-len
-is done HERE, i.e. user must supply uint64-len just as for the 'true 64-bit' mi64 functions!
-In other words, these kinds of compiler warnings are expected:
-
-	mi64.c: In function ‘mi64_div_y32’:
-	warning: passing argument 1 of ‘mi64_is_div_by_scalar32’ from incompatible pointer type
-	note: expected ‘const uint32 *’ but argument is of type ‘uint64 *’
+/*** NOTE *** len is the uint64 length, just as for the 'true 64-bit' mi64 functions; the
+doubling to a 32-bit word count is done HERE. x[] is read as uint64 throughout and the 32-bit
+words are extracted with mi64_word32(), so there is no uint64-array-viewed-as-uint32[] cast
+and none of the incompatible-pointer warnings that used to be expected here.
 */
 #ifdef __CUDA_ARCH__
 __device__

--- a/src/mi64.c
+++ b/src/mi64.c
@@ -5769,6 +5769,20 @@ int mi64_div_binary(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY
 }
 #endif	// __CUDA_ARCH__ ?
 
+/* Extract the i'th 32-bit word of a uint64 array, least-significant half of each limb first.
+Reading the limb and shifting keeps this a by-value operation: no (uint32 *) view of a uint64
+object - which is a strict-aliasing violation, and was silently miscompiled under -flto by at
+least one clang - and no dependence on host byte order, since the shift addresses the value
+rather than the storage. Contrast trailz32() in util.c, which needs a USE_BIG_ENDIAN arm
+precisely because it inspects storage.  */
+#ifdef __CUDA_ARCH__
+__device__
+#endif
+static uint32 mi64_word32(const uint64 x[], uint32 i)
+{
+	return (uint32)(x[i>>1] >> ((i&1)<<5));
+}
+
 /// Fast is-divisible-by-32-bit-scalar using Montgomery modmul and right-to-left modding:
 /*** NOTE *** Routine assumes x[] is a uint64 array cast to uint32[], hence the doubling-of-len
 is done HERE, i.e. user must supply uint64-len just as for the 'true 64-bit' mi64 functions!
@@ -5781,7 +5795,7 @@ In other words, these kinds of compiler warnings are expected:
 #ifdef __CUDA_ARCH__
 __device__
 #endif
-int mi64_is_div_by_scalar32(const uint32 x[], uint32 q, uint32 len)
+int mi64_is_div_by_scalar32(const uint64 x[], uint32 q, uint32 len)
 {
 	uint32 i,j,nshift,dlen,qinv,tmp,cy;
 
@@ -5792,7 +5806,7 @@ int mi64_is_div_by_scalar32(const uint32 x[], uint32 q, uint32 len)
 	/* q must be odd for Montgomery-style modmul to work, so first shift off any low 0s: */
 	nshift = trailz32(q);
 	if(nshift) {
-		if(trailz32(x[0]) < nshift) return FALSE;
+		if(trailz32(mi64_word32(x,0)) < nshift) return FALSE;
 		q >>= nshift;
 	}
 
@@ -5803,11 +5817,12 @@ int mi64_is_div_by_scalar32(const uint32 x[], uint32 q, uint32 len)
 	cy = (uint32)0;
 	dlen = len+len;	/* Since are processing a uint64 array cast to uint32[], double the #words parameter */
 	for(i = 0; i < dlen; ++i) {
-		tmp  = x[i] - cy;
+		const uint32 xcur = mi64_word32(x,i);
+		tmp  = xcur - cy;
 		/* Add q if had a borrow - Since we low=half multiply tmp by qinv below and q*qinv == 1 (mod 2^32),
 		   can simply add 1 to tmp*qinv result instead of adding q to the difference here:
 		*/
-		cy = (cy > x[i]); /* Comparing this rather than (tmp > x[i]) frees up tmp for the multiply */
+		cy = (cy > xcur); /* Comparing this rather than (tmp > x[i]) frees up tmp for the multiply */
 		/* Now do the Montgomery mod: cy = umulh( q, mulq(tmp, qinv) ); */
 		tmp *= qinv;
 		tmp += cy;
@@ -5817,7 +5832,7 @@ int mi64_is_div_by_scalar32(const uint32 x[], uint32 q, uint32 len)
 }
 
 /* Same as above, but assumes q and its modular inverse have been precomputed: */
-int		mi64_is_div_by_scalar32p(const uint32 x[], uint32 q, uint32 qinv, uint32 len)
+int		mi64_is_div_by_scalar32p(const uint64 x[], uint32 q, uint32 qinv, uint32 len)
 {
 	uint32 i,dlen,tmp,cy;
 
@@ -5825,11 +5840,12 @@ int		mi64_is_div_by_scalar32p(const uint32 x[], uint32 q, uint32 qinv, uint32 le
 	cy = (uint32)0;
 	dlen = len+len;	/* Since are processing a uint64 array cast to uint32[], double the #words parameter */
 	for(i = 0; i < dlen; ++i) {
-		tmp  = x[i] - cy;
+		const uint32 xcur = mi64_word32(x,i);
+		tmp  = xcur - cy;
 		/* Add q if had a borrow - Since we low=half multiply tmp by qinv below and q*qinv == 1 (mod 2^32),
 		   can simply add 1 to tmp*qinv result instead of adding q to the difference here:
 		*/
-		cy = (cy > x[i]); /* Comparing this rather than (tmp > x[i]) frees up tmp for the multiply */
+		cy = (cy > xcur); /* Comparing this rather than (tmp > x[i]) frees up tmp for the multiply */
 		/* Now do the Montgomery mod: cy = umulh( q, mulq(tmp, qinv) ); */
 		tmp *= qinv;
 		tmp += cy;
@@ -5934,7 +5950,7 @@ int		mi64_is_div_by_scalar32p_x8(
 }
 
 #ifndef __CUDA_ARCH__
-uint32	mi64_is_div_by_scalar32_x4(const uint32 x[], uint32 q0, uint32 q1, uint32 q2, uint32 q3, uint32 len)
+uint32	mi64_is_div_by_scalar32_x4(const uint64 x[], uint32 q0, uint32 q1, uint32 q2, uint32 q3, uint32 len)
 {
 	uint32 i,j,nshift0,nshift1,nshift2,nshift3;
 	uint32 retval=0,dlen = len+len, qinv0,qinv1,qinv2,qinv3,tmp0,tmp1,tmp2,tmp3,cy0,cy1,cy2,cy3;
@@ -5944,7 +5960,7 @@ uint32	mi64_is_div_by_scalar32_x4(const uint32 x[], uint32 q0, uint32 q1, uint32
 	if(q0 + q1 + q2 + q3 == 4) return TRUE;
 	if(len == 0) return TRUE;
 
-	trailx = trailz32(x[0]);
+	trailx = trailz32(mi64_word32(x,0));
 
 	/* q must be odd for Montgomery-style modmul to work, so first shift off any low 0s: */
 	nshift0 = trailz32(q0);
@@ -5972,7 +5988,7 @@ uint32	mi64_is_div_by_scalar32_x4(const uint32 x[], uint32 q0, uint32 q1, uint32
 	cy2 = (uint32)0;
 	cy3 = (uint32)0;
 	for(i = 0; i < dlen; ++i) {
-		xcur = x[i];
+		xcur = mi64_word32(x,i);
 
 		tmp0 = xcur - cy0;
 		tmp1 = xcur - cy1;
@@ -6007,7 +6023,7 @@ uint32	mi64_is_div_by_scalar32_x4(const uint32 x[], uint32 q0, uint32 q1, uint32
 	return retval;
 }
 
-uint32	mi64_is_div_by_scalar32_x8(const uint32 x[], uint32 q0, uint32 q1, uint32 q2, uint32 q3, uint32 q4, uint32 q5, uint32 q6, uint32 q7, uint32 len)
+uint32	mi64_is_div_by_scalar32_x8(const uint64 x[], uint32 q0, uint32 q1, uint32 q2, uint32 q3, uint32 q4, uint32 q5, uint32 q6, uint32 q7, uint32 len)
 {
 	uint32 i,j,nshift0,nshift1,nshift2,nshift3,nshift4,nshift5,nshift6,nshift7;
 	uint32 retval=0,dlen = len+len, qinv0,qinv1,qinv2,qinv3,qinv4,qinv5,qinv6,qinv7,tmp0,tmp1,tmp2,tmp3,tmp4,tmp5,tmp6,tmp7,cy0,cy1,cy2,cy3,cy4,cy5,cy6,cy7;
@@ -6017,7 +6033,7 @@ uint32	mi64_is_div_by_scalar32_x8(const uint32 x[], uint32 q0, uint32 q1, uint32
 	if(q0 + q1 + q2 + q3 + q4 + q5 + q6 + q7 == 8) return TRUE;
 	if(len == 0) return TRUE;
 
-	trailx = trailz32(x[0]);
+	trailx = trailz32(mi64_word32(x,0));
 
 	/* q must be odd for Montgomery-style modmul to work, so first shift off any low 0s: */
 	nshift0 = trailz32(q0);						nshift4 = trailz32(q4);
@@ -6045,7 +6061,7 @@ uint32	mi64_is_div_by_scalar32_x8(const uint32 x[], uint32 q0, uint32 q1, uint32
 	cy2 = (uint32)0;							cy6 = (uint32)0;
 	cy3 = (uint32)0;							cy7 = (uint32)0;
 	for(i = 0; i < dlen; ++i) {
-		xcur = x[i];
+		xcur = mi64_word32(x,i);
 
 		tmp0 = xcur - cy0;						tmp4 = xcur - cy4;
 		tmp1 = xcur - cy1;						tmp5 = xcur - cy5;
@@ -8115,7 +8131,7 @@ uint32 mi64_div_y32(const uint64 x[], uint32 y, uint64 q[], uint32 len)
 		rem = tsum%y;
 	}
 	if(rem == 0 && x != q) {	// If overwrote input with quotient in above loop, skip this
-		ASSERT(mi64_is_div_by_scalar32((const uint32 *)x, y, len), "Results of mi64_div_y32 and mi64_is_div_by_scalar32 differ!");
+		ASSERT(mi64_is_div_by_scalar32(x, y, len), "Results of mi64_div_y32 and mi64_is_div_by_scalar32 differ!");
 		return 0;
 	}
 	return (uint32)rem;

--- a/src/mi64.h
+++ b/src/mi64.h
@@ -317,9 +317,9 @@ DEV uint64	mi64_div_by_scalar64_u4	(uint64 x[], uint64 a, uint32 lenX, uint64 q[
 	int		mi64_div_binary			(const uint64 x[], const uint64 y[], uint32 lenX, uint32 lenY, uint64 q[], uint32*lenQ, uint64 r[]);
 
 /* Fast is-divisible-by-scalar, div-by-scalar y]: */
-DEV int		mi64_is_div_by_scalar32 (const uint32 x[], uint32 a, uint32 len);
-DEV uint32	mi64_is_div_by_scalar32_x4(const uint32 x[], uint32 tryq0, uint32 tryq1, uint32 tryq2, uint32 tryq3, uint32 len);
-DEV uint32	mi64_is_div_by_scalar32_x8(const uint32 x[], uint32 tryq0, uint32 tryq1, uint32 tryq2, uint32 tryq3, uint32 tryq4, uint32 tryq5, uint32 tryq6, uint32 tryq7, uint32 len);
+DEV int		mi64_is_div_by_scalar32 (const uint64 x[], uint32 a, uint32 len);
+DEV uint32	mi64_is_div_by_scalar32_x4(const uint64 x[], uint32 tryq0, uint32 tryq1, uint32 tryq2, uint32 tryq3, uint32 len);
+DEV uint32	mi64_is_div_by_scalar32_x8(const uint64 x[], uint32 tryq0, uint32 tryq1, uint32 tryq2, uint32 tryq3, uint32 tryq4, uint32 tryq5, uint32 tryq6, uint32 tryq7, uint32 len);
 DEV int		mi64_is_div_by_scalar64	(const uint64 x[], uint64 a, uint32 len);
 DEV int		mi64_is_div_by_scalar64_x4(const uint64 x[], uint64 q0, uint64 q1, uint64 q2, uint64 q3, uint32 len);
 DEV int		mi64_is_div_by_scalar64_u2	(const uint64 x[], uint64 a, uint32 len);	// 2-way interleaved-|| loop


### PR DESCRIPTION
`mi64_is_div_by_scalar32()` and its `_x4`/`_x8`/`32p` siblings declared their input as `const uint32 x[]` and doubled the caller-supplied (uint64) length internally, so **every call site handed them a uint64 array through a `(uint32 *)` cast.** The comment above the first of them described the resulting incompatible-pointer warnings as *expected*.

That is a strict-aliasing violation, and clang 14 on aarch64 acts on it: with `-flto` the call is inlined, TBAA concludes the `uint32` reads cannot alias the `uint64` object, and the function returns FALSE for inputs that are plainly divisible. `mi64_div_y32()` then trips its own cross-check:

```
Assertion 'mi64_is_div_by_scalar32((const uint32 *)x, y, len)' failed:
Results of mi64_div_y32 and mi64_is_div_by_scalar32 differ!
```

## What the disagreement actually is

Instrumenting the assertion printed the failing triples:

```
len=1 y= 3 rem=0 x[0]=255      255 = 3 × 85
len=1 y= 5 rem=0 x[0]=255      255 = 5 × 51
len=1 y= 7 rem=0 x[0]=763      763 = 7 × 109
len=1 y=11 rem=0 x[0]=2541     2541 = 11 × 231
len=1 y=13 rem=0 x[0]=2795     2795 = 13 × 215
```

All genuinely divisible — so `mi64_div_y32` is right and the *cross-check* is wrong. Only the check is affected; the division results callers consume were always correct. The job aborts, it does not compute anything incorrectly.

## Fix

Take `const uint64 x[]` and read each half by value:

```c
static uint32 mi64_word32(const uint64 x[], uint32 i)
{
	return (uint32)(x[i>>1] >> ((i&1)<<5));
}
```

No `(uint32 *)` view of a `uint64` object, so no aliasing violation — and because the shift addresses the *value* rather than the storage, no dependence on host byte order. The old word indexing assumed little-endian, so this is one less thing for a big-endian port to trip over. `mi64_is_div_by_scalar32p_x8()` is left alone: it takes eight separate arrays and has no callers.

## Verification

aarch64, Ubuntu clang 14.0.0, `-O3 -flto`, same branch and container throughout:

| build | disagreements | outcome |
|---|---|---|
| unfixed | **5** | abort |
| unfixed + `-fno-strict-aliasing` | 0 | clean — confirms the mechanism |
| unfixed + `-fno-lto` | 0 | clean — confirms the mechanism |
| **this fix, no workaround flags** | **0** | **exit 0, factoring self-tests pass** |

The two flag variants are diagnostics, not the fix — they each remove one leg of the mechanism (TBAA, and the inlining that exposes it).

On x86-64: Mlucas builds clean in `nosimd` and `avx2`; Mfactor's self-tests, which call `_x4` and `_x8` directly, pass. Real aarch64 hardware with Debian clang 14.0.6 never exhibited the bug either way — it needs this specific combination, which is why it shows up only in the `ubuntu-22.04-arm` + clang CI cell.

## How it surfaced

CI on the combined-PR integration branch. On stock `main` the same code is equally undefined; whether it misbehaves is up to the compiler.