### PR TITLE
Fix all ShellCheck findings and unmask the ShellCheck CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: ShellCheck
-      run: shellcheck --version; shopt -s globstar; shellcheck -o avoid-nullary-conditions,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh
+      run: shellcheck --version; shopt -s globstar; shellcheck -o avoid-nullary-conditions,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh
 
   macOS:
     name: Mlucas macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,8 +336,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: ShellCheck
-      run: shopt -s globstar; shellcheck -o avoid-nullary-conditions,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh
-      continue-on-error: true
+      run: shellcheck --version; shopt -s globstar; shellcheck -o avoid-nullary-conditions,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh
 
   macOS:
     name: Mlucas macOS

--- a/config-fermat.sh
+++ b/config-fermat.sh
@@ -80,5 +80,5 @@ for fft in "${!FFTS[@]}"; do
 	if [[ $f -le 17 || $f -ge 32 ]]; then
 		args+=(-shift 0)
 	fi
-	time $MLUCAS -f "$f" -fft "$fft" -iters "$ITERS" "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing\|pmax_rec\|fft radices'
+	time "$MLUCAS" -f "$f" -fft "$fft" -iters "$ITERS" "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing\|pmax_rec\|fft radices'
 done

--- a/config-fermat.sh
+++ b/config-fermat.sh
@@ -74,10 +74,11 @@ for fft in "${!FFTS[@]}"; do
 	args=("${ARGS[@]}")
 	# First we test the very fiddly F15 and then loop over F16 up to maximum
 	if [[ $f -eq 15 ]]; then
+		# shellcheck disable=SC2054 # '8,8,16' is one comma-separated Mlucas -radset argument, not three array elements
 		args+=(-radset 8,8,16)
 	fi
 	if [[ $f -le 17 || $f -ge 32 ]]; then
 		args+=(-shift 0)
 	fi
-	time $MLUCAS -f "$f" -fft "$fft" -iters $ITERS "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing\|pmax_rec\|fft radices'
+	time $MLUCAS -f "$f" -fft "$fft" -iters "$ITERS" "${args[@]}" 2>&1 | tee -a config-fermat.log | grep -i 'error\|warn\|assert\|writing\|pmax_rec\|fft radices'
 done

--- a/makemake.sh
+++ b/makemake.sh
@@ -61,11 +61,11 @@ case $OSTYPE in
 		;;
 esac
 
-MAKE=make
-if ! command -v $MAKE >/dev/null && command -v mingw32-make >/dev/null; then
+MAKE='make'
+if ! command -v "$MAKE" >/dev/null && command -v mingw32-make >/dev/null; then
 	MAKE=mingw32-make
 fi
-if ! command -v $MAKE >/dev/null; then
+if ! command -v "$MAKE" >/dev/null; then
 	echo "Error: This script requires Make" >&2
 	echo "On Ubuntu and Debian run: 'sudo apt update' and 'sudo apt install -y build-essential'" >&2
 	exit 1
@@ -80,6 +80,13 @@ elif ! command -v gcc >/dev/null; then
 	echo "On Ubuntu and Debian run: 'sudo apt update' and 'sudo apt install -y build-essential'" >&2
 	exit 1
 fi
+
+# The three try_* helpers below are feature *probes*: a nonzero return means "this toolchain does not
+# support that", which is an answer, not an error. They are therefore always called from an 'if'/'&&'/'!'
+# condition, which suppresses 'set -e' inside them - exactly what we want, and what they are written for
+# (each does its own error handling, e.g. 'mktemp -d || return 1'). ShellCheck's optional
+# check-set-e-suppressed check flags every such call as SC2310, so each call site below carries a narrow
+# '# shellcheck disable=SC2310'.
 
 # Returns success iff $CC (default gcc) accepts the given flag(s) for a full compile-and-link of a
 # trivial program - used below to auto-detect toolchain-version-dependent flag/feature support instead
@@ -303,6 +310,7 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 	# The AVX-512 kernels use "extended" register names (zmm16-31/xmm16-31/k0-7) that some older
 	# Clang releases reject even when otherwise AVX-512-aware; probe rather than let the user hit a
 	# wall of asm errors deep in the build:
+	# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 	if [[ $arg == avx512* ]] && ! try_avx512_asm; then
 		echo "Error: ${CC:-gcc}'s assembler does not support the AVX-512 extended register names (zmm16-31/xmm16-31/k0-7) needed for this build mode ... aborting. Try a newer compiler, or build with 'avx2' instead." >&2
 		exit 1
@@ -321,6 +329,7 @@ elif [[ $OSTYPE == darwin* ]]; then
 	avx1_0=$( sysctl -n hw.optional.avx1_0  2>/dev/null || echo 0)
 	sse2=$(   sysctl -n hw.optional.sse2    2>/dev/null || echo 0)
 	neon=$(   sysctl -n hw.optional.neon    2>/dev/null || echo 0)
+	# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 	if ((avx512f)) && try_avx512_asm; then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
@@ -356,6 +365,7 @@ elif [[ $OSTYPE == darwin* ]]; then
 elif [[ $OSTYPE == linux* ]]; then
 
 	# Linux:
+	# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 	if grep -iq 'avx512' /proc/cpuinfo && try_avx512_asm; then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
@@ -443,6 +453,7 @@ EOF
 
 	case $output in
 		avx512)
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if try_avx512_asm; then
 				echo -e "The CPU supports the AVX512 SIMD build mode.\n"
 				ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
@@ -467,6 +478,7 @@ EOF
 		asimd)
 			echo -e "The CPU supports the ASIMD build mode.\n"
 			ARGS+=(-DUSE_ARM_V8_SIMD)
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if try_flag -mcpu=native; then
 				ARGS+=(-mcpu=native)
 			elif try_flag -march=native; then
@@ -478,6 +490,7 @@ EOF
 		none_arm)
 			echo -e "The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n"
 			echo "Warning: This likely means there is a bug in this script. Please report!" >&2
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if try_flag -mcpu=native; then
 				ARGS+=(-mcpu=native)
 			elif try_flag -march=native; then
@@ -491,6 +504,7 @@ EOF
 			;;
 		none)
 			echo -e "The CPU architecture is not recognized by this script ... building in scalar-double mode.\n"
+			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			try_flag -march=native && ARGS+=(-march=native)
 			;;
 		*)
@@ -527,7 +541,9 @@ CFLAGS_PROBED=(-Wall -g -O3)
 # unconditionally: every toolchain then compiles the same dialect, and gnu99 (vs plain c99) keeps the GNU
 # extensions enabled. -D_GNU_SOURCE (set in CPPFLAGS below) still exposes the POSIX/GNU library surface:
 CFLAGS_PROBED+=(-std=gnu99)
+# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 try_flag -fdiagnostics-color && CFLAGS_PROBED=(-fdiagnostics-color "${CFLAGS_PROBED[@]}")
+# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 if try_lto -flto=auto; then
 	CFLAGS_PROBED+=(-flto=auto)
 elif try_lto -flto; then

--- a/makemake.sh
+++ b/makemake.sh
@@ -84,9 +84,7 @@ fi
 # The three try_* helpers below are feature *probes*: a nonzero return means "this toolchain does not
 # support that", which is an answer, not an error. They are therefore always called from an 'if'/'&&'/'!'
 # condition, which suppresses 'set -e' inside them - exactly what we want, and what they are written for
-# (each does its own error handling, e.g. 'mktemp -d || return 1'). ShellCheck's optional
-# check-set-e-suppressed check flags every such call as SC2310, so each call site below carries a narrow
-# '# shellcheck disable=SC2310'.
+# (each does its own error handling, e.g. 'mktemp -d || return 1').
 
 # Returns success iff $CC (default gcc) accepts the given flag(s) for a full compile-and-link of a
 # trivial program - used below to auto-detect toolchain-version-dependent flag/feature support instead
@@ -310,7 +308,6 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 	# The AVX-512 kernels use "extended" register names (zmm16-31/xmm16-31/k0-7) that some older
 	# Clang releases reject even when otherwise AVX-512-aware; probe rather than let the user hit a
 	# wall of asm errors deep in the build:
-	# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 	if [[ $arg == avx512* ]] && ! try_avx512_asm; then
 		echo "Error: ${CC:-gcc}'s assembler does not support the AVX-512 extended register names (zmm16-31/xmm16-31/k0-7) needed for this build mode ... aborting. Try a newer compiler, or build with 'avx2' instead." >&2
 		exit 1
@@ -329,7 +326,6 @@ elif [[ $OSTYPE == darwin* ]]; then
 	avx1_0=$( sysctl -n hw.optional.avx1_0  2>/dev/null || echo 0)
 	sse2=$(   sysctl -n hw.optional.sse2    2>/dev/null || echo 0)
 	neon=$(   sysctl -n hw.optional.neon    2>/dev/null || echo 0)
-	# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 	if ((avx512f)) && try_avx512_asm; then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
@@ -365,7 +361,6 @@ elif [[ $OSTYPE == darwin* ]]; then
 elif [[ $OSTYPE == linux* ]]; then
 
 	# Linux:
-	# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 	if grep -iq 'avx512' /proc/cpuinfo && try_avx512_asm; then
 		echo -e "The CPU supports the AVX512 SIMD build mode.\n"
 		ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
@@ -453,7 +448,6 @@ EOF
 
 	case $output in
 		avx512)
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if try_avx512_asm; then
 				echo -e "The CPU supports the AVX512 SIMD build mode.\n"
 				ARGS+=(-DUSE_AVX512 -march=native -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
@@ -478,7 +472,6 @@ EOF
 		asimd)
 			echo -e "The CPU supports the ASIMD build mode.\n"
 			ARGS+=(-DUSE_ARM_V8_SIMD)
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if try_flag -mcpu=native; then
 				ARGS+=(-mcpu=native)
 			elif try_flag -march=native; then
@@ -490,7 +483,6 @@ EOF
 		none_arm)
 			echo -e "The CPU supports no Mlucas-recognized SIMD build mode ... building in scalar-double mode.\n"
 			echo "Warning: This likely means there is a bug in this script. Please report!" >&2
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			if try_flag -mcpu=native; then
 				ARGS+=(-mcpu=native)
 			elif try_flag -march=native; then
@@ -504,7 +496,6 @@ EOF
 			;;
 		none)
 			echo -e "The CPU architecture is not recognized by this script ... building in scalar-double mode.\n"
-			# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 			try_flag -march=native && ARGS+=(-march=native)
 			;;
 		*)
@@ -541,9 +532,7 @@ CFLAGS_PROBED=(-Wall -g -O3)
 # unconditionally: every toolchain then compiles the same dialect, and gnu99 (vs plain c99) keeps the GNU
 # extensions enabled. -D_GNU_SOURCE (set in CPPFLAGS below) still exposes the POSIX/GNU library surface:
 CFLAGS_PROBED+=(-std=gnu99)
-# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 try_flag -fdiagnostics-color && CFLAGS_PROBED=(-fdiagnostics-color "${CFLAGS_PROBED[@]}")
-# shellcheck disable=SC2310 # a failed probe is an answer, not an error
 if try_lto -flto=auto; then
 	CFLAGS_PROBED+=(-flto=auto)
 elif try_lto -flto; then
@@ -584,7 +573,7 @@ EOF
 
 echo -e "Building $TARGET"
 printf "%'d CPU cores detected ... parallel-building using that number of make threads.\n" "$CPU_THREADS"
-if ! time $MAKE "${MAKE_ARGS[@]}" "$TARGET" >build.log 2>&1; then
+if ! time "$MAKE" "${MAKE_ARGS[@]}" "$TARGET" >build.log 2>&1; then
 	echo -e "\n*** There were build errors - see '${DIR}/build.log' for details. ***\n" >&2
 	grep -A 2 '[Ee]rror:' build.log || tail build.log
 	exit 1


### PR DESCRIPTION
## The mask

The `ShellCheck` job in `.github/workflows/ci.yml` carries `continue-on-error: true`. Its step has been **exiting 1 on every run** — the CI log shows the confusing combination of a green check mark on the job *and* `Process completed with exit code 1` inside it. So the job has never gated anything.

This PR fixes all of the findings and removes the mask.

## Findings, and how each was fixed

Scope is what CI actually checks out — `git ls-files '*.sh'` — i.e. `makemake.sh` and `config-fermat.sh`.

| Code | Count | Fix |
| --- | --- | --- |
| **SC2310** (`check-set-e-suppressed`) | 17 | **The optional check is removed from the `-o` list** (per review). |
| **SC2248** (`quote-safe-variables`) | 3 | `command -v "$MAKE"` ×2 in `makemake.sh`; `-iters "$ITERS"` in `config-fermat.sh`. |
| **SC2209** | 1 | `MAKE=make` → `MAKE='make'`. |
| **SC2054** | 1 | `args+=(-radset 8,8,16)` — narrow `# shellcheck disable=SC2054`. |

### SC2310 — the check is dropped rather than suppressed

Every one of the 17 is a call of the `try_flag` / `try_avx512_asm` / `try_lto` feature probes. A nonzero return from those is the *"this toolchain does not support that"* **answer**, not an error — so calling them from an `if`/`&&`/`!` condition, which suppresses `set -e` inside them, is exactly the intent. Each probe also does its own error handling (`tmpdir=$(mktemp -d) || return 1`), so none relies on `set -e`.

An earlier revision of this PR suppressed each call site with a narrow `# shellcheck disable=SC2310`. Per review, removing the optional check from the invocation is the better trade: it only ever fired on intentional code, so nine directives were pure noise. The block comment explaining *why* the probes are called conditionally is kept — that is worth documenting regardless of what the linter thinks.

### SC2054 — a genuine false positive

`8,8,16` is a single Mlucas `-radset` argument; the commas are part of the value, not array element separators. Suppressed in place with a comment saying so, and the verification below confirms it is still passed as one `argv` entry.

### SC2248 / SC2209, and the `time` sites

`$MAKE` holds `make` or `mingw32-make`, `$ITERS` holds `100` — whitespace- and glob-free literals set in the script itself, so the quotes are documentation rather than a semantic change. `MAKE='make'` likewise just tells ShellCheck (and the reader) that this is the string `make`, not a forgotten `$(make)`.

`time $MAKE ...` and `time $MLUCAS ...` are also now quoted. ShellCheck does not analyse the command word of a `time`-prefixed pipeline so these were never flagged, but per review the inconsistency was not worth keeping. Both are inert for the same reason as above.

### Not weakened

- Apart from `check-set-e-suppressed`, the `-o` option list is **unchanged**.
- `avoid-nullary-conditions`, `deprecate-which` and `require-double-brackets` produced **zero** findings — both scripts already use `[[ ]]` throughout — so no `[ ... ]` → `[[ ... ]]` conversions were needed. Good, because that rewrite changes word-splitting/glob semantics on the RHS of `=`.

## Verification

Using the `koalaman/shellcheck` container:

- new option list, both scripts: **rc=0, 0 findings**
- **negative control** — same files with `check-set-e-suppressed` re-enabled: rc=1, **18 SC2310 findings**. The check would still catch these if it were ever wanted back; this PR is not hiding them.
- **v0.9.0, v0.10.0 and stable all rc=0**, so `ubuntu-latest` shipping a different version carries no skew risk.
- `makemake.sh avx2` builds rc=0 with the quoted `time "$MAKE"`; `config-fermat.sh`'s quoted `time "$MLUCAS"` invokes the binary correctly.

Rebased onto current main: the branch was 46 commits behind, and since this PR unmasks the job it must be clean against what main contains now. Current main lints at 5 findings under the new option list — all of them the SC2248/SC2209/SC2054 this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
