### PR TITLE
Fix the k1om (Xeon Phi Knights Corner / IMCI512) cross-build

### DIFF
--- a/makemake.sh
+++ b/makemake.sh
@@ -264,6 +264,13 @@ if [[ ${#MODES[*]} -eq 1 ]]; then
 			ARGS+=(-DUSE_AVX512 -mavx512f -mavx512cd -mavx512dq -mavx512bw -mavx512vl -mfma)
 			;;
 		k1om)
+			# Cross-build note: the Intel MPSS SDK's environment-setup-k1om-mpss-linux script exports
+			# CFLAGS and CPPFLAGS itself. The Makefile uses 'CFLAGS ?=', which defers to the environment,
+			# so merely sourcing the SDK script silently drops -O3 and -D_GNU_SOURCE and builds at -O0.
+			# At -O0 you get two failures that are NOT k1om defects: "impossible constraint in 'asm'" in
+			# radix16_dif_dit_pass_asm.h (the "e" constraint on pfetch_dist needs the optimiser), and
+			# threadpool.c losing CPU_ZERO/sched_setaffinity (that one is the missing -D_GNU_SOURCE).
+			# Re-export CFLAGS/CPPFLAGS *after* sourcing the SDK script.
 			echo "Building for 1st-gen Xeon Phi 512-bit SIMD in directory '${DIR}_${arg}'; the executable will be named '${TARGET}'"
 			ARGS+=(-DUSE_IMCI512)
 			;;

--- a/src/carry_gcc64.h
+++ b/src/carry_gcc64.h
@@ -17988,12 +17988,13 @@ Check the compile optimization level - If -O0, try upping to at east -O1.
 		/* If aligned on 32-byte but not 64-byte boundary, our index-octet-to-be-written-back is in low half of zmm3, but needs
 		to get written to the high half of the 64-byte memory chunk at bjmod_0, while preserving the low half stored there: */\
 		"vpermf32x4	$78,%%zmm3,%%zmm3	\n\t"/* Swap lo,hi halves of zmm4. High half gets written to memory, low half writemasked-off: */\
-		"vmovapd	%%zmm3,(%%rsi){%%k5%}	\n\t"/* VMOVAPD here, since opmask is qword-granular */\
-	"jmp 2f	\n\t"
+		"vmovapd	%%zmm3,(%%rsi)%{%%k5%}	\n\t"/* VMOVAPD here, since opmask is qword-granular */\
+	"jmp 2f	\n\t"\
+	"1:		\n\t"\
 		/* Else if bjmodn0 aligned on 64-byte boundary, our index-octet-to-be-written-back is in low half of zmm3, and needs
 		to get written to the low half of the 64-byte memory chunk at bjmod_0, while preserving the high half stored there: */\
-		"vmovapd	%%zmm3,(%%rsi){%%k6%}	\n\t"
-	"2:		\n\t"
+		"vmovapd	%%zmm3,(%%rsi)%{%%k6%}	\n\t"\
+	"2:		\n\t"\
 		/* Store cy_out: */\
 		"movq		%[__cy] ,%%rbx			\n\t	vmovaps	%%zmm1,(%%rbx)	\n\t"\
 		/* Store maxerr: */\

--- a/src/radix16_dyadic_square.c
+++ b/src/radix16_dyadic_square.c
@@ -98,7 +98,7 @@ void radix16_dyadic_square(
 	static int index0_mod=-1, index1_mod=-1;
 	int nradices_prim_radix0;
 	int i,j,j1,iroot/* ,k */;
-#ifndef USE_AVX512
+#if !defined(USE_AVX512) || defined(USE_IMCI512)	// IMCI512 #defines USE_AVX512, but its non-vectorized sincos-indexing arm below needs these:
 	int l,k1,k2;
 #endif
 #ifdef USE_SSE2

--- a/src/radix16_wrapper_square.c
+++ b/src/radix16_wrapper_square.c
@@ -165,7 +165,7 @@ The scratch array (2nd input argument) is only needed for data table initializat
   #ifdef USE_AVX512
 	double *add4,*add5,*add6,*add7, *bdd4,*bdd5,*bdd6,*bdd7, *cdd4,*cdd5,*cdd6,*cdd7;
   #endif
-  #ifdef USE_PRECOMPUTED_TWIDDLES
+  #if defined(USE_PRECOMPUTED_TWIDDLES) || defined(USE_IMCI512)	// IMCI512 needs these in its non-vectorized on-the-fly sincos-indexing arm below:
 	vec_dbl *tmp,*tm1, *c_tmp,*s_tmp;
   #endif
 	vec_dbl *bpt0,*bpt1,*bpt2,*bpt3;

--- a/src/radix32_dyadic_square.c
+++ b/src/radix32_dyadic_square.c
@@ -88,7 +88,7 @@ void radix32_dyadic_square(
 #ifndef USE_SSE2
 	int j2;
 #endif
-#ifndef USE_AVX512
+#if !defined(USE_AVX512) || defined(USE_IMCI512)	// IMCI512 #defines USE_AVX512, but its non-vectorized sincos-indexing arm below needs these:
 	int l,k1,k2;
 #endif
 #ifdef USE_SSE2


### PR DESCRIPTION
## Summary

`makemake.sh` has accepted a `k1om` target (1st-gen Xeon Phi / Knights Corner, `-DUSE_IMCI512`) for years, but **it has never compiled**. There is no CI job for it either — `.github/workflows/ci.yml` builds `'' NOSIMD SSE2 AVX AVX2 AVX512` (plus `ASIMD` on arm) and never passes `k1om` — so the breakage went unnoticed.

This PR is the first working KNC cross-build. Verified in both directions with the Intel MPSS 3.8.6 SDK:

| tree | result |
| --- | --- |
| stock `main` @ 418f365b | **fails**, `src/carry_gcc64.h:17995` and `:18081` |
| this PR | **builds clean**, `-O3 -Wall`, 0 errors, `readelf`: `Class: ELF64  Type: EXEC  Machine: Intel K1OM` |

### Why so many of these are guard bugs

`src/platform.h:263` makes `USE_IMCI512` **imply** `USE_AVX512` (and `USE_AVX2`/`USE_AVX`/`USE_SSE2`). IMCI512 shares `zmm`/`k` register names with AVX-512 but is a different ISA. The consequence is that every `#ifdef USE_AVX512` block also compiles for KNC, and every `#ifndef USE_AVX512` block is skipped for it. I fixed each site individually rather than touching that implication, whose blast radius would be enormous.

## Changes

### `src/carry_gcc64.h` — required to compile **and** required for correctness

Three defects in the bjmodn-writeback tail of `AVX_cmplx_carry_fast_errcheck_X8`. This code sits inside `#ifdef USE_AVX512` → `#ifdef USE_IMCI512`, so **no x86-64 target compiles it**.

1. **Missing `1:` label.** The code does `jz 1f` to select the 64-byte-aligned arm, but no such label existed anywhere. This is not only an assembler error — the placement is load-bearing. `andq $63,%rdx` sets ZF iff `bjmod_0` is 64-byte aligned, and that case must write the **low** half of the index octet under mask `k6` (`= knot k5 = 0b00001111`), so the label belongs immediately before the `k6` store. Putting it anywhere else would assemble fine and silently write the wrong half.
2. **Unescaped `{` in the writemasks.** `(%%rsi){%%k5%}` / `(%%rsi){%%k6%}`. In GCC extended asm a literal brace must be written `%{`; bare `{...|...}` is dialect-alternative syntax. The closing `%}` was already escaped, so the brace was never closed — internally inconsistent. Every other writemask in this 23k-line file uses the correct `%{%%k1%}` form. This is what produced the reported error.
3. **Missing backslash line-continuations** after `"jmp 2f \n\t"`, the `k6` `vmovapd`, and `"2: \n\t"`. These **terminated the `#define` early**, spilling the remainder of the macro body — the `cy_out` store, the `maxerr` store, and the entire 8×8 doubles transpose — into file scope. That is the `:18081: expected identifier or '(' before '}'` error. Severe, not cosmetic: the macro was truncated.

### `src/radix16_dyadic_square.c`, `src/radix32_dyadic_square.c` — required to compile

```diff
-#ifndef USE_AVX512
+#if !defined(USE_AVX512) || defined(USE_IMCI512)
 	int l,k1,k2;
 #endif
```

The IMCI512 arm (`// Vectorized version below a no-go on 1st-gen Xeon Phi`) is a hand-rolled scalar sincos-index computation that uses `l`, `k1`, `k2` throughout. Because IMCI implies AVX512, `#ifndef USE_AVX512` skipped the declarations. `tmp,tm1` were already correctly declared under `#ifdef USE_IMCI512`, and `c_tmp,s_tmp` unconditionally — only these three were missing.

### `src/radix16_wrapper_square.c` — required to compile

```diff
-#ifdef USE_PRECOMPUTED_TWIDDLES
+#if defined(USE_PRECOMPUTED_TWIDDLES) || defined(USE_IMCI512)
 	vec_dbl *tmp,*tm1, *c_tmp,*s_tmp;
 #endif
```

Same class of bug, guarded on the wrong feature: these four are used by the IMCI512 arm but were declared only under `USE_PRECOMPUTED_TWIDDLES`, an orthogonal build option. The sibling files (`radix16_dyadic_square.c:134`, `radix32_wrapper_square.c:177`) already declare them under `#ifdef USE_IMCI512`; this file was the outlier.

All three declaration guards are **exact no-ops when `USE_IMCI512` is undefined**.

### `makemake.sh` — comment only

Documents the `-O0` trap below.

## The MPSS SDK `-O0` trap

Worth calling out for anyone reproducing this. The SDK's `environment-setup-k1om-mpss-linux` **exports `CFLAGS` and `CPPFLAGS` itself**, and the Makefile uses `CFLAGS ?=`, which defers to the environment. So merely sourcing the SDK script and running `makemake.sh` silently drops `-O3` and `-D_GNU_SOURCE` and builds at `-O0`. At `-O0` you hit two failures that are **not** KNC defects and will send you chasing ghosts:

- `impossible constraint in 'asm'` in `radix16_dif_dit_pass_asm.h` — the `"e"` constraint on `pfetch_dist` needs the optimiser to fold it to a constant;
- `threadpool.c` losing `CPU_ZERO`/`sched_setaffinity` — that one is the dropped `-D_GNU_SOURCE`.

Re-export both *after* sourcing the SDK script. (Also note `makemake.sh` runs `make -j` without `-k`, so an error count is only the first parallel slice.)

## Testing

**KNC cannot be executed here — there is no Knights Corner hardware, and Intel SDE does not emulate IMCI512.** So the k1om evidence is limited to: clean `-O3 -Wall` build, 0 errors, links, and a valid `Intel K1OM` ELF64 executable (12,020,900 bytes). I make no runtime claim about KNC.

Because all four changed files are **shared** code, x86-64 was regression-tested in compensation, always against a pristine `main` baseline run through the identical harness:

**Codegen comparison — the decisive result.** `objdump -d` of every object file, this PR vs stock `main`:

| build | objects text-identical | text-differing |
| --- | --- | --- |
| nosimd | 99 | **0** |
| avx | 99 | **0** |
| avx2 | 99 | **0** |
| avx512 | 99 | **0** |

**396/396 objects produce byte-identical machine code**, so this patch provably cannot affect x86-64. (Raw `cmp` on the `.o` files does differ — that is DWARF `DW_AT_comp_dir` recording different build paths.)

**Self-tests.** `./Mlucas -s tt`, threaded and single-threaded, AVX-512 under `sde64 -skx`:

| mode | threaded | single-threaded |
| --- | --- | --- |
| nosimd | `rc=0`, 19 Res64 | `rc=0`, 30 Res64 |
| avx | `rc=0`, 12 Res64 | build fails (also on stock main) |
| avx2 | `rc=0`, 12 Res64 | build fails (also on stock main) |
| avx512 (SDE) | `rc=0` | build fails (also on stock main) |
| sse2 | build fails (also on stock main) | build fails (also on stock main) |

Residue-line diff (`Res64|Res35m1|Res36m1|ERROR`) against baseline: **0 differing lines** in every runnable configuration.

**Pre-existing failures, confirmed identical on stock `main` and not caused by this PR:** `radix32_main_carry_loop.h:62` `'addi'`/`'cy_i' undeclared` (breaks sse2 threaded and sse2/avx/avx2/avx512 single-threaded); all six Mfactor variants (`implicit declaration of twopmodq100_2WORD_DOUBLE_q4`, and `#error P{2,3,4}WORD may not be used together with USE_FMADD!`) — so the Mfactor coverage I wanted was unobtainable, equally with or without this patch; `nonzero exit carry in radix16_ditN_cy_dif1` under SDE avx512 and `radix30_ditN_cy_dif1` under single-threaded nosimd, both at identical log line numbers in baseline.

## Audit findings deliberately NOT fixed here

While auditing all 79 `USE_IMCI512` sites I found divergences that change *runtime* behaviour on hardware I cannot execute. Flagging rather than guessing:

- **`radix40` and `radix56` are missing their "no IMCI-512 support" skip-guard.** Six siblings (`radix16`, `radix20`, `radix36`, `radix44`, `radix52`, `radix60`) carry a live `#ifdef USE_IMCI512 → WARN(...); return(ERR_RADIX0_UNAVAILABLE);`. In `radix40_ditN_cy_dif1.c:342` the body is **commented out**, leaving a live but empty `#ifdef`; in `radix56_ditN_cy_dif1.c:480` the guard is `#if 0 //def USE_IMCI512`. So on KNC those two leading radices will run a path all their siblings declare unsupported. Either the author validated them on real KNC and re-enabled them deliberately, or these are debugging leftovers that will yield wrong residues. **I can't tell without hardware, and since the file never compiled, no such run has ever happened.** Question for anyone with a KNC: which is it?
- Cosmetic: `radix44_ditN_cy_dif1.c:370`'s guard message names `radix36_ditN_cy_dif1`; and four files spell it `k10m` instead of `k1om`.
- `radix32_dyadic_square.c:122` uses `#if defined(USE_AVX512) && defined(USE_IMCI512)` where siblings use plain `#ifdef USE_IMCI512` — redundant, behaviour identical, left alone.

I found **no** missing-statement asymmetry between IMCI and AVX-512 arms (the radix20/radix960 defect class). The IMCI arms are wholesale alternative implementations rather than partial edits, which makes that failure mode unlikely here.

## CI

**No k1om CI job is added, and none is unmasked** — because none exists to unmask. Adding one needs the MPSS 3.8.6 SDK (301 MB, requires an EOL CentOS 7 host, not readily redistributable), so it isn't a drop-in GitHub Actions job. The `-O0` trap is documented in `makemake.sh` instead, where anyone attempting a k1om build will see it. Happy to add a job if you'd like to host the SDK somewhere fetchable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
