### PR TITLE
Fix wrong residues from clang's vectorizer on radix-144/176/208 AVX-512 builds

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -1627,6 +1627,30 @@ extern int NTHREADS;
 	#define COMPILER_VERSION "[Unknown]"
 #endif
 
+/* Suppress loop auto-vectorization for the following loop.
+Clang's loop vectorizer miscompiles the outer DFT-dispatch loops in the radix-{144,176,208}
+dif_pass1() routines on an AVX-512 build, silently producing a wrong residue. Tested at
+288K radset {144,8,8,16}, p = 5782013, -shift 0 (correct Res64 = 9869BE81D9AB1564):
+
+	clang  14.0.0	8518F7A93A6691AE	wrong
+	clang  18.1.3	8518F7A93A6691AE	wrong
+	clang  19.1.7	8518F7A93A6691AE	wrong
+	clang  20.1.8	8518F7A93A6691AE	wrong
+	clang  21.1.8	9869BE81D9AB1564	ok
+	clang  22.1.8	9869BE81D9AB1564	ok
+	gcc 13, 16	9869BE81D9AB1564	ok
+
+so the last known-bad is 20.1.8 and the first known-good 21.1.8; no 21.x before 21.1.8 was
+available to test. Apple clang uses its own version numbering that does not map onto upstream
+LLVM releases, so treat it as affected regardless of major.
+Deliberately expands to nothing for non-clang compilers: GCC warns on unrecognized
+"#pragma clang ..." under -Wall, which every Mlucas build uses. */
+#if defined(__clang__) && (defined(__apple_build_version__) || __clang_major__ < 21)
+	#define NO_LOOP_VECTORIZE	_Pragma("clang loop vectorize(disable)")
+#else
+	#define NO_LOOP_VECTORIZE
+#endif
+
 // In case OS_BITS not yet def'd:
 #ifndef	OS_BITS
 	#if __SIZEOF_LONG_LONG__ == 4

--- a/src/radix144_ditN_cy_dif1.c
+++ b/src/radix144_ditN_cy_dif1.c
@@ -1624,6 +1624,10 @@ void radix144_dif_pass1(double a[], int n)
 	*/
 	//...gather the needed data (144 64-bit complex) and do 16 radix-9 transforms:
 		tptr = t;
+		// Each iteration of this loop is a full radix-9 DFT, so there is nothing for the loop
+		// vectorizer to gain here - and clang <= 18 miscompiles it, yielding a wrong residue for
+		// every radix set with this leading radix on an AVX-512 build. See platform.h.
+		NO_LOOP_VECTORIZE
 		for(l = 0; l < 16; l++) {
 			iptr = dif_pcshft + dif_ncshft[l];
 			// Hi-part of p-offset indices:

--- a/src/radix176_ditN_cy_dif1.c
+++ b/src/radix176_ditN_cy_dif1.c
@@ -1780,6 +1780,10 @@ void radix176_dif_pass1(double a[], int n)
 	*/
 	/*...gather the needed data (176 64-bit complex) and do 16 radix-11 transforms...*/
 		tptr = t;
+		// Each iteration of this loop is a full radix-11 DFT, so there is nothing for the loop
+		// vectorizer to gain here - and clang <= 18 miscompiles it, yielding a wrong residue for
+		// every radix set with this leading radix on an AVX-512 build. See platform.h.
+		NO_LOOP_VECTORIZE
 		for(l = 0; l < 16; l++) {
 			iptr = dif_pcshft + dif_ncshft[l];
 			// Hi-part of p-offset indices:

--- a/src/radix208_ditN_cy_dif1.c
+++ b/src/radix208_ditN_cy_dif1.c
@@ -1622,6 +1622,10 @@ void radix208_dif_pass1(double a[], int n)
 	*/
 	/*...gather the needed data (208 64-bit complex) and do 16 radix-13 transforms...*/
 		tptr = t;
+		// Each iteration of this loop is a full radix-13 DFT, so there is nothing for the loop
+		// vectorizer to gain here - and clang <= 18 miscompiles it, yielding a wrong residue for
+		// every radix set with this leading radix on an AVX-512 build. See platform.h.
+		NO_LOOP_VECTORIZE
 		for(l = 0; l < 16; l++) {
 			iptr = dif_pcshft + dif_ncshft[l];
 			// Hi-part of p-offset indices:


### PR DESCRIPTION
On an AVX-512 build, **clang releases up to and including 20 silently return a wrong residue** for any radix set whose leading radix is **144, 176 or 208**. GCC is unaffected, as is clang 21+.

In the self-test that is **22 wrong cases**. Most degenerate to `Res64 = 0000000000000002` with `AvgMaxErr ≈ 8e-6` — the transform running on trivial data, not drifting numerically:

```
  ***   Res64 Error   ***
 current   =                    2
 should be = 10982518631231592448
```

## Root cause

Clang's loop vectorizer miscompiles the outer DFT-dispatch loop in `radix{144,176,208}_dif_pass1()` — the loop that walks 16 radix-9/11/13 DFTs via `dif_pcshft`/`dif_ncshft`.

Isolated at 288K, radset `{144,8,8,16}`, p = 5782013, `-shift 0`:

| build | Res64 | |
|---|---|---|
| gcc 13, gcc 16 | `9869BE81D9AB1564` | correct |
| clang 14.0.0 | `8518F7A93A6691AE` | **wrong** |
| clang 18.1.3 | `8518F7A93A6691AE` | **wrong** |
| clang 19.1.7 | `8518F7A93A6691AE` | **wrong** |
| clang 20.1.8 | `8518F7A93A6691AE` | **wrong** |
| clang 21.1.8 | `9869BE81D9AB1564` | correct |
| clang 22.1.8 | `9869BE81D9AB1564` | correct |

Narrowing, each step from the previous one:

- Compiling **only** `radix144_ditN_cy_dif1.c` with gcc and everything else with clang 18 gives the correct value — the defect is confined to that one translation unit.
- clang 18 at `-O1` is correct; `-O2` and `-O3` are wrong; `-O2 -fno-vectorize` is correct. So it is the loop vectorizer.
- `-fno-strict-aliasing` and `-fwrapv` change nothing, so it is neither a TBAA nor a signed-overflow issue.
- Disabling vectorization on **this single loop** — and no other — restores the correct residue. Clang vectorizes eight other loops in this file; all are innocent.
- UBSan is clean, and `dif_pcshft[17]` is correctly sized for the maximum `dif_ncshft[]` value of 8 plus the `+8` dereference, so there is no detectable UB in the source.
- clang 21 vectorizes the *identical* set of loops and gets the right answer.

## The fix

A `NO_LOOP_VECTORIZE` macro in `platform.h`, applied at the three loops. It expands to `_Pragma("clang loop vectorize(disable)")` only for clang < 21, and to nothing otherwise — GCC warns on unrecognized `#pragma clang ...` under `-Wall`, which every Mlucas build uses. Apple clang numbers its releases independently of upstream LLVM, so it is treated as affected regardless of major version.

There is no performance cost: each iteration of this loop is an entire radix-9/11/13 DFT, so there was never a vectorizer win to give up.

## Why only three files

I surveyed the whole tree for the same loop shape. Eleven other files have it, and clang 18 does vectorize the dispatch loop in six of them: radix160 (`:2113`), radix224 (`:3007`), radix240 (`:2442`), radix288 (`:2516`), radix352 (`:2407`), radix992 (`:2184`).

**Being vectorized is not sufficient to be miscompiled.** In the very CI run that exposed this, those radices ran clean:

| leading radix | self-test cases run | wrong |
|---|---|---|
| 144 | 13 | **10** |
| 176 | 15 | **6** |
| 208 | 13 | **6** |
| 160 | 16 | 0 |
| 224 | 15 | 0 |
| 240 | 16 | 0 |
| 288 | 11 | 0 |
| 352 | 9 | 0 |

So I have deliberately **not** touched them: disabling vectorization in code that demonstrably produces correct answers would be an unjustified change.

**radix992** is not covered by that table — no self-test case at these FFT lengths uses it — so I tested it separately, at 992K radset `{992,16,32}`, p = 17541061 (0.90 × pmax_rec):

- on stock `main`, **both** clang 18 and gcc 13 die with `SDE ERROR: Could not read memory` at the same offset. Identical under both compilers, so it is not this vectorizer bug — it is a separate, pre-existing radix992 defect.
- on the integration branch, which carries the radix992 SIMD-carry work, the same case runs clean: `Res64: 5E8E162D36939598`, MaxErr 0.0498.

So radix992 needs nothing from this PR.

## Provenance

Pre-existing in `main` — stock `upstream/main` built with clang 18 reproduces `8518F7A93A6691AE` bit-for-bit. It became visible only because the self-test grew real exit statuses; previously it always returned 0 and 22 wrong residues went unnoticed.

It also looks intermittent in CI because the main `Mlucas Linux` job self-tests the *auto-detected* build, so AVX-512 code only executes when the job lands on an AVX-512-capable runner SKU. Both conditions — AVX-512 execution and clang ≤ 20 — must hold.

## Verification

- clang 18.1.3 **with this patch**: `9869BE81D9AB1564` (correct), via a full rebuild from a clean checkout of this branch, run under Intel SDE `-skx`.
- clang 22 and gcc 16: macro expands to nothing, the loop is still vectorized, zero pragma warnings — no change in behaviour for unaffected compilers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
